### PR TITLE
Fix broken impots in invoke_cli

### DIFF
--- a/python/core/deprecated_compilation.py
+++ b/python/core/deprecated_compilation.py
@@ -15,6 +15,10 @@ from mlir.execution_engine import *
 from mlir.runtime import *
 
 from .transforms import *
+from .compilation import (attach_inplaceable_attributes, attach_passthrough,
+                          emit_benchmarking_function, operand_type, scalar_type,
+                          _MLIR_RUNNER_UTILS_LIB_ENV,
+                          _MLIR_RUNNER_UTILS_LIB_DEFAULT)
 
 
 # TODO: retire this because it has internal  assumptions about number of

--- a/python/local_search/invoke_cli.py
+++ b/python/local_search/invoke_cli.py
@@ -8,7 +8,8 @@ from mlir.dialects import linalg
 from mlir.dialects.linalg.opdsl.lang import OperandKind
 from mlir.runtime import *
 
-from ..core.compilation import numpy_type, compile_and_callback
+from ..core.compilation import numpy_type
+from ..core.deprecated_compilation import compile_and_callback
 from ..core.search_vars import collect_variables
 from ..core import experts
 


### PR DESCRIPTION
These were broken by the move of some functions from compilation.py to
deprecated_compilation.py.