### PR TITLE
Remove nesting from transformations to enqueue the staged vector lowering

### DIFF
--- a/lib/LinalgTensorCodegenDriver.cpp
+++ b/lib/LinalgTensorCodegenDriver.cpp
@@ -441,11 +441,11 @@ std::unique_ptr<OperationPass<ModuleOp>> mlir::createLLVMLoweringPass() {
 //===----------------------------------------------------------------------===//
 
 void mlir::addLowerToVectorTransforms(OpPassManager &passManager) {
-  passManager.addNestedPass<FuncOp>(createLinalgVectorLoweringPass(0));
-  passManager.addNestedPass<FuncOp>(createLinalgVectorLoweringPass(1));
-  passManager.addNestedPass<FuncOp>(createLinalgVectorLoweringPass(2));
-  passManager.addNestedPass<FuncOp>(createLinalgVectorLoweringPass(3));
-  passManager.addNestedPass<FuncOp>(createLinalgVectorLoweringPass(4));
-  passManager.addNestedPass<FuncOp>(createLinalgVectorLoweringPass(5));
-  passManager.addNestedPass<FuncOp>(createLinalgVectorLoweringPass(6));
+  passManager.addPass(createLinalgVectorLoweringPass(0));
+  passManager.addPass(createLinalgVectorLoweringPass(1));
+  passManager.addPass(createLinalgVectorLoweringPass(2));
+  passManager.addPass(createLinalgVectorLoweringPass(3));
+  passManager.addPass(createLinalgVectorLoweringPass(4));
+  passManager.addPass(createLinalgVectorLoweringPass(5));
+  passManager.addPass(createLinalgVectorLoweringPass(6));
 }


### PR DESCRIPTION
The documentation specifies that the passmanager is expected to be a
`builtin.func` pass manager, so the additional nesting is unnecessary
(actually incorrect).