### PR TITLE
Add simple script to run all benchmarks

### DIFF
--- a/python/examples/matmul/bench.py
+++ b/python/examples/matmul/bench.py
@@ -89,5 +89,19 @@ def main():
                  pytorch_benchmark=pytorch_kernel)
 
 
+def benchmark():
+  n_iters = 10
+  problem_size_list = [
+      [200, 200, 200],
+      [1000, 1000, 1000],
+      [2000, 2000, 2000],
+  ]
+  test_harness(lambda s, t: EinsumProblem('mk,kn'), [[np.float32] * 3],
+               map(make_size_list, problem_size_list),
+               all_experts,
+               n_iters=n_iters,
+               function_name='matmul_on_tensors')
+
+
 if __name__ == '__main__':
   main()

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Script to run tests and benchmarks.
+
+import io
+import importlib
+import glob
+import os
+import subprocess
+import sys
+
+from contextlib import redirect_stdout
+
+def _convert_path_to_module(test_script : str) -> str:
+  """Convert the path of the test script to its module name."""
+  test_script = test_script.replace(os.sep, ".")
+  test_script = test_script.strip(".")
+  if test_script.endswith(".py"):
+    return test_script[:-3]
+  return test_script
+
+
+def _run_benchmark(bench_script: str):
+  """Check if the provided script has a benchmark() function and run it."""
+  module_name = _convert_path_to_module(bench_script)
+  module = importlib.import_module(module_name)
+  if not hasattr(module, "benchmark"):
+    return
+  print(f"- running {bench_script}:")
+  f = io.StringIO()
+  with redirect_stdout(f):
+    module.benchmark()
+  out = f.getvalue()
+  expert = 0
+  for line in out.splitlines():
+    if "Runtime problem size" in line:
+      sizes = [x.split(",")[0].split("}")[0] for x in line.split(":")[1:]]
+      problem_size = "x".join([x.strip() for x in sizes])
+      print(f"  -> problem {problem_size}:\t")
+      expert = 0
+    if "expert" in line:
+      print(f"     - expert[{expert}]:\t\t", end="")
+      expert = expert + 1
+    if "GFlops/s" in line:
+      compute_throughputs = line.split()
+      print(f"{compute_throughputs[-2]} GFlops/s\t\t", end="")
+    if "GBs/s" in line:
+      memory_throughputs = line.split()
+      print(f"{memory_throughputs[-2]} GBs/s")
+
+
+def main():
+  for f in glob.glob("./python/**/*bench.py", recursive=True):
+    _run_benchmark(f)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Aggregate the average median performance of all experiments of a specific benchmark. Currently, some benchmarks timeout.

Output:
```
- running ./python/transpose/transpose_2d_bench.py: FAILED
  -> test execution timed out
- running ./python/transpose/transpose_4d_bench.py: SUCCESS
  -> 0.00 GFlops/s
  -> 16.18 GBs/s
- running ./python/matvec/bench.py: SUCCESS
  -> 2.44 GFlops/s
  -> 4.93 GBs/s
- running ./python/matmul/bench.py: FAILED
  -> test execution timed out
- running ./python/copy/copy_2d_bench.py: SUCCESS
  -> 0.00 GFlops/s
  -> 147.60 GBs/s
- running ./python/reduction/column_reduction_2d_bench.py: SUCCESS
  -> 16.86 GFlops/s
  -> 67.86 GBs/s
- running ./python/reduction/reduction_1d_bench.py: SUCCESS
  -> 4.16 GFlops/s
  -> 16.70 GBs/s
- running ./python/reduction/row_reduction_2d_bench.py: SUCCESS
  -> 13.54 GFlops/s
  -> 54.41 GBs/s
- running ./python/conv/conv_1d_bench.py: SUCCESS
  -> 106.31 GFlops/s
  -> 8.22 GBs/s
- running ./python/conv/conv_3d_bench.py: SUCCESS
  -> 1.65 GFlops/s
  -> 0.03 GBs/s
- running ./python/conv/conv_2d_bench.py: SUCCESS
  -> 49.16 GFlops/s
  -> 1.45 GBs/s
- running ./python/padding/padded_conv1d_bench.py: SUCCESS
  -> 78.24 GFlops/s
  -> 5.40 GBs/s
- running ./python/depthwise_conv/depthwise_conv_1d_bench.py: SUCCESS
  -> 37.70 GFlops/s
  -> 96.84 GBs/s
```