### PR TITLE
Add missing dependencies to CMake

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,9 +10,16 @@ add_mlir_library(IREELinalgTensorSandbox
   MLIRGPUOps
   MLIRLinalg
   MLIRLinalgTransforms
+  MLIRAffineToStandard
+  MLIRMemRefTransforms
+  IREELinalgTensorSandboxTransforms
+  MLIRSCFToStandard
+  MLIRLinalgToLLVM
+  MLIRVectorToLLVM
+  MLIRMathToLLVM
+  MLIRMemRefToLLVM
 
   DEPENDS
-  IREELinalgTensorSandboxTransforms
   RunnersPassIncGen
   MLIRLinalgExtInterfacesIncGen
   MLIRLinalgExtOpsIncGen
@@ -24,6 +31,7 @@ add_mlir_public_c_api_library(IREELinalgTensorSandboxCAPI
 
   PARTIAL_SOURCES_INTENDED
   LINK_LIBS PRIVATE
+  MLIRPass
   IREELinalgTensorSandbox
   IREELinalgTensorSandboxTransforms
 )

--- a/lib/Dialects/LinalgExt/IR/CMakeLists.txt
+++ b/lib/Dialects/LinalgExt/IR/CMakeLists.txt
@@ -9,5 +9,8 @@ add_mlir_library(MLIRLinalgExt
   MLIRLinalgExtPassIncGen
 
   LINK_LIBS PUBLIC
+  MLIRAffine
   MLIRIR
+  MLIRMemRef
+  MLIRTensor
 )

--- a/lib/Dialects/LinalgExt/Transforms/CMakeLists.txt
+++ b/lib/Dialects/LinalgExt/Transforms/CMakeLists.txt
@@ -6,6 +6,18 @@ add_mlir_library(MLIRLinalgExtTransforms
   MLIRLinalgExt
 
   LINK_LIBS PUBLIC
+  MLIRAffineToStandard
+  MLIRSCFToStandard
+  MLIRLinalgToLLVM
+  MLIRVectorToLLVM
+  MLIRMathToLLVM
+  MLIRMemRefToLLVM
   MLIRIR
+  MLIRMath
+  MLIRLinalg
+  MLIRLinalgTransforms
+  MLIRLinalgExt
+  MLIRPass
   MLIRSCF
+  MLIRTransforms
 )

--- a/lib/Dialects/VectorExt/CMakeLists.txt
+++ b/lib/Dialects/VectorExt/CMakeLists.txt
@@ -7,4 +7,5 @@ add_mlir_library(MLIRVectorExt
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRControlFlowInterfaces
 )


### PR DESCRIPTION
Numerous dependencies were missing from various CMake files. The entire
build probably worked because it was never attempted with
`-DBUILD_SHARED_LIBS=On`, but there is no reason it won't break in a
different environment.