### PR TITLE
Add lit testing to the test runner.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -59,6 +59,12 @@ jobs:
         python configure.py --llvm-path=../llvm-project
         ccache -s
 
+    - name: Build FileCheck
+      run: |
+        echo "IREE_LLVM_SANDBOX_BUILD_DIR=${GITHUB_WORKSPACE}/sandbox/build" >> $GITHUB_ENV
+        cd ${GITHUB_WORKSPACE}/sandbox/build
+        ninja FileCheck
+
     - name: Test
       run: |
         cd ${GITHUB_WORKSPACE}/sandbox

--- a/README.md
+++ b/README.md
@@ -117,3 +117,15 @@ TODOs:
 
 1.  hook up a lit test target.
 2.  re-add npcomp instructions once it is upgraded to use the same build setup.
+
+
+## Running tests
+
+The following commands either run the lit tests only or all tests:
+```
+# Run lit tests
+lit -v test
+# Run python and lit tests
+python ./run_tests
+```
+The lit configuration file `test/lit.cfg.py` contains a list of excluded tests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ iree-runtime-snapshot
 torch
 torchvision
 torchaudio
+
+# Testing.
+lit

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+import lit.formats
+import lit.util
+
+import lit.llvm
+
+# Configuration file for the 'lit' test runner.
+lit.llvm.initialize(lit_config, config)
+
+# name: The name of this test suite.
+config.name = "mlir-proto-opt tests"
+
+config.test_format = lit.formats.ShTest(execute_external=True)
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = [".mlir"]
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The path where tests shall execute.
+build_dir = os.environ["IREE_LLVM_SANDBOX_BUILD_DIR"]
+config.test_exec_root = os.path.join(build_dir, 'test')
+
+#config.use_default_substitutions()
+config.excludes = [
+  "lit.cfg.py",
+  "lit.site.cfg.py",
+
+  # Currently disabled tests.
+  "tiling.mlir",
+  "constant.mlir",
+  "test_matmul_f32_cuda.mlir",
+  "matmul-f32-mt-cpu.mlir",
+  "pack-2d-to-4d-by-8x4-blocks.mlir",
+  "test_matmul_f16_cuda_mma.mlir",
+  "vector-distribution.mlir",
+  "matmul-f32-base.mlir"
+]
+
+config.substitutions.extend([
+    ("%PYTHON", sys.executable),
+])
+
+# Add the build/bin directory to the path.
+sys.path.append(os.path.join(build_dir, "bin"))
+config.environment["PYTHONPATH"] = ":".join(sys.path)
+config.environment["PATH"] = ":".join(sys.path)
+project_root = os.path.dirname(os.path.dirname(__file__))


### PR DESCRIPTION
Add a lit test configuration and include it in run_tests.py. The revision adds a new dependency to pylit and requires rerunning `python -m pip install -r requirements.txt`. A number of tests are currently failing and are added to `config.excludes` in test/lit.cfg.py.
