### PR TITLE
Add an initial version of the Linalg Transform pass

### DIFF
--- a/include/Dialects/CMakeLists.txt
+++ b/include/Dialects/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(LinalgExt)
+add_subdirectory(LinalgTransform)
 add_subdirectory(VectorExt)

--- a/include/Dialects/LinalgTransform/CMakeLists.txt
+++ b/include/Dialects/LinalgTransform/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_mlir_dialect(LinalgTransformOps linalg_transform)

--- a/include/Dialects/LinalgTransform/LinalgTransformOps.h
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.h
@@ -1,0 +1,20 @@
+//===-- LinalgTransformOps.h - Linalg Transform dialect ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_LINALG_IR_LINALGTRANSFORMOPS_H
+#define MLIR_DIALECT_LINALG_IR_LINALGTRANSFORMOPS_H
+
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/IR/OpDefinition.h"
+
+#include "Dialects/LinalgTransform/LinalgTransformOpsDialect.h.inc"
+
+#define GET_OP_CLASSES
+#include "Dialects/LinalgTransform/LinalgTransformOps.h.inc"
+
+#endif // MLIR_DIALECT_LINALG_IR_LINALGTRANSFORMOPS_H

--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -1,0 +1,110 @@
+//===- LinalgTransform.td - Linalg transform dialect -------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Definitions of attributes, operations and types used to control
+// transformations on the Linalg dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LINALG_TRANSFORM_OPS
+#define LINALG_TRANSFORM_OPS
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/OpAsmInterface.td"
+
+def Linalg_Transform_Dialect : Dialect {
+  let name = "linalg_transform";
+  let cppNamespace = "::mlir::linalg::transform";
+  let dependentDialects = [
+    "linalg::LinalgDialect",
+  ];
+}
+
+class Linalg_Transform_Operation<string name, list<OpTrait> props = []>
+    : Op<Linalg_Transform_Dialect, name, props> {
+  let cppNamespace = "::mlir::linalg::transform";
+}
+
+def SequenceOp : Linalg_Transform_Operation<"sequence",
+                                            [NoTerminator, OpAsmOpInterface]> {
+  let description = [{Contains a sequence of transformation ops to apply.}];
+
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = "attr-dict-with-keyword regions";
+
+  let extraClassDeclaration = [{
+    static StringRef getDefaultDialect() { return "linalg_transform"; }
+  }];
+}
+
+def TileOp : Linalg_Transform_Operation<"tile"> {
+  let description = [{Indicates that ops of a specific kind in the given
+  function should be tiled with the options provided as attributes.}];
+
+  let arguments = (ins SymbolRefAttr:$fun_name,
+                   StrAttr:$op_name,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$sizes,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$interchange,
+                   DefaultValuedAttr<BoolAttr, "false">:$pad,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$pack_paddings,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$hoist_paddings,
+                   DefaultValuedAttr<BoolAttr, "false">:$scalarize_dyn_dims,
+                   DefaultValuedAttr<BoolAttr, "false">:$generalize
+                  );
+
+  let assemblyFormat = "$op_name `in` $fun_name attr-dict";
+}
+
+def BufferizeOp : Linalg_Transform_Operation<"bufferize"> {
+  let description = [{Indicates that the entire module should be bufferized.}];
+  let assemblyFormat = "attr-dict";
+}
+
+def DecomposeOp : Linalg_Transform_Operation<"decompose"> {
+  let description = [{Indicates that ops in the entire module should be
+  decomposed into lower-level components.}];
+  let assemblyFormat = "attr-dict";
+}
+
+def VectorizeOp : Linalg_Transform_Operation<"vectorize"> {
+  let description = [{Indiactes that ops of a specific kind in the given
+  function should be vectorized with the options provided as attributes.}];
+
+  let arguments = (ins SymbolRefAttr:$fun_name,
+                   StrAttr:$op_name,
+                   DefaultValuedAttr<BoolAttr, "false">:$vectorize_padding
+                  );
+
+  let assemblyFormat = "$op_name `in` $fun_name attr-dict";
+}
+
+def LowerVectorsOp : Linalg_Transform_Operation<"lower_vectors"> {
+  let description = [{Indicates that the vector operations in the entire
+  module should be lowered to simpler primitives (multiple stages of lowering
+  be executed at once).}];
+
+  let arguments =
+    (ins DefaultValuedAttr<I64ArrayAttr, "{0, 1, 2, 3, 4, 5, 6}">:$stages,
+     DefaultValuedAttr<StrAttr, "\"outerproduct\"">:$contraction_lowering,
+     DefaultValuedAttr<StrAttr, "\"innerparallel\"">:$multireduction_lowering,
+     DefaultValuedAttr<StrAttr, "\"eltwise\"">:$transpose_lowering,
+     DefaultValuedAttr<BoolAttr, "false">:$transpose_avx2_lowering
+    );
+
+  let assemblyFormat = "attr-dict";
+}
+
+def LowerToLLVMOp : Linalg_Transform_Operation<"lower_to_llvm"> {
+  let description = [{Indicates that the entire module should be converted
+  to the LLVM dialect. This is expected to be the last transformation in
+  a sequence.}];
+
+  let assemblyFormat = "attr-dict";
+}
+
+#endif // LINALG_TRANSFORM_OPS

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(Transforms)
 set(IREE_LINALG_TENSOR_SANDBOX_LIBRARIES
   MLIRLinalgExt
   MLIRLinalgExtTransforms
+  MLIRLinalgTransformOps
   MLIRVectorExt
   MLIRVectorExtTransform
   IREELinalgTensorSandboxTransforms
@@ -64,6 +65,7 @@ add_mlir_library(IREELinalgTensorSandboxRegistration
   DEPENDS
   ${IREE_LINALG_TENSOR_SANDBOX_DEPENDS}
   MLIRLinalgOpsIncGen
+  MLIRLinalgTransformOpsIncGen
 )
 
 add_mlir_public_c_api_library(IREELinalgTensorSandboxCAPI

--- a/lib/Dialects/CMakeLists.txt
+++ b/lib/Dialects/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(LinalgExt)
+add_subdirectory(LinalgTransform)
 add_subdirectory(VectorExt)

--- a/lib/Dialects/LinalgTransform/CMakeLists.txt
+++ b/lib/Dialects/LinalgTransform/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/lib/Dialects/LinalgTransform/IR/CMakeLists.txt
+++ b/lib/Dialects/LinalgTransform/IR/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_mlir_library(MLIRLinalgTransformOps
+  LinalgTransformOps.cpp
+
+  DEPENDS
+  MLIRLinalgTransformOpsIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+)

--- a/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -1,0 +1,23 @@
+//===-- LinalgTransformOps.cpp - Linalg Transform dialect -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialects/LinalgTransform/LinalgTransformOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/OpImplementation.h"
+
+#include "Dialects/LinalgTransform/LinalgTransformOpsDialect.cpp.inc"
+
+void mlir::linalg::transform::LinalgTransformDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "Dialects/LinalgTransform/LinalgTransformOps.cpp.inc"
+      >();
+}
+
+#define GET_OP_CLASSES
+#include "Dialects/LinalgTransform/LinalgTransformOps.cpp.inc"

--- a/lib/Registration.cpp
+++ b/lib/Registration.cpp
@@ -6,6 +6,7 @@
 
 #include "Registration.h"
 #include "Dialects/LinalgExt/LinalgExtDialect.h"
+#include "Dialects/LinalgTransform/LinalgTransformOps.h"
 #include "Dialects/LinalgExt/Passes.h"
 #include "Dialects/VectorExt/VectorExtDialect.h"
 #include "Transforms/Passes.h"
@@ -88,7 +89,9 @@ void mlir::registerOutsideOfDialectRegistry() {
 void mlir::registerIntoDialectRegistry(DialectRegistry &registry) {
   registerAllDialects(registry);
   registerIreeDialects(registry);
-  registry.insert<linalg_ext::LinalgExtDialect, vector_ext::VectorExtDialect>();
+  registry.insert<linalg_ext::LinalgExtDialect,
+                  linalg::transform::LinalgTransformDialect,
+                  vector_ext::VectorExtDialect>();
 
   linalg_ext::registerTilingInterfaceExternalModels(registry);
 

--- a/test/LinalgTransform/roundtrip.mlir
+++ b/test/LinalgTransform/roundtrip.mlir
@@ -1,0 +1,20 @@
+// RUN: mlir-proto-opt %s | FileCheck %s
+
+// CHECK: linalg_transform.sequence
+linalg_transform.sequence {
+  // CHECK: tile "linalg.matmul" in @matmul_tensors {
+  // CHECK_DAG: pad = false
+  // CHECK-DAG: sizes = [4, 4, 4]
+  // CHECK: }
+  tile "linalg.matmul" in @matmul_tensors {sizes = [4, 4, 4], pad = false}
+  // CHECK: decompose
+  decompose
+  // CHECK: vectorize "linalg.matmul" in @matmul_tensors {vectorize_padding = true}
+  vectorize "linalg.matmul" in @matmul_tensors {vectorize_padding = true}
+  // CHECK: bufferize
+  bufferize
+  // CHECK: lower_vectors {multireduction_lowering = "innerreduce"}
+  lower_vectors { multireduction_lowering = "innerreduce"}
+  // CHECK: lower_to_llvm
+  lower_to_llvm
+}


### PR DESCRIPTION
This pass is intended to control Linalg transformations at a finer
granularity and to be able to serialize transforamtion specifications as
IR. Currently, it matches the control approach adopted by
CodegenStrategy, i.e., targeting ops of a specific kind in a named
function when applicable, but this is subject to future evolution.