### PR TITLE
Stop relying on an ordered list of problem parameters in ProblemInstance

### DIFF
--- a/python/contraction/definitions.py
+++ b/python/contraction/definitions.py
@@ -37,6 +37,7 @@ class EinsumProblem(ProblemDefinition):
     """
     self.specification = EinsumSpecification(specification)
 
+  @property
   def keys(self) -> List[str]:
     """Returns the list of parameter keys for the current problem definition."""
     return list(self.specification.output_dims +

--- a/python/contraction/einsum_test.py
+++ b/python/contraction/einsum_test.py
@@ -17,9 +17,8 @@ dummy_expert = TransformationList(transforms=[Bufferize()] +
 
 def main():
   problem_definition = EinsumProblem("klnp,nk->pl")
-  problem = ProblemInstance(problem_definition, problem_definition.keys(),
-                            [np.float32] * 3)
-  sizes = {k: v for k, v in zip(problem_definition.keys(), [10, 12, 14, 16])}
+  problem = ProblemInstance(problem_definition, [np.float32] * 3)
+  sizes = {k: v for k, v in zip(problem_definition.keys, [10, 12, 14, 16])}
   problem.compile(
       entry_point_name="einsum_main",
       fun_to_benchmark_name="einsum_on_tensors",

--- a/python/conv/conv_1d_bench.py
+++ b/python/conv/conv_1d_bench.py
@@ -69,9 +69,8 @@ def main():
                 'WCF',
                 strides=compile_time_problem_sizes_dict['strides'],
                 dilations=compile_time_problem_sizes_dict['dilations']),
-            problem_sizes_keys=keys,
             np_types=np_types)
-        assert problem.problem_definition.keys() == keys
+        assert problem.problem_definition.keys == keys
 
         problem.compile(
             entry_point_name='main',

--- a/python/conv/conv_2d_bench.py
+++ b/python/conv/conv_2d_bench.py
@@ -69,9 +69,8 @@ def main():
                 'HWCF',
                 strides=compile_time_problem_sizes_dict['strides'],
                 dilations=compile_time_problem_sizes_dict['dilations']),
-            problem_sizes_keys=keys,
             np_types=np_types)
-        assert problem.problem_definition.keys() == keys
+        assert problem.problem_definition.keys == keys
 
         problem.compile(
             entry_point_name='main',

--- a/python/conv/conv_3d_bench.py
+++ b/python/conv/conv_3d_bench.py
@@ -65,9 +65,8 @@ def main():
                 'DHWCF',
                 strides=compile_time_problem_sizes_dict['strides'],
                 dilations=compile_time_problem_sizes_dict['dilations']),
-            problem_sizes_keys=keys,
             np_types=np_types)
-        assert problem.problem_definition.keys() == keys
+        assert problem.problem_definition.keys == keys
 
         problem.compile(
             entry_point_name='main',

--- a/python/conv/definitions.py
+++ b/python/conv/definitions.py
@@ -120,6 +120,7 @@ class ConvolutionProblem(ProblemDefinition):
     self.__kernel_format = kernel_format
     self.__op_builder = ops.__dict__[name]
 
+  @property
   def keys(self) -> List[str]:
     """Returns the list of parameter keys for the current problem definition."""
     result = list(self.__input_format)

--- a/python/copy/copy_2d_bench.py
+++ b/python/copy/copy_2d_bench.py
@@ -125,7 +125,6 @@ def main():
 
         problem = ProblemInstance(
             problem_definition=Copy2DProblem(),
-            problem_sizes_keys=keys,
             np_types=np_types)
 
         problem.compile(

--- a/python/core/utils.py
+++ b/python/core/utils.py
@@ -1,5 +1,4 @@
-from collections.abc import Callable
-from typing import Any, Optional, Sequence, Type
+from typing import Any, Mapping, Optional, Sequence, Type
 
 import numpy as np
 
@@ -19,7 +18,7 @@ def inspect_all(obj):
   print([name for name in dir(obj) if name.startswith('__')])
 
 
-def assert_dict_entries_match_keys(dictionary: dict,
+def assert_dict_entries_match_keys(dictionary: Mapping[str, Any],
                                    required_keys: Sequence[str]):
   assert len(
       set(required_keys).symmetric_difference(set(dictionary.keys()))

--- a/python/depthwise_conv/definitions.py
+++ b/python/depthwise_conv/definitions.py
@@ -122,6 +122,7 @@ class DepthwiseConvolutionProblem(ProblemDefinition):
     self.__kernel_format = kernel_format
     self.__op_builder = ops.__dict__[name]
 
+  @property
   def keys(self) -> List[str]:
     """Returns the list of parameter keys for the current problem definition."""
     result = list(self.__input_format)

--- a/python/depthwise_conv/depthwise_conv_1d_bench.py
+++ b/python/depthwise_conv/depthwise_conv_1d_bench.py
@@ -67,7 +67,6 @@ def main():
                 'WC',
                 strides=compile_time_problem_sizes_dict['strides'],
                 dilations=compile_time_problem_sizes_dict['dilations']),
-            problem_sizes_keys=keys,
             np_types=np_types)
         assert problem.problem_definition.keys() == keys
 

--- a/python/fusion/test.py
+++ b/python/fusion/test.py
@@ -47,7 +47,6 @@ def fill_matmul_fusion():
   problem_sizes_dict = {'M': 24, 'N': 32, 'K': 48}
   problem = ProblemInstance(
       problem_definition=MatmulProblem(),
-      problem_sizes_keys=problem_sizes_dict,
       np_types=[np.float32, np.float32, np.float32])
 
   ## These lit tests are not actually run, but can be checked locally using
@@ -86,7 +85,6 @@ def fill_matmul_bias_add_fusion():
   problem_sizes_dict = {'M': 24, 'N': 32, 'K': 48}
   problem = ProblemInstance(
       problem_definition=MatmulBiasAddProblem(),
-      problem_sizes_keys=problem_sizes_dict,
       np_types=[np.float32, np.float32, np.float32, np.float32])
 
   ## These lit tests are not actually run, but can be checked locally using

--- a/python/matmul/bench.py
+++ b/python/matmul/bench.py
@@ -96,7 +96,6 @@ def main():
         for expert in all_experts:
           problem = ProblemInstance(
               problem_definition=EinsumProblem('mk,kn'),
-              problem_sizes_keys=keys,
               np_types=np_types)
 
           problem.compile(

--- a/python/matmul/test.py
+++ b/python/matmul/test.py
@@ -218,7 +218,6 @@ def main():
       for expert in all_experts:
         problem = ProblemInstance(
             problem_definition=EinsumProblem('mk,kn'),
-            problem_sizes_keys=keys,
             np_types=np_types)
 
         problem.compile(

--- a/python/matvec/bench.py
+++ b/python/matvec/bench.py
@@ -74,7 +74,6 @@ def main():
       for expert in all_experts:
         problem = ProblemInstance(
             problem_definition=EinsumProblem('mn,n'),
-            problem_sizes_keys=keys,
             np_types=np_types)
 
         problem.compile(

--- a/python/matvec/test.py
+++ b/python/matvec/test.py
@@ -218,7 +218,6 @@ def main():
       for expert in all_experts:
         problem = ProblemInstance(
             problem_definition=EinsumProblem('mn,n'),
-            problem_sizes_keys=keys,
             np_types=np_types)
 
         problem.compile(

--- a/python/padding/padded_conv1d_bench.py
+++ b/python/padding/padded_conv1d_bench.py
@@ -62,7 +62,6 @@ def main():
                 WpadR=compile_time_problem_sizes_dict['WpadR'],
                 stride=compile_time_problem_sizes_dict['stride'],
                 dilation=compile_time_problem_sizes_dict['dilation']),
-            problem_sizes_keys=keys,
             np_types=np_types)
 
         problem.compile(

--- a/python/reduction/row_reduction_2d_bench.py
+++ b/python/reduction/row_reduction_2d_bench.py
@@ -95,7 +95,6 @@ def main():
 
         problem = ProblemInstance(
             problem_definition=RowReduction2DProblem(),
-            problem_sizes_keys=keys,
             np_types=np_types)
 
         problem.compile(

--- a/python/reduction/row_reduction_2d_test.py
+++ b/python/reduction/row_reduction_2d_test.py
@@ -49,7 +49,6 @@ def main():
       for expert in all_experts:
         problem = ProblemInstance(
             problem_definition=RowReduction2DProblem(),
-            problem_sizes_keys=keys,
             np_types=np_types)
 
         problem.compile(

--- a/python/transpose/transpose_2d_bench.py
+++ b/python/transpose/transpose_2d_bench.py
@@ -197,7 +197,6 @@ def main():
         problem = ProblemInstance(
             problem_definition=TransposeNDProblem(
                 permutation=[1, 0], op_builder=transpose_2d),
-            problem_sizes_keys=keys,
             np_types=np_types)
 
         problem.compile(

--- a/python/transpose/transpose_4d_bench.py
+++ b/python/transpose/transpose_4d_bench.py
@@ -78,7 +78,6 @@ def main():
     instance = ProblemInstance(
         problem_definition=TransposeNDProblem(
             permutation=problem[1], op_builder=problem[2]),
-        problem_sizes_keys=keys,
         np_types=[np.float32, np.float32])
 
     instance.compile(


### PR DESCRIPTION
A previous commit rendered this constructor field irrelevant as the problem
parameters are accepted as a mapping anyway, the list was required only because
of internal data marshalling that has been refactored. Drop the key list
argument form the ProblemInstance constructor. When available, expose the list
of expected keys as a property on ProblemDefinition for convenience.