### PR TITLE
Run PDL matching patterns once per operatio

### DIFF
--- a/test/LinalgTransform/bufferize.mlir
+++ b/test/LinalgTransform/bufferize.mlir
@@ -25,9 +25,6 @@ pdl.pattern @pdl_target : benefit(1) {
   %results = pdl.types
   %0 = pdl.operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
   pdl.apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
-  // TODO: this should be implicit, injected by the driver or have PDL only do the matching
-  // FIXME: not putting [] here crashes the pdl-to-pdl-interp
-  pdl.apply_native_constraint "notTagged"[](%0 : !pdl.operation)
   // TODO: we don't want this, but it is the required terminator for pdl.pattern
   pdl.rewrite %0 with "linalg_transform.apply"
 }

--- a/test/LinalgTransform/single-tiling-full-script.mlir
+++ b/test/LinalgTransform/single-tiling-full-script.mlir
@@ -19,9 +19,6 @@ pdl.pattern @pdl_target : benefit(1) {
   %results = pdl.types
   %0 = pdl.operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
   pdl.apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
-  // TODO: this should be implicit, injected by the driver or have PDL only do the matching
-  // FIXME: not putting [] here crashes the pdl-to-pdl-interp
-  pdl.apply_native_constraint "notTagged"[](%0 : !pdl.operation)
   // TODO: we don't want this, but it is the required terminator for pdl.pattern
   pdl.rewrite %0 with "linalg_transform.apply"
 }

--- a/test/LinalgTransform/tile.mlir
+++ b/test/LinalgTransform/tile.mlir
@@ -34,9 +34,6 @@ pdl.pattern @pdl_target : benefit(1) {
   %results = pdl.types
   %0 = pdl.operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
   pdl.apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
-  // TODO: this should be implicit, injected by the driver or have PDL only do the matching
-  // FIXME: not putting [] here crashes the pdl-to-pdl-interp
-  pdl.apply_native_constraint "notTagged"[](%0 : !pdl.operation)
   // TODO: we don't want this, but it is the required terminator for pdl.pattern
   pdl.rewrite %0 with "linalg_transform.apply"
 }

--- a/test/LinalgTransform/vectorize.mlir
+++ b/test/LinalgTransform/vectorize.mlir
@@ -26,9 +26,6 @@ pdl.pattern @pdl_target : benefit(1) {
   %results = pdl.types
   %0 = pdl.operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
   pdl.apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
-  // TODO: this should be implicit, injected by the driver or have PDL only do the matching
-  // FIXME: not putting [] here crashes the pdl-to-pdl-interp
-  pdl.apply_native_constraint "notTagged"[](%0 : !pdl.operation)
   // TODO: we don't want this, but it is the required terminator for pdl.pattern
   pdl.rewrite %0 with "linalg_transform.apply"
 }


### PR DESCRIPTION
Introduce a new helper function that wraps PatternApplicator so that
each pattern (in the case of Transform dialect, only the matching part
is actually relevant) is checked at most once against every operation.
No greedy recursive pattern application or worklist of newly created
operations is needed for this purpose. This allows us to stop relying
on the absence of the "matched" attribute in the IR to stop recursive
matching. The attribute itself is still added as a debugging aid.