### PR TITLE
Introduce transform-aware canonicalization

### DIFF
--- a/include/Dialects/LinalgTransform/TrackingRewriteDriver.h
+++ b/include/Dialects/LinalgTransform/TrackingRewriteDriver.h
@@ -1,0 +1,29 @@
+//===-- TrackingRewriteDriver.h - Special pattern rewriter ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_LINALG_TRANSFORMS_TRACKINGREWRITEDRIVER_H
+#define MLIR_DIALECT_LINALG_TRANSFORMS_TRACKINGREWRITEDRIVER_H
+
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+
+/// Apply the given list of transformations to the regions of the
+/// isolated-from-above operation `root` greedily until convergence. Update
+/// Linalg operations in values of `trackedOperations` if they are replaced by
+/// other Linalg operations during the rewriting process. Tracked operations
+/// must be replaced with Linalg operations and must not be erased in the
+/// patterns.
+LogicalResult applyPatternsTrackAndFoldGreedily(
+    Operation *root, DenseMap<Value, Operation *> &trackedOperations,
+    const FrozenRewritePatternSet &patterns,
+    GreedyRewriteConfig config = GreedyRewriteConfig());
+} // namespace mlir
+
+#endif // MLIR_DIALECT_LINALG_TRANSFORMS_TRACKINGREWRITEDRIVER_H

--- a/lib/Dialects/LinalgTransform/Transforms/CMakeLists.txt
+++ b/lib/Dialects/LinalgTransform/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_library(MLIRLinalgTransformTransforms
+  TrackingRewriteDriver.cpp
   TransformInterpreter.cpp
 
   DEPENDS

--- a/lib/Dialects/LinalgTransform/Transforms/TrackingRewriteDriver.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TrackingRewriteDriver.cpp
@@ -1,0 +1,439 @@
+//===-- TrackingRewriteDriver.cpp - Pattern rewriter keeping track of ops -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialects/LinalgTransform/TrackingRewriteDriver.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Rewrite/PatternApplicator.h"
+#include "mlir/Transforms/FoldUtils.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ScopedPrinter.h"
+
+#define DEBUG_TYPE "tracking-rewrite-driver"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE << "]: ")
+
+using namespace mlir;
+using namespace mlir::linalg;
+
+namespace {
+
+/// Find the linalg op that defines all values in range, potentially
+/// transitively through tensor casts.
+static LinalgOp findSingleLinalgOpDefiningAll(ValueRange range) {
+  LinalgOp sourceOp = nullptr;
+  for (Value value : range) {
+    // See through tensor casts.
+    //
+    // TODO: we may need some generalization (interfaces?) of this for other
+    // operations, especially multi-operand ones to understand which of their
+    // operands may be coming from a Linalg op. Or a completely different
+    // mechanism of tracking op replacement at creation, or even different
+    // patterns that identify the "main" result of a transformation.
+    while (auto castOp = value.getDefiningOp<tensor::CastOp>())
+      value = castOp.source();
+
+    if (auto currentSourceOp = value.getDefiningOp<LinalgOp>()) {
+      if (!sourceOp || sourceOp == currentSourceOp) {
+        sourceOp = currentSourceOp;
+        continue;
+      }
+
+      LLVM_DEBUG(
+          DBGS() << "different source linalg ops for replacing one op: \n"
+                 << sourceOp << "\n"
+                 << currentSourceOp << "\n");
+    }
+    return nullptr;
+  }
+  return sourceOp;
+}
+
+// TODO: if GreedyPatternRewriteDriver had been public, we would have derived
+// it, but we have to copy for now.
+class TrackingRewriteDriver : public PatternRewriter {
+public:
+  explicit TrackingRewriteDriver(
+      MLIRContext *ctx, DenseMap<Value, Operation *> &trackedOperations,
+      const FrozenRewritePatternSet &patterns,
+      const GreedyRewriteConfig &config)
+      : PatternRewriter(ctx), trackedOperations(trackedOperations),
+        matcher(patterns), folder(ctx), config(config) {
+    worklist.reserve(64);
+    matcher.applyDefaultCostModel();
+
+    for (auto &pair : trackedOperations)
+      trackedOperationKeys.try_emplace(pair.second, pair.first);
+  }
+
+  void replaceOp(Operation *op, ValueRange newValues) override {
+    if (isa<LinalgOp>(op)) {
+      LinalgOp replacement = findSingleLinalgOpDefiningAll(newValues);
+      assert(replacement &&
+             "replacing a linalg op, but could not find the replacement op");
+
+      if (Value key = trackedOperationKeys.lookup(op)) {
+        LLVM_DEBUG(DBGS() << "replacing tracked " << *op << " with "
+                          << *replacement << "for " << key << "\n");
+        trackedOperations[key] = replacement;
+        trackedOperationKeys.erase(op);
+        trackedOperationKeys.try_emplace(replacement, key);
+      }
+    }
+    PatternRewriter::replaceOp(op, newValues);
+  }
+
+  /// PatternRewriter hook for erasing a dead operation.
+  void eraseOp(Operation *op) override {
+    LLVM_DEBUG({
+      logger.startLine() << "** Erase   : '" << op->getName() << "'(" << op
+                         << ")\n";
+    });
+    assert(trackedOperationKeys.count(op) == 0 &&
+           "attempting to erase a tracked op");
+    PatternRewriter::eraseOp(op);
+  }
+
+  // TODO: if notifyRootReplaced had been also getting the ValueRange, we
+  // wouldn't need to override these.
+  void
+  replaceOpWithIf(Operation *, ValueRange, bool *,
+                  llvm::unique_function<bool(OpOperand &) const>) override {
+    llvm_unreachable("TrackingRewriteDriver::replaceOpWithIf not implemented");
+  }
+
+private:
+  DenseMap<Value, Operation *> &trackedOperations;
+  DenseMap<Operation *, Value> trackedOperationKeys;
+
+  //--------------------------------------------------------------------------//
+  // The code below is taken from GreedyPatternRewriteDriver.
+  //--------------------------------------------------------------------------//
+public:
+  /// Simplify the operations within the given regions.
+  bool simplify(MutableArrayRef<Region> regions);
+
+  /// Add the given operation to the worklist.
+  void addToWorklist(Operation *op);
+
+  /// Pop the next operation from the worklist.
+  Operation *popFromWorklist();
+
+  /// If the specified operation is in the worklist, remove it.
+  void removeFromWorklist(Operation *op);
+
+protected:
+  // Implement the hook for inserting operations, and make sure that newly
+  // inserted ops are added to the worklist for processing.
+  void notifyOperationInserted(Operation *op) override;
+
+  // Look over the provided operands for any defining operations that should
+  // be re-added to the worklist. This function should be called when an
+  // operation is modified or removed, as it may trigger further
+  // simplifications.
+  template <typename Operands>
+  void addToWorklist(Operands &&operands);
+
+  // If an operation is about to be removed, make sure it is not in our
+  // worklist anymore because we'd get dangling references to it.
+  void notifyOperationRemoved(Operation *op) override;
+
+  // When the root of a pattern is about to be replaced, it can trigger
+  // simplifications to its users - make sure to add them to the worklist
+  // before the root is changed.
+  void notifyRootReplaced(Operation *op) override;
+
+  /// PatternRewriter hook for notifying match failure reasons.
+  LogicalResult
+  notifyMatchFailure(Operation *op,
+                     function_ref<void(Diagnostic &)> reasonCallback) override;
+
+  /// The low-level pattern applicator.
+  PatternApplicator matcher;
+
+  /// The worklist for this transformation keeps track of the operations that
+  /// need to be revisited, plus their index in the worklist.  This allows us to
+  /// efficiently remove operations from the worklist when they are erased, even
+  /// if they aren't the root of a pattern.
+  std::vector<Operation *> worklist;
+  DenseMap<Operation *, unsigned> worklistMap;
+
+  /// Non-pattern based folder for operations.
+  OperationFolder folder;
+
+private:
+  /// Configuration information for how to simplify.
+  GreedyRewriteConfig config;
+
+#ifndef NDEBUG
+  /// A logger used to emit information during the application process.
+  llvm::ScopedPrinter logger{llvm::dbgs()};
+#endif
+};
+
+} // namespace
+
+bool TrackingRewriteDriver::simplify(MutableArrayRef<Region> regions) {
+#ifndef NDEBUG
+  const char *logLineComment =
+      "//===-------------------------------------------===//\n";
+
+  /// A utility function to log a process result for the given reason.
+  auto logResult = [&](StringRef result, const llvm::Twine &msg = {}) {
+    logger.unindent();
+    logger.startLine() << "} -> " << result;
+    if (!msg.isTriviallyEmpty())
+      logger.getOStream() << " : " << msg;
+    logger.getOStream() << "\n";
+  };
+  auto logResultWithLine = [&](StringRef result, const llvm::Twine &msg = {}) {
+    logResult(result, msg);
+    logger.startLine() << logLineComment;
+  };
+#endif
+
+  bool changed = false;
+  unsigned iteration = 0;
+  do {
+    worklist.clear();
+    worklistMap.clear();
+
+    if (!config.useTopDownTraversal) {
+      // Add operations to the worklist in postorder.
+      for (auto &region : regions)
+        region.walk([this](Operation *op) { addToWorklist(op); });
+    } else {
+      // Add all nested operations to the worklist in preorder.
+      for (auto &region : regions)
+        region.walk<WalkOrder::PreOrder>(
+            [this](Operation *op) { worklist.push_back(op); });
+
+      // Reverse the list so our pop-back loop processes them in-order.
+      std::reverse(worklist.begin(), worklist.end());
+      // Remember the reverse index.
+      for (size_t i = 0, e = worklist.size(); i != e; ++i)
+        worklistMap[worklist[i]] = i;
+    }
+
+    // These are scratch vectors used in the folding loop below.
+    SmallVector<Value, 8> originalOperands, resultValues;
+
+    changed = false;
+    while (!worklist.empty()) {
+      auto *op = popFromWorklist();
+
+      // Nulls get added to the worklist when operations are removed, ignore
+      // them.
+      if (op == nullptr)
+        continue;
+
+      LLVM_DEBUG({
+        logger.getOStream() << "\n";
+        logger.startLine() << logLineComment;
+        logger.startLine() << "Processing operation : '" << op->getName()
+                           << "'(" << op << ") {\n";
+        logger.indent();
+
+        // If the operation has no regions, just print it here.
+        if (op->getNumRegions() == 0) {
+          op->print(
+              logger.startLine(),
+              OpPrintingFlags().printGenericOpForm().elideLargeElementsAttrs());
+          logger.getOStream() << "\n\n";
+        }
+      });
+
+      // If the operation is trivially dead - remove it.
+      if (isOpTriviallyDead(op)) {
+        notifyOperationRemoved(op);
+        op->erase();
+        changed = true;
+
+        LLVM_DEBUG(logResultWithLine("success", "operation is trivially dead"));
+        continue;
+      }
+
+      // Collects all the operands and result uses of the given `op` into work
+      // list. Also remove `op` and nested ops from worklist.
+      originalOperands.assign(op->operand_begin(), op->operand_end());
+      auto preReplaceAction = [&](Operation *op) {
+        // Add the operands to the worklist for visitation.
+        addToWorklist(originalOperands);
+
+        // Add all the users of the result to the worklist so we make sure
+        // to revisit them.
+        for (auto result : op->getResults())
+          for (auto *userOp : result.getUsers())
+            addToWorklist(userOp);
+
+        notifyOperationRemoved(op);
+      };
+
+      // Add the given operation to the worklist.
+      auto collectOps = [this](Operation *op) { addToWorklist(op); };
+
+      // Try to fold this op.
+      bool inPlaceUpdate;
+      if ((succeeded(folder.tryToFold(op, collectOps, preReplaceAction,
+                                      &inPlaceUpdate)))) {
+        LLVM_DEBUG(logResultWithLine("success", "operation was folded"));
+
+        changed = true;
+        if (!inPlaceUpdate)
+          continue;
+      }
+
+      // Try to match one of the patterns. The rewriter is automatically
+      // notified of any necessary changes, so there is nothing else to do
+      // here.
+#ifndef NDEBUG
+      auto canApply = [&](const Pattern &pattern) {
+        LLVM_DEBUG({
+          logger.getOStream() << "\n";
+          logger.startLine() << "* Pattern " << pattern.getDebugName() << " : '"
+                             << op->getName() << " -> (";
+          llvm::interleaveComma(pattern.getGeneratedOps(), logger.getOStream());
+          logger.getOStream() << ")' {\n";
+          logger.indent();
+        });
+        return true;
+      };
+      auto onFailure = [&](const Pattern &pattern) {
+        LLVM_DEBUG(logResult("failure", "pattern failed to match"));
+      };
+      auto onSuccess = [&](const Pattern &pattern) {
+        LLVM_DEBUG(logResult("success", "pattern applied successfully"));
+        return success();
+      };
+
+      LogicalResult matchResult =
+          matcher.matchAndRewrite(op, *this, canApply, onFailure, onSuccess);
+      if (succeeded(matchResult))
+        LLVM_DEBUG(logResultWithLine("success", "pattern matched"));
+      else
+        LLVM_DEBUG(logResultWithLine("failure", "pattern failed to match"));
+#else
+      LogicalResult matchResult = matcher.matchAndRewrite(op, *this);
+#endif
+
+#ifndef NDEBUG
+#endif
+
+      changed |= succeeded(matchResult);
+    }
+
+    // After applying patterns, make sure that the CFG of each of the regions
+    // is kept up to date.
+    if (config.enableRegionSimplification)
+      changed |= succeeded(simplifyRegions(*this, regions));
+  } while (changed &&
+           (++iteration < config.maxIterations ||
+            config.maxIterations == GreedyRewriteConfig::kNoIterationLimit));
+
+  // Whether the rewrite converges, i.e. wasn't changed in the last iteration.
+  return !changed;
+}
+
+void TrackingRewriteDriver::addToWorklist(Operation *op) {
+  // Check to see if the worklist already contains this op.
+  if (worklistMap.count(op))
+    return;
+
+  worklistMap[op] = worklist.size();
+  worklist.push_back(op);
+}
+
+Operation *TrackingRewriteDriver::popFromWorklist() {
+  auto *op = worklist.back();
+  worklist.pop_back();
+
+  // This operation is no longer in the worklist, keep worklistMap up to date.
+  if (op)
+    worklistMap.erase(op);
+  return op;
+}
+
+void TrackingRewriteDriver::removeFromWorklist(Operation *op) {
+  auto it = worklistMap.find(op);
+  if (it != worklistMap.end()) {
+    assert(worklist[it->second] == op && "malformed worklist data structure");
+    worklist[it->second] = nullptr;
+    worklistMap.erase(it);
+  }
+}
+
+void TrackingRewriteDriver::notifyOperationInserted(Operation *op) {
+  LLVM_DEBUG({
+    logger.startLine() << "** Insert  : '" << op->getName() << "'(" << op
+                       << ")\n";
+  });
+  addToWorklist(op);
+}
+
+template <typename Operands>
+void TrackingRewriteDriver::addToWorklist(Operands &&operands) {
+  for (Value operand : operands) {
+    // If the use count of this operand is now < 2, we re-add the defining
+    // operation to the worklist.
+    // TODO: This is based on the fact that zero use operations
+    // may be deleted, and that single use values often have more
+    // canonicalization opportunities.
+    if (!operand || (!operand.use_empty() && !operand.hasOneUse()))
+      continue;
+    if (auto *defOp = operand.getDefiningOp())
+      addToWorklist(defOp);
+  }
+}
+
+void TrackingRewriteDriver::notifyOperationRemoved(Operation *op) {
+  addToWorklist(op->getOperands());
+  op->walk([this](Operation *operation) {
+    removeFromWorklist(operation);
+    folder.notifyRemoval(operation);
+  });
+}
+
+void TrackingRewriteDriver::notifyRootReplaced(Operation *op) {
+  LLVM_DEBUG({
+    logger.startLine() << "** Replace : '" << op->getName() << "'(" << op
+                       << ")\n";
+  });
+  for (auto result : op->getResults())
+    for (auto *user : result.getUsers())
+      addToWorklist(user);
+}
+
+LogicalResult TrackingRewriteDriver::notifyMatchFailure(
+    Operation *op, function_ref<void(Diagnostic &)> reasonCallback) {
+  LLVM_DEBUG({
+    Diagnostic diag(op->getLoc(), DiagnosticSeverity::Remark);
+    reasonCallback(diag);
+    logger.startLine() << "** Failure : " << diag.str() << "\n";
+  });
+  return failure();
+}
+
+//--------------------------------------------------------------------------//
+// End of the code below is taken from GreedyPatternRewriteDriver.
+//--------------------------------------------------------------------------//
+
+LogicalResult mlir::applyPatternsTrackAndFoldGreedily(
+    Operation *root, DenseMap<Value, Operation *> &trackedOperations,
+    const FrozenRewritePatternSet &patterns, GreedyRewriteConfig config) {
+  assert(root->hasTrait<OpTrait::IsIsolatedFromAbove>() &&
+         "can only apply patterns greedily to ops isolated form above");
+
+  TrackingRewriteDriver driver(root->getContext(), trackedOperations, patterns,
+                               config);
+  bool converged = driver.simplify(root->getRegions());
+  LLVM_DEBUG(if (!converged) {
+    llvm::dbgs() << "The pattern rewrite doesn't converge after scanning "
+                 << config.maxIterations << " times\n";
+  });
+  return success(converged);
+}

--- a/test/LinalgTransform/tile.mlir
+++ b/test/LinalgTransform/tile.mlir
@@ -11,12 +11,12 @@ func @matmul_tensors(
 //      CHECK: %[[TD0:.*]] = scf.for {{.*}} to {{.*}} step {{.*}} iter_args(%[[TC0:.*]] = %[[TC]]) -> (tensor<128x128xf32>) {
 //      CHECK:   %[[TD1:.*]] = scf.for {{.*}} to {{.*}} step {{.*}} iter_args(%[[TC1:.*]] = %[[TC0]]) -> (tensor<128x128xf32>) {
 //      CHECK:     %[[TD2:.*]] = scf.for {{.*}} to {{.*}} step {{.*}} iter_args(%[[TC2:.*]] = %[[TC1]]) -> (tensor<128x128xf32>) {
-//      CHECK:       %[[sTA:.*]] = tensor.extract_slice %[[TA]][{{.*}}] : tensor<128x128xf32> to tensor<?x?xf32>
-//      CHECK:       %[[sTB:.*]] = tensor.extract_slice %[[TB]][{{.*}}] : tensor<128x128xf32> to tensor<?x?xf32>
-//      CHECK:       %[[sTC:.*]] = tensor.extract_slice %[[TC2]][{{.*}}] : tensor<128x128xf32> to tensor<?x?xf32>
-//      CHECK:       %[[sTD:.*]] = linalg.matmul {{.*}} ins(%[[sTA]], %[[sTB]] : tensor<?x?xf32>, tensor<?x?xf32>)
-// CHECK-SAME:                                  outs(%[[sTC]] : tensor<?x?xf32>)  -> tensor<?x?xf32>
-//      CHECK:       %[[TD:.*]] = tensor.insert_slice %[[sTD]] into %[[TC2]][{{.*}}]  : tensor<?x?xf32> into tensor<128x128xf32>
+//      CHECK:       %[[sTA:.*]] = tensor.extract_slice %[[TA]][{{.*}}] : tensor<128x128xf32> to tensor<4x4xf32>
+//      CHECK:       %[[sTB:.*]] = tensor.extract_slice %[[TB]][{{.*}}] : tensor<128x128xf32> to tensor<4x4xf32>
+//      CHECK:       %[[sTC:.*]] = tensor.extract_slice %[[TC2]][{{.*}}] : tensor<128x128xf32> to tensor<4x4xf32>
+//      CHECK:       %[[sTD:.*]] = linalg.matmul {{.*}} ins(%[[sTA]], %[[sTB]] : tensor<4x4xf32>, tensor<4x4xf32>)
+// CHECK-SAME:                                  outs(%[[sTC]] : tensor<4x4xf32>)  -> tensor<4x4xf32>
+//      CHECK:       %[[TD:.*]] = tensor.insert_slice %[[sTD]] into %[[TC2]][{{.*}}]  : tensor<4x4xf32> into tensor<128x128xf32>
 //      CHECK:       scf.yield %[[TD]] : tensor<128x128xf32>
 //      CHECK:     scf.yield %[[TD2]] : tensor<128x128xf32>
 //      CHECK:   scf.yield %[[TD1]] : tensor<128x128xf32>

--- a/test/LinalgTransform/vectorize.mlir
+++ b/test/LinalgTransform/vectorize.mlir
@@ -11,9 +11,8 @@ func @matmul_tensors(
   // CHECK: %[[VA:.*]] = vector.transfer_read %[[TA]]
   // CHECK: %[[VB:.*]] = vector.transfer_read %[[TB]]
   // CHECK: %[[VC:.*]] = vector.transfer_read %[[TC]]
-  // CHECK: %[[VCPartial:.*]] = vector.contract {{.*}} %[[VA]], %[[VB]]
-  // CHECK: %[[VCFull:.*]] = arith.addf %[[VCPartial]], %[[VC]]
-  // CHECK: vector.transfer_write %[[VCFull]], %[[TC]]
+  // CHECK: %[[VCU:.*]] = vector.contract {{.*}} %[[VA]], %[[VB]], %[[VC]]
+  // CHECK: vector.transfer_write %[[VCU]], %[[TC]]
   %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
                      outs(%arg2: tensor<128x128xf32>)
     -> tensor<128x128xf32>


### PR DESCRIPTION
Introduce a new variant of the greedy pattern rewrite driver, adapted
from upstream MLIR since the class itself is an implementation detail
and cannot be derived. This variant is aware of the mapping between
values used in the Transform dialect and the operations and updates it
if the mapped operations are being updated by canonicalization patterns
(which does happen, e.g., after tiling to propagate static shape
information into types). This driver allows the transformation
interpreter to run a "canonicalization" pass without resorting to actual
passes and without risking to lose track of the operations that are
being transformed.