### PR TITLE
Convolution performance improvements.

### DIFF
--- a/lib/LinalgTensorCodegenDriver.cpp
+++ b/lib/LinalgTensorCodegenDriver.cpp
@@ -229,8 +229,6 @@ void LinalgFuseOutputIntoReductionPass::runOnOperation() {
 
 void LinalgSingleTilingExpertPass::runOnOperation() {
   FuncOp funcOp = getOperation();
-  if (anchorOpName.empty())
-    return;
 
   // Set up tiling and vectorization options.
   LinalgTilingOptions tilingOptions;

--- a/python/examples/conv/conv_1d_bench.py
+++ b/python/examples/conv/conv_1d_bench.py
@@ -23,7 +23,8 @@ all_experts = [
             fun_name,
             op_name,
             #           N  W   C  KW  F
-            tile_sizes=[1, 8, 32, 1, 8]) +\
+            tile_sizes=[1, 8, 32, 1, 8],
+            pad=True) +\
           Vectorize(fun_name, op_name) +\
           Bufferize() +\
           LowerVectors(transpose_lowering='shuffle') +\

--- a/python/examples/conv/conv_2d_bench.py
+++ b/python/examples/conv/conv_2d_bench.py
@@ -23,8 +23,9 @@ all_experts = [
             fun_name=fun_name,
             op_name=op_name,
             #           N  H  W  C  KH  KW  F
-            tile_sizes=[1, 1, 8, 32, 1, 1, 8]) + \
-          Vectorize(fun_name, op_name) + \
+            tile_sizes=[1, 1, 8, 32, 1, 1, 8],
+            pad=True) + \
+          Vectorize(fun_name, "") + \
           Bufferize() + \
           LowerVectors(transpose_lowering='shuffle') +\
           LowerToLLVM()


### PR DESCRIPTION
Initial convolution performance improvements:
- enable decomposition by removing the check for the empty anchor op name in the driver
- set the vectorization op_name to the empty string since decomposition changes the op_name
- enable padding (not relevant for the current benchmarks).