### PR TITLE
Run vectorization twice for convolution to obtain good performance.

### DIFF
--- a/python/examples/conv/conv_2d_bench.py
+++ b/python/examples/conv/conv_2d_bench.py
@@ -24,7 +24,16 @@ all_experts = [
             op_name=op_name,
             #           N  H  W  C  KH  KW  F
             tile_sizes=[1, 1, 8, 32, 1, 1, 8],
-            pad=True) + \
+            pad=True,
+            hoist_paddings=[7, 7, 0]) + \
+          # The two stage vectorization is needed since running canonicalize
+          # in between named op vectorization and pad tensor op vectorization
+          # produces significantly better code.
+          # The two stage vectorization is needed since only running
+          # canonicalize in between enables an efficient vectorization of
+          # the pad tensor operations.
+          # TODO: Remove once vectorization in one step works.
+          Vectorize(fun_name, "", vectorize_paddings=False) + \
           Vectorize(fun_name, "") + \
           Bufferize() + \
           LowerVectors(transpose_lowering='shuffle') +\

--- a/python/examples/core/transforms.py
+++ b/python/examples/core/transforms.py
@@ -179,17 +179,26 @@ class Tile(Transform):
 
 
 class Vectorize(Transform):
+  """Vectorize named operations.
+
+  This transform can be configured as follows:
+  * `vectorize_paddings`: Vectorize pad tensor operations.
+  """
 
   variables = {
-    'vectorize': (BoolVariable, True),
+    'vectorize_paddings': (BoolVariable, True),
   }
 
   def __init__(self, fun_name: str, op_name: str, **kwargs):
+    self._parse_variables_in_kwargs(kwargs)
+    vectorize_paddings_str = ''
+    if self.vectorize_paddings:
+      vectorize_paddings_str = 'vectorize-padding'
     pipeline = (f'linalg-single-tiling-expert-driver{{'
                 f'     anchor-func={fun_name} '
                 f'     anchor-op={op_name} '
                 f'     vectorize '
-                f'     vectorize-padding}},'
+                f'     {vectorize_paddings_str}}},'
                 f'canonicalize,'
                 f'cse')
     self._parse_variables_in_kwargs(kwargs)


### PR DESCRIPTION
At the moment, we need to run vectorization twice and only in the second run lower the pad tensor ops. The canonicalization and enabling pass running in between unlocks a better pad tensor op vectorization.