### PR TITLE
Make Transformation instances compose similarly to classes

### DIFF
--- a/python/conv/conv_2d_bench.py
+++ b/python/conv/conv_2d_bench.py
@@ -18,20 +18,22 @@ op_name = 'linalg.conv_2d_nhwc_hwcf'
 ################################################################################
 
 all_experts = [
-    SingleTilingExpert(
-        fun_name=fun_name,
-        op_name=op_name,
-        #           N  H  W  C  KH  KW  F
-        tile_sizes=[1, 1, 8, 32, 1, 1, 8],
-        tile_interchange=[],
-        peel=[],
-        pad=False,
-        pack_paddings=[],
-        hoist_paddings=[],
-        # kwargs passed down to LowerVectors.
-        # TODO: better composition of experts.
-        transpose_lowering='shuffle',
-        print_ir_after_all=False)
+    e.print_ir(after_all=False) for e in [
+        TileAndDecompose(
+            fun_name=fun_name,
+            op_name=op_name,
+            #           N  H  W  C  KH  KW  F
+            tile_sizes=[1, 1, 8, 32, 1, 1, 8],
+            tile_interchange=[],
+            peel=[],
+            pad=False,
+            pack_paddings=[],
+            hoist_paddings=[]) + \
+          Vectorize(fun_name, op_name) + \
+          Bufferize() + \
+          StagedVectorLowering(transpose_lowering='shuffle') +\
+          LowerToLLVM()
+    ]
 ]
 
 ################################################################################

--- a/python/conv/conv_3d_bench.py
+++ b/python/conv/conv_3d_bench.py
@@ -17,7 +17,7 @@ op_name = 'linalg.conv_3d_ndhwc_dhwcf'
 ### Compilation strategies.
 ################################################################################
 
-all_experts = [
+all_experts = [ e.print_ir(after_all=False) for e in [
     SingleTilingExpert(
         fun_name=fun_name,
         op_name=op_name,
@@ -27,9 +27,8 @@ all_experts = [
         peel=[],
         pad=False,
         pack_paddings=[],
-        hoist_paddings=[],
-        print_ir_after_all=False)
-]
+        hoist_paddings=[])
+]]
 
 ################################################################################
 ### Problem instantiation

--- a/python/copy/copy_2d_bench.py
+++ b/python/copy/copy_2d_bench.py
@@ -79,9 +79,9 @@ def all_experts(fun_name: str, problem_sizes: List[int]):
           pack_paddings=[],
           hoist_paddings=[],
           # kwargs start here.
-          post_bufferization_transforms=post_bufferization_transforms,
-          # Set to True to see the IR.
-          print_ir_after_all=False),
+          post_bufferization_transforms=post_bufferization_transforms).print_ir(
+              # Set to True to see the IR.
+              after_all=False),
   ]
 
 

--- a/python/core/experts.py
+++ b/python/core/experts.py
@@ -11,17 +11,20 @@ def LowerVectorFactory(stage):
 
   return type('LowerVectors' + str(stage), (LowerVectors,), {'__init__': init})
 
+
 VectorLowering = TransformListFactory('VectorLowering',
                                       [LowerVectorFactory(i) for i in range(7)])
 
 # TODO: After DecomposeToLowerDimensionalNamedOp the op_name to anchor on
 # changes: we need a better control mechanism.
 LoweringOnlyExpert = Bufferize.then(VectorLowering).then(LowerToLLVM)
-SingleTilingExpert = Tile.then(DecomposeToLowerDimensionalNamedOp).then(Vectorize).then(
-    LoweringOnlyExpert)
+SingleTilingExpert = Tile.then(DecomposeToLowerDimensionalNamedOp).then(
+    Vectorize).then(LoweringOnlyExpert)
 DoubleTilingExpert = Tile.then(SingleTilingExpert)
 TripleTilingExpert = Tile.then(DoubleTilingExpert)
 
+TileAndDecompose = Tile.then(DecomposeToLowerDimensionalNamedOp)
+DoubleTileAndDecompose = Tile.then(TileAndDecompose)
 
 # Expert compiler that applies the whole sparse compiler.
 class ExpertSparseCompiler(TransformationList):

--- a/python/core/transforms.py
+++ b/python/core/transforms.py
@@ -1,7 +1,7 @@
 from mlir.ir import *
 
 from .search_vars import *
-from .transform import Transform
+from .transform import Transform, TransformationList
 
 import mlir.all_passes_registration
 
@@ -33,23 +33,6 @@ def _get_pad_str(transform: Transform) -> str:
   if hoist_paddings:
     pad_str = pad_str + f' hoist-paddings={",".join(hoist_paddings)}'
   return pad_str
-
-
-class Print(Transform):
-  """Print intermediate IR.
-
-  Dump the module and do not change it. The transform can be configured as
-  follows:
-  * `print_header`: Print header.
-  """
-
-  def __init__(self, print_header='', **kwargs):
-    self.print_header = print_header
-
-  def __call__(self, module: Module, fun_name: str):
-    print('[[[ IR printer: ' + self.print_header + ' ]]]')
-    module.dump()
-    return module
 
 
 class ExperimentalSplitAndFuseFillOp(Transform):
@@ -298,6 +281,10 @@ class LowerVectors(Transform):
         f'canonicalize,'
         f'cse')
     self.pipeline = (f'builtin.func({pipeline})')
+
+def StagedVectorLowering(**kwargs):
+  return TransformationList(
+      transforms=[LowerVectors(stage=i, **kwargs) for i in range(7)])
 
 
 class LowerToLLVM(Transform):

--- a/python/depthwise_conv/depthwise_conv_1d_bench.py
+++ b/python/depthwise_conv/depthwise_conv_1d_bench.py
@@ -26,8 +26,7 @@ all_experts = [
         peel=[],
         pad=False,
         pack_paddings=[],
-        hoist_paddings=[],
-        print_ir_after_all=False)
+        hoist_paddings=[]).print_ir(after_all=False)
 ]
 
 ################################################################################

--- a/python/fusion/test.py
+++ b/python/fusion/test.py
@@ -5,6 +5,7 @@
 from ..core.experts import *
 from ..core.harness import *
 from ..core.transforms import *
+from ..core.transform import Print
 
 from .definitions import *
 

--- a/python/matvec/bench.py
+++ b/python/matvec/bench.py
@@ -13,7 +13,7 @@ from ..contraction.definitions import *
 ### Compilation strategies.
 ################################################################################
 
-all_experts = [
+all_experts = [e.print_ir(after_all=False) for e in [
     SingleTilingExpert(
         'matvec_on_tensors',
         'linalg.generic',
@@ -22,8 +22,7 @@ all_experts = [
         peel=[],
         pad=True,
         pack_paddings=[1, 1, 0],
-        hoist_paddings=[2, 3, 0],
-        print_ir_after_all=False),
+        hoist_paddings=[2, 3, 0]),
     DoubleTilingExpert(
         'matvec_on_tensors',
         'linalg.generic',
@@ -38,9 +37,8 @@ all_experts = [
         peel2=[],
         pad2=True,
         pack_paddings2=[1, 1, 0],
-        hoist_paddings2=[4, 3, 0],
-        print_ir_after_all=False)
-]
+        hoist_paddings2=[4, 3, 0])
+]]
 
 ################################################################################
 ### Problem instantiations.

--- a/python/padding/padded_conv1d_bench.py
+++ b/python/padding/padded_conv1d_bench.py
@@ -19,15 +19,13 @@ all_experts = [
     SingleTilingExpert(
         fun_name=fun_name,
         op_name=op_name,
-        #      N  W   C  KW  F
+        #           N  W   C  KW  F
         tile_sizes=[1, 8, 32, 1, 8],
         tile_interchange=[],
         peel=[],
         pad=False,
         pack_paddings=[],
-        hoist_paddings=[],
-        print_ir_at_begin=True,
-        print_ir_after_all=False)
+        hoist_paddings=[]).print_ir(at_begin=True, after_all=False)
 ]
 
 ################################################################################

--- a/python/reduction/column_reduction_2d_test.py
+++ b/python/reduction/column_reduction_2d_test.py
@@ -14,7 +14,10 @@ from .definitions import *
 ################################################################################
 
 # No tiling.
-expert_no_tiling = LoweringOnlyExpert('column_reduction_2d_on_tensors', 'linalg.generic', print_ir_after_all=False)
+expert_no_tiling = LoweringOnlyExpert(
+    'column_reduction_2d_on_tensors',
+    'linalg.generic')\
+  .print_ir(after_all=False)
 
 all_experts = [expert_no_tiling]
 

--- a/python/reduction/reduction_1d_test.py
+++ b/python/reduction/reduction_1d_test.py
@@ -14,7 +14,8 @@ from .definitions import *
 ################################################################################
 
 # No tiling.
-expert_no_tiling = LoweringOnlyExpert('reduction_1d_on_tensors', 'linalg.generic', print_ir_after_all=False)
+expert_no_tiling = LoweringOnlyExpert(
+    'reduction_1d_on_tensors', 'linalg.generic').print_ir(after_all=False)
 
 all_experts = [expert_no_tiling]
 

--- a/python/transpose/transpose_4d_bench.py
+++ b/python/transpose/transpose_4d_bench.py
@@ -12,7 +12,14 @@ import typing as tp
 fun_name = 'transpose_4d_on_tensors'
 op_name = 'linalg.generic'
 
-expert_transpose_4d_0213 = SingleTilingExpert(
+def tiling_shuffle_lowering(**kwargs):
+  return TileAndDecompose(**kwargs)\
+    .then(Vectorize(fun_name, op_name, transpose_lowering='shuffle'))\
+    .then(Bufferize())\
+    .then(StagedVectorLowering())\
+    .then(LowerToLLVM())
+
+expert_transpose_4d_0213 = tiling_shuffle_lowering(
     fun_name=fun_name,
     op_name=op_name,
     tile_sizes=[1, 4, 4, 16],
@@ -20,13 +27,9 @@ expert_transpose_4d_0213 = SingleTilingExpert(
     peel=[0, 1],
     pad=False,
     pack_paddings=[],
-    hoist_paddings=[],
-    transpose_lowering='shuffle',
-    # kwargs start here.
-    # transforms=[Print('Input IR')],
-    print_ir_after_all=False)
+    hoist_paddings=[]).print_ir(after_all=False)
 
-expert_transpose_4d_1302 = SingleTilingExpert(
+expert_transpose_4d_1302 = tiling_shuffle_lowering(
     fun_name=fun_name,
     op_name=op_name,
     tile_sizes=[1, 0, 4, 4],
@@ -34,11 +37,7 @@ expert_transpose_4d_1302 = SingleTilingExpert(
     peel=[0, 1],
     pad=False,
     pack_paddings=[],
-    hoist_paddings=[],
-    transpose_lowering='shuffle',
-    # kwargs start here.
-    # transforms=[Print('Input IR')],
-    print_ir_after_all=False)
+    hoist_paddings=[]).print_ir(after_all=False)
 
 ################################################################################
 ### Problem instantiations.


### PR DESCRIPTION
A previous commit provided a fluent-style API for `Transformation` and
`TransformationList` subclasses to compose and create new
`TransformationList` subclasses parameterizable by a union of the
options of individual transformations. Implement the same for objects of
said classes. This makes the nicely chainable with the `then` function
that clearly indicates the order of transformations.

This makes the construction of custom transformation chains slightly
more verbose, although arguably more readable, by having each
transformation that takes parameters be listed instead of taking one
list of kwargs into a transformation list and dispatching them to
individual transformations. Further improvements are necessary in the
specification of transformation "variables", currently tied into
autotuning, to allow for a more concise specification of parameters.