### PR TITLE
Add a simple script to run the tests.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -59,4 +59,9 @@ jobs:
         python configure.py --llvm-path=../llvm-project
         ccache -s
 
+    - name: Test
+      run: |
+        cd ${GITHUB_WORKSPACE}/sandbox
+        python run_tests.py
+
     # TODO: Add a build for IREE but it will get stale as soon as we update core + sandbox

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Script to run tests and benchmarks.
+
+import glob
+import os
+import subprocess
+import sys
+
+
+def _convert_path_to_module(test_script : str) -> str:
+  """Convert the path of the test script to its module name."""
+  test_script = test_script.replace(os.sep, ".")
+  test_script = test_script.strip(".")
+  if test_script.endswith(".py"):
+    return test_script[:-3]
+  return test_script
+
+
+def _run_test(test_script: str) -> bool:
+  """Run the provided test script an return failure or success.
+
+  A test succeeds if:
+  - it does not time out
+  - it returns zero
+  - it does not print FAILURE
+  """
+  print(f"- running {test_script}: ", end="")
+  module = _convert_path_to_module(test_script)
+  environment = os.environ
+  environment["PYTHONPATH"] = "./build/tools/sandbox/python_package"
+  environment["MLIR_RUNNER_UTILS_LIB"] = "./build/lib/libmlir_runner_utils.so"
+  proc = subprocess.Popen(["python", "-m", module],
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                          env=environment)
+  try:
+    outs, errs = proc.communicate(timeout=20)
+  except subprocess.TimeoutExpired:
+    proc.kill()
+    print("\033[31m" + "FAILED" + "\033[m")
+    print("  -> test execution timed out")
+    return False
+  if proc.returncode != 0:
+    print("\033[31m" + "FAILED" + "\033[m")
+    print(f"  -> test returned code {proc.returncode}")
+    return False
+  # Check the output for numerical failures.
+  outs = outs.decode("utf-8")
+  errs = errs.decode("utf-8")
+  for line in outs.splitlines() + errs.splitlines():
+    if line.count("FAILURE") != 0:
+      print("\033[31m" + "FAILED" + "\033[m")
+      print(f"  -> test failure: {line}")
+      return False
+  print("\033[32m" + "SUCCESS" + "\033[m")
+  return True
+
+
+def main():
+  results = []
+  for f in glob.glob("./python/**/*test.py", recursive=True):
+    results.append(_run_test(f))
+  errors = results.count(False)
+  if errors:
+    print(f'-> {errors} tests failed!')
+    exit(1)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Add a simple script to run the tests found in the python directory. 

It currently detects if a test times out, returns a non-zero error code, or prints 'FAILURE': 
```
- running ./python/fusion/test.py: SUCCESS
- running ./python/matvec/test.py: SUCCESS
- running ./python/matmul/test.py: SUCCESS
- running ./python/reduction/reduction_1d_test.py: SUCCESS
- running ./python/reduction/row_reduction_2d_test.py: SUCCESS
- running ./python/reduction/column_reduction_2d_test.py: SUCCESS
- running ./python/contraction/einsum_test.py: SUCCESS
```
This addresses issue #29