### PR TITLE
Stop indiscriminately passing all kwargs to all Transforms

### DIFF
--- a/python/core/transform.py
+++ b/python/core/transform.py
@@ -87,6 +87,13 @@ class Transform:
     class must be provided.
     """
     cls = self.__class__
+
+    for name in kwargs:
+      if name not in cls.variables and name not in ('fun_name', 'op_name'):
+        raise ValueError(
+            f"Unexpected {name} keyword argument, "
+            f"{cls.__name__} only accepts {list(cls.variables.keys())}")
+
     for name in cls.variables:
       if name not in kwargs and not isinstance(cls.variables[name], tuple):
         raise ValueError(f"Missing {name} mandatory keyword argument when "
@@ -235,18 +242,14 @@ class TransformListMetaclass(type):
 
     def init(self, fun_name: str, op_name: str, **kwargs):
       self.transforms = []
-      kwargs['fun_name'] = fun_name
-      kwargs['op_name'] = op_name
       for transform, remapping in zip(transforms, remappings):
-        transform_args = deepcopy(kwargs)
+        transform_args = {}
+        transform_args['fun_name'] = fun_name
+        transform_args['op_name'] = op_name
         for name, transform_name in remapping.items():
-          if transform_name == name:
-            continue
-          if name in transform_args:
-            transform_args[transform_name] = transform_args[name]
-            del transform_args[name]
+          if name in kwargs:
+            transform_args[transform_name] = kwargs[name]
         self.transforms.append(transform(**transform_args))
-      self.__dict__.update(kwargs)
 
     attrs['__init__'] = init
     attrs['_transform_classes'] = transforms

--- a/python/matmul/bench.py
+++ b/python/matmul/bench.py
@@ -32,10 +32,10 @@ all_experts = [
                             pack_paddings2=[1, 1, 0],
                             hoist_paddings2=[5, 6, 0]).then(\
       Vectorize('matmul_on_tensors',
-                'linalg.generic',
-                transpose_lowering='eltwise')).then(\
+                'linalg.generic')).then(\
       LoweringOnlyExpert('matmul_on_tensors',
-                         'linalg.generic'))
+                         'linalg.generic',
+                         transpose_lowering='eltwise'))
     ]]
 
 ################################################################################
@@ -50,7 +50,7 @@ def make_size_list(sizes: Sequence):
 
 # CHECK-NOT: FAILURE
 def main():
-  n_iters = 1000
+  n_iters = 10
   problem_size_list = [
       [192, 128, 256],
       [260, 280, 300],

--- a/python/transpose/transpose_2d_bench.py
+++ b/python/transpose/transpose_2d_bench.py
@@ -74,11 +74,11 @@ def all_experts(problem_sizes: List[int], transpose_avx2_lowering):
                                  tile_sizes2=sizes2,
                                  pack_paddings2=[0, 1],
                                  hoist_paddings2=[2, 2])
-  vectorize = Vectorize(fun_name,
-                        op_name,
-                        tranpose_lowering='shuffle',
-                        transpose_avx2_lowering=transpose_avx2_lowering)
-  lowering = LoweringOnlyExpert(fun_name, op_name)
+  vectorize = Vectorize(fun_name, op_name)
+  lowering = LoweringOnlyExpert(fun_name,
+                                op_name,
+                                transpose_lowering='shuffle',
+                                transpose_avx2_lowering=transpose_avx2_lowering)
 
   return [e.print_ir(after_all=False)
       for e in [\

--- a/python/transpose/transpose_4d_bench.py
+++ b/python/transpose/transpose_4d_bench.py
@@ -14,9 +14,9 @@ op_name = 'linalg.generic'
 
 def tiling_shuffle_lowering(**kwargs):
   return TileAndDecompose(**kwargs)\
-    .then(Vectorize(fun_name, op_name, transpose_lowering='shuffle'))\
+    .then(Vectorize(fun_name, op_name))\
     .then(Bufferize())\
-    .then(LowerVectors())\
+    .then(LowerVectors(transpose_lowering='shuffle'))\
     .then(LowerToLLVM())
 
 expert_transpose_4d_0213 = tiling_shuffle_lowering(


### PR DESCRIPTION
Historically, the entire list of kwargs passed into a
`TransformationList` call was being passed down to all individual
`Transform`s. Incorrect arguments not consumed by any transform,
including typos, would get silently ignored. Fix that by only allowing
the arguments that correspond to variables listed in the Transform.

Function and operation name are still accepted everywhere since they are
used to target transformations and are not variables.

Fix the bugs this uncovered.