### PR TITLE
Add an e2e python test that runs through linalg_ext.in_parallel

### DIFF
--- a/include/Dialects/LinalgExt/Transforms/Utils.h
+++ b/include/Dialects/LinalgExt/Transforms/Utils.h
@@ -9,9 +9,12 @@
 #ifndef IREE_LLVM_SANDBOX_DIALECTS_LINALGEXT_TRANSFORMS_UTILS_H_
 #define IREE_LLVM_SANDBOX_DIALECTS_LINALGEXT_TRANSFORMS_UTILS_H_
 
+#include "mlir/Support/LLVM.h"
+
 namespace mlir {
 class Location;
 class OpBuilder;
+class Operation;
 class Value;
 
 namespace tensor {
@@ -19,6 +22,37 @@ class ExtractSliceOp;
 }
 
 namespace linalg_ext {
+
+/// Helper function which auto-completes the missing trailing dimensions to
+/// always be offset = 0, size = dim, stride = 1.
+void completeOffsetsSizesAndStrides(OpBuilder &b, Location loc, Value tensor,
+                                    ArrayRef<Value> leadingOffsets,
+                                    ArrayRef<Value> leadingSizes,
+                                    ArrayRef<Value> leadingStrides,
+                                    SmallVectorImpl<Value> &offsets,
+                                    SmallVectorImpl<Value> &sizes,
+                                    SmallVectorImpl<Value> &strides);
+
+/// Create a tensor::ExtractSliceOp by auto-completing the missing trailing
+/// dimensions to always be offset = 0, size = dim, stride = 1.
+Value createSubsetExtractOpFromLeadingOffsetsSizesAndStrides(
+    OpBuilder &b, Location loc, Value tensor,
+    llvm::ArrayRef<Value> leadingOffsets, ArrayRef<Value> leadingSizes,
+    ArrayRef<Value> leadingStrides);
+
+/// Create a tensor::InsertSliceOp by auto-completing the missing trailing
+/// dimensions to always be offset = 0, size = dim, stride = 1.
+Value createSubsetInsertOpFromLeadingOffsetsSizesAndStrides(
+    OpBuilder &b, Location loc, Value tensor, Value dest,
+    ArrayRef<Value> leadingOffsets, ArrayRef<Value> leadingSizes,
+    ArrayRef<Value> leadingStrides);
+
+/// Create a linalg_ext::ParallelInsertSliceOp by auto-completing the missing
+/// trailing dimensions to always be offset = 0, size = dim, stride = 1.
+Operation *createParallelInsertSliceOpFromLeadingOffsetsSizesAndStrides(
+    OpBuilder &b, Location loc, Value tensor, Value dest,
+    ArrayRef<Value> leadingOffsets, ArrayRef<Value> leadingSizes,
+    ArrayRef<Value> leadingStrides);
 
 /// Insert the `source` tensor into the `dest` tensor by creating the relevant
 /// `subset_insert` op. The details of the `subset_insert` op are retrieved

--- a/lib/Dialects/LinalgExt/Transforms/TileToSequentialFor.cpp
+++ b/lib/Dialects/LinalgExt/Transforms/TileToSequentialFor.cpp
@@ -78,17 +78,9 @@ struct TileOpToSCFRewriter : public OpRewritePattern<linalg_ext::TileOp> {
     // clang-format on
     SmallVector<Value> implicitSubtensorExtracts;
     for (Value tensor : forOp.getRegionIterArgs()) {
-      auto rankedTensorType = tensor.getType().cast<RankedTensorType>();
-      SmallVector<Value> offsets(rankedTensorType.getRank(), zero);
-      offsets.front() = offset;
-      SmallVector<Value> sizes;
-      sizes.push_back(size);
-      for (int64_t i = 1, e = rankedTensorType.getRank(); i < e; ++i)
-        sizes.push_back(rewriter.create<tensor::DimOp>(loc, tensor, i));
-      SmallVector<Value> strides(rankedTensorType.getRank(), one);
       implicitSubtensorExtracts.push_back(
-          rewriter.createOrFold<tensor::ExtractSliceOp>(loc, tensor, offsets,
-                                                        sizes, strides));
+          createSubsetExtractOpFromLeadingOffsetsSizesAndStrides(
+              rewriter, loc, tensor, offset, size, one));
     }
 
     // Regroup the values that replace the tileOp's bbArg and move the body.

--- a/lib/Dialects/LinalgExt/Transforms/Utils.cpp
+++ b/lib/Dialects/LinalgExt/Transforms/Utils.cpp
@@ -17,9 +17,76 @@
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include <mlir/Dialect/Affine/IR/AffineOps.h>
 
 using namespace mlir;
 using namespace mlir::linalg_ext;
+
+void mlir::linalg_ext::completeOffsetsSizesAndStrides(
+    OpBuilder &b, Location loc, Value tensor, ArrayRef<Value> leadingOffsets,
+    ArrayRef<Value> leadingSizes, ArrayRef<Value> leadingStrides,
+    SmallVectorImpl<Value> &offsets, SmallVectorImpl<Value> &sizes,
+    SmallVectorImpl<Value> &strides) {
+  assert(leadingOffsets.size() == leadingSizes.size() &&
+         "expected matching lengths");
+  assert(leadingSizes.size() == leadingStrides.size() &&
+         "expected matching lengths");
+
+  auto rankedTensorType = tensor.getType().cast<RankedTensorType>();
+  int64_t tensorRank = rankedTensorType.getRank();
+  int64_t leadingRank = leadingOffsets.size();
+  offsets = SmallVector<Value>(leadingOffsets.begin(), leadingOffsets.end());
+  sizes = SmallVector<Value>(leadingSizes.begin(), leadingSizes.end());
+  strides = SmallVector<Value>(leadingStrides.begin(), leadingStrides.end());
+  if (leadingRank >= tensorRank)
+    return;
+  Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
+  Value one = b.create<arith::ConstantIndexOp>(loc, 1);
+  for (int64_t i = leadingRank, e = tensorRank; i < e; ++i) {
+    offsets.push_back(zero);
+    sizes.push_back(b.createOrFold<tensor::DimOp>(loc, tensor, i));
+    strides.push_back(one);
+  }
+}
+
+/// Create a tensor::ExtractSliceOp by auto-completing the missing trailing
+/// dimensions to always be offset = 0, size = dim, stride = 1.
+Value mlir::linalg_ext::createSubsetExtractOpFromLeadingOffsetsSizesAndStrides(
+    OpBuilder &b, Location loc, Value tensor, ArrayRef<Value> leadingOffsets,
+    ArrayRef<Value> leadingSizes, ArrayRef<Value> leadingStrides) {
+  SmallVector<Value> offsets, sizes, strides;
+  completeOffsetsSizesAndStrides(b, loc, tensor, leadingOffsets, leadingSizes,
+                                 leadingStrides, offsets, sizes, strides);
+  return b.createOrFold<tensor::ExtractSliceOp>(loc, tensor, offsets, sizes,
+                                                strides);
+}
+
+/// Create a tensor::InsertSliceOp by auto-completing the missing trailing
+/// dimensions to always be offset = 0, size = dim, stride = 1.
+Value mlir::linalg_ext::createSubsetInsertOpFromLeadingOffsetsSizesAndStrides(
+    OpBuilder &b, Location loc, Value tensor, Value dest,
+    ArrayRef<Value> leadingOffsets, ArrayRef<Value> leadingSizes,
+    ArrayRef<Value> leadingStrides) {
+  SmallVector<Value> offsets, sizes, strides;
+  completeOffsetsSizesAndStrides(b, loc, tensor, leadingOffsets, leadingSizes,
+                                 leadingStrides, offsets, sizes, strides);
+  return b.createOrFold<tensor::InsertSliceOp>(loc, tensor, dest, offsets,
+                                               sizes, strides);
+}
+
+/// Create a linalg_ext::ParallelInsertSliceOp by auto-completing the missing
+/// trailing dimensions to always be offset = 0, size = dim, stride = 1.
+Operation *
+mlir::linalg_ext::createParallelInsertSliceOpFromLeadingOffsetsSizesAndStrides(
+    OpBuilder &b, Location loc, Value tensor, Value dest,
+    ArrayRef<Value> leadingOffsets, ArrayRef<Value> leadingSizes,
+    ArrayRef<Value> leadingStrides) {
+  SmallVector<Value> offsets, sizes, strides;
+  completeOffsetsSizesAndStrides(b, loc, tensor, leadingOffsets, leadingSizes,
+                                 leadingStrides, offsets, sizes, strides);
+  return b.createOrFold<linalg_ext::ParallelInsertSliceOp>(
+      loc, tensor, dest, offsets, sizes, strides);
+}
 
 /// Insert the `source` tensor into the `dest` tensor by creating the relevant
 /// `subset_insert` op. The details of the `subset_insert` op are retrieved

--- a/python/examples/core/transforms.py
+++ b/python/examples/core/transforms.py
@@ -220,10 +220,26 @@ class LinalgExtTileToSequentialFor(Transform):
       **kwargs):
     self._parse_variables_in_kwargs(kwargs)
 
-    pipeline = (f'linalg-tile-to-sequential-for{{'
-                #f'     anchor-func={fun_name} '
-                #f'     anchor-op={op_name} '
-                f'}},'
+    pipeline = (f'linalg-tile-to-sequential-for,'
+                f'canonicalize,'
+                f'cse')
+    self.pipeline = (f'builtin.func({pipeline})')
+
+class LinalgExtTileToInParallel(Transform):
+  """Rewrite linalg_ext.tile op to linalg_ext.in_parallel.
+  """
+
+  variables = {}
+
+  def __init__(
+      self,
+      fun_name: str,
+      op_name: str,
+      **kwargs):
+    self._parse_variables_in_kwargs(kwargs)
+
+    pipeline = (f'linalg-tile-to-in-parallel,'
+                f'linalg-in-parallel-to-sequential-for,'
                 f'canonicalize,'
                 f'cse')
     self.pipeline = (f'builtin.func({pipeline})')

--- a/python/examples/linalg_ext/test_in_par.py
+++ b/python/examples/linalg_ext/test_in_par.py
@@ -25,13 +25,13 @@ expert_linalg_ext_tile = TestExpert([
     LinalgExtTile('matmul_on_tensors',
                   'linalg.generic',
                   tile_sizes=[2]),
-    LinalgExtTileToSequentialFor('matmul_on_tensors',
+    LinalgExtTileToInParallel('matmul_on_tensors',
                                  'linalg.generic'),
     Vectorize('matmul_on_tensors', 'linalg.generic'),
 ])
 
 all_experts = [
-    e.print_ir(after_all=True, llvm=True) for e in [
+    e.print_ir(after_all=False, llvm=False) for e in [
         expert_linalg_ext_tile
     ]
 ]

--- a/python/examples/linalg_ext/test_seq.py
+++ b/python/examples/linalg_ext/test_seq.py
@@ -1,0 +1,62 @@
+# RUN: %PYTHON %s 2>&1 | FileCheck %s
+
+# This file contains simple test cases that combine various codegen options.
+
+from ..core.experts import *
+from ..core.harness import *
+from ..core.transforms import *
+
+from ..contraction.definitions import *
+
+import typing as tp
+
+################################################################################
+# Compilation strategies.
+################################################################################
+
+
+def TestExpert(transforms: tp.Sequence[tp.Union[Transform,
+                                                TransformationList]]):
+  return (TransformationList(transforms=transforms) + Bufferize() +
+          LoweringOnlyExpert('matmul_on_tensors', 'linalg.generic'))
+
+
+expert_linalg_ext_tile = TestExpert([
+    LinalgExtTile('matmul_on_tensors',
+                  'linalg.generic',
+                  tile_sizes=[2]),
+    LinalgExtTileToSequentialFor('matmul_on_tensors',
+                                 'linalg.generic'),
+    Vectorize('matmul_on_tensors', 'linalg.generic'),
+])
+
+all_experts = [
+    e.print_ir(after_all=False, llvm=False) for e in [
+        expert_linalg_ext_tile
+    ]
+]
+
+################################################################################
+# Problem instantiations.
+################################################################################
+
+keys = ['m', 'n', 'k']
+
+
+def make_size_list(sizes: Sequence[int]):
+    return {k: v for k, v in zip(keys, sizes)}
+
+
+# CHECK-NOT: FAILURE
+def main():
+    n_iters = 1
+    problem_size_list = [[3, 5, 7]]
+    test_harness(lambda s, t: EinsumProblem('mk,kn'), [[np.float32] * 3],
+                 map(make_size_list, problem_size_list),
+                 all_experts,
+                 n_iters=n_iters,
+                 function_name='matmul_on_tensors')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The run is still sequential until we have bufferization enabled for linalg_ext.in_parallel.
This revision also fixes some op building issues that will be better verified once D115677 lands.