### PR TITLE
Fix VectorExt/Transform build

### DIFF
--- a/lib/Dialects/VectorExt/Transform/CMakeLists.txt
+++ b/lib/Dialects/VectorExt/Transform/CMakeLists.txt
@@ -5,5 +5,9 @@ add_mlir_library(MLIRVectorExtTransform
   MLIRVectorExt
 
   LINK_LIBS PUBLIC
+  MLIRAffine
   MLIRIR
+  MLIRLinalg
+  MLIRVector
+  MLIRVectorExt
 )


### PR DESCRIPTION
Virtually none of the library dependencies were listed in
CMakeLists.txt.