### PR TITLE
Always use transforms for printing IR

### DIFF
--- a/python/depthwise_conv/depthwise_conv_1d_bench.py
+++ b/python/depthwise_conv/depthwise_conv_1d_bench.py
@@ -16,7 +16,7 @@ op_name = 'linalg.depthwise_conv_1d_nwc_wc'
 ################################################################################
 
 all_experts = [
-    # LoweringOnlyExpert([], print_ir_after_all=False),
+    # LoweringOnlyExpert().print_ir(after_all=False),
     SingleTilingExpert(
         fun_name=fun_name,
         op_name=op_name,

--- a/python/local_search/invoke_cli.py
+++ b/python/local_search/invoke_cli.py
@@ -144,12 +144,8 @@ def invoke(op, expert, assignments, iters, runs):
       print(f'throughput: {iters/elapsed_time}')
 
   compile_and_callback(
-      op,
-      expert(
-          'matmul_on_tensors',
-          'linalg.' + op.op_name,
-          print_ir_after_all=True,
-          **assignments), callback, **assignments)
+      op, expert('matmul_on_tensors', 'linalg.' + op.op_name, **assignments),
+      callback, **assignments).print_ir(after_all=True)
 
 
 def main(argv):

--- a/python/reduction/row_reduction_2d_test.py
+++ b/python/reduction/row_reduction_2d_test.py
@@ -14,7 +14,8 @@ from .definitions import *
 ################################################################################
 
 # No tiling.
-expert_no_tiling = LoweringOnlyExpert('row_reduction_2d_on_tensors', 'linalg.generic', print_ir_after_all=False)
+expert_no_tiling = LoweringOnlyExpert(
+    'row_reduction_2d_on_tensors', 'linalg.generic').print_ir(after_all=False)
 
 expert_fuse_output = TransformationList(transforms=[ExperimentalSplitAndFuseFillOp(
         'row_reduction_2d_on_tensors', 'linalg.generic', tile_sizes=[24, 16])]

--- a/python/vector/add.py
+++ b/python/vector/add.py
@@ -59,10 +59,7 @@ def main():
     create_vector_add(module, 'add_2d_f32', [8, 128], f32)
     create_vector_add(module, 'add_3d_i8', [8, 128, 4], i8)
 
-    transform = Transform(
-        # print_ir_after_all=True,
-        # print_llvmir=True
-    )
+    transform = Transform().print_ir(after_all=False, llvm=False)
 
     def apply_transform_to_entry_point_name(module):
       return transform('add_2d_f32', module)


### PR DESCRIPTION
`TransformationList`s used to support two ways of printing IR: using the
`Print` pseudo-transformation and using the various flags passed as
kwarg when creating the `TransformationList`. The latter is poorly
composable (e.g., transformations with different "print after all" flag
values have no natural composition). Drop it in favor of using the
`Print` transformation and the chainable `print_ir` function that
simplifies the insertion of `Print`s into the `TransformationList`.
