### PR TITLE
Build FileCheck by default.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -58,12 +58,7 @@ jobs:
         cd ${GITHUB_WORKSPACE}/sandbox
         python configure.py --llvm-path=../llvm-project
         ccache -s
-
-    - name: Build FileCheck
-      run: |
         echo "IREE_LLVM_SANDBOX_BUILD_DIR=${GITHUB_WORKSPACE}/sandbox/build" >> $GITHUB_ENV
-        cd ${GITHUB_WORKSPACE}/sandbox/build
-        ninja FileCheck
 
     - name: Test
       run: |

--- a/configure.py
+++ b/configure.py
@@ -143,7 +143,7 @@ def main(args):
   cmake_args = ["cmake", "--build", build_dir, "--target", \
                 "tools/sandbox/all", "mlir-opt", "mlir-translate", \
                 "mlir_runner_utils", "mlir_c_runner_utils", \
-                "llvm-mca", "llvm-objdump", "llc", "opt"]
+                "llvm-mca", "llvm-objdump", "llc", "opt", "FileCheck"]
   print(f"-- Performing initial build: {' '.join(cmake_args)}")
   subprocess.check_call(cmake_args, cwd=build_dir)
 


### PR DESCRIPTION
Add FileCheck to the build targets and remove the separate build step from the Github action.