### PR TITLE
Make LowerVectors a single multi-stage Transform

### DIFF
--- a/python/conv/conv_1d_bench.py
+++ b/python/conv/conv_1d_bench.py
@@ -26,7 +26,7 @@ all_experts = [
             tile_sizes=[1, 8, 32, 1, 8]) +\
           Vectorize(fun_name, op_name) +\
           Bufferize() +\
-          StagedVectorLowering(transpose_lowering='shuffle') +\
+          LowerVectors(transpose_lowering='shuffle') +\
           LowerToLLVM()
     ]
 ]

--- a/python/conv/conv_2d_bench.py
+++ b/python/conv/conv_2d_bench.py
@@ -26,7 +26,7 @@ all_experts = [
             tile_sizes=[1, 1, 8, 32, 1, 1, 8]) + \
           Vectorize(fun_name, op_name) + \
           Bufferize() + \
-          StagedVectorLowering(transpose_lowering='shuffle') +\
+          LowerVectors(transpose_lowering='shuffle') +\
           LowerToLLVM()
     ]
 ]

--- a/python/core/experts.py
+++ b/python/core/experts.py
@@ -1,23 +1,9 @@
 from .transforms import *
 from .transform import TransformListFactory, TransformationList
 
-
-def LowerVectorFactory(stage):
-  """Create a new Transformation class that binds the lowering stage to the
-  given number at class construction time rather than at object construction."""
-
-  def init(self, **kwargs):
-    LowerVectors.__init__(self, stage, **kwargs)
-
-  return type('LowerVectors' + str(stage), (LowerVectors,), {'__init__': init})
-
-
-VectorLowering = TransformListFactory('VectorLowering',
-                                      [LowerVectorFactory(i) for i in range(7)])
-
 # TODO: After DecomposeToLowerDimensionalNamedOp the op_name to anchor on
 # changes: we need a better control mechanism.
-LoweringOnlyExpert = Bufferize.then(VectorLowering).then(LowerToLLVM)
+LoweringOnlyExpert = Bufferize.then(LowerVectors).then(LowerToLLVM)
 SingleTilingExpert = Tile.then(DecomposeToLowerDimensionalNamedOp).then(
     Vectorize).then(LoweringOnlyExpert)
 DoubleTilingExpert = Tile.then(SingleTilingExpert)

--- a/python/fusion/test.py
+++ b/python/fusion/test.py
@@ -15,7 +15,7 @@ from .definitions import *
 
 
 fusion_test_expert = Fuse.then(Bufferize).then(Print).then(
-    VectorLowering).then(LowerToLLVM)
+    LowerVectors).then(LowerToLLVM)
 
 
 # 1 linalg.fill -> linalg.matmul fusion.

--- a/python/matmul/bench.py
+++ b/python/matmul/bench.py
@@ -50,7 +50,7 @@ def make_size_list(sizes: Sequence):
 
 # CHECK-NOT: FAILURE
 def main():
-  n_iters = 10000
+  n_iters = 1000
   problem_size_list = [
       [192, 128, 256],
       [260, 280, 300],

--- a/python/reduction/column_reduction_2d_bench.py
+++ b/python/reduction/column_reduction_2d_bench.py
@@ -26,7 +26,7 @@ def all_experts(problem_sizes: List[int]):
           tile_sizes=[4, 128] if problem_sizes[1] > 256 else [4])\
           .then(Vectorize(fun_name, op_name))\
           .then(Bufferize())\
-          .then(StagedVectorLowering(
+          .then(LowerVectors(
             multi_reduction_lowering='innerparallel'))\
           .then(LowerToLLVM())\
           .print_ir(after_all=False),

--- a/python/reduction/reduction_1d_bench.py
+++ b/python/reduction/reduction_1d_bench.py
@@ -27,7 +27,7 @@ def all_experts(problem_sizes: List[int]):
           tile_sizes=[32])\
       .then(Vectorize(fun_name, op_name))\
       .then(Bufferize())\
-      .then(StagedVectorLowering(multi_reduction_lowering='innerreduction'))\
+      .then(LowerVectors(multi_reduction_lowering='innerreduction'))\
       .then(LowerToLLVM())\
       .print_ir(after_all=False),
   ]

--- a/python/reduction/row_reduction_2d_bench.py
+++ b/python/reduction/row_reduction_2d_bench.py
@@ -50,7 +50,7 @@ def all_experts(problem_sizes: List[int]):
           tile_sizes=[4, 128] if problem_sizes[1] > 256 else [4])\
       .then(Vectorize(fun_name, op_name))\
       .then(Bufferize())\
-      .then(StagedVectorLowering(multi_reduction_lowering='innerreduction'))\
+      .then(LowerVectors(multi_reduction_lowering='innerreduction'))\
       .then(LowerToLLVM())\
       .print_ir(after_all=False),
       # experimental_tile_and_fuse_expert

--- a/python/transpose/transpose_4d_bench.py
+++ b/python/transpose/transpose_4d_bench.py
@@ -16,7 +16,7 @@ def tiling_shuffle_lowering(**kwargs):
   return TileAndDecompose(**kwargs)\
     .then(Vectorize(fun_name, op_name, transpose_lowering='shuffle'))\
     .then(Bufferize())\
-    .then(StagedVectorLowering())\
+    .then(LowerVectors())\
     .then(LowerToLLVM())
 
 expert_transpose_4d_0213 = tiling_shuffle_lowering(

--- a/python/vector/add.py
+++ b/python/vector/add.py
@@ -44,7 +44,7 @@ def create_vector_add(module, name: str, sizes: List[int], element_type):
 class Transform(TransformationList):
 
   def __init__(self, **kwargs):
-    extra_transforms = [LowerVectors(stage=0), LowerToLLVM()]
+    extra_transforms = [LowerVectors(stages=0), LowerToLLVM()]
     t = extra_transforms if 'transforms' not in kwargs else kwargs[
         'transforms'] + extra_transforms
     d = {'transforms': t}


### PR DESCRIPTION
Historically, `LowerVectors` has been parameterized by the vector
lowering stage (one out of 7). This leads to unnecessary complexity when
composing transformations that requires factories and non-trivial Python
constructs just to reuse one three-line method from the base `Transform`
class. Reimplement this method to run the pass pipeline as many times as
there are stages instead. `LowerVectors` is now directly composable with
other `Transform`s and can run an arbitrary subset of stages.