### PR TITLE
[github] Read the LLVM commit from environment

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -39,7 +39,8 @@ jobs:
       with:
         path: llvm-project
         repository: llvm/llvm-project
-        ref: ${{ steps.get_llvm_commit_hash.outputs.LLVM_COMMIT }}
+        ref: ${{ env.LLVM_COMMIT }}
+        
 
     - name: Install Python depends
       run: |


### PR DESCRIPTION
The workflow was set up to read the LLVM commit from action outputs, but the action was writing it to the environment instead. The workflow has been always checking out LLVM HEAD instead of the pinned version.