### PR TITLE
Finer-grain targeting in transform dialect

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.h
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.h
@@ -14,6 +14,28 @@
 #include "mlir/IR/OpDefinition.h"
 
 #include "Dialects/LinalgTransform/LinalgTransformOpsDialect.h.inc"
+#include <mlir/IR/BuiltinAttributes.h>
+
+namespace mlir {
+/// A trait for transform ops that can be targeted at either the result of a
+/// matcher (identified by its symbol name) or at the result of another
+/// transformation (identified by the value it produced).
+template <typename ConcreteOp>
+class TargetableTransformOpTrait
+    : public OpTrait::TraitBase<ConcreteOp, TargetableTransformOpTrait> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    Optional<SymbolRefAttr> matcher = cast<ConcreteOp>(op).matcher();
+    Value input = cast<ConcreteOp>(op).op();
+    if (!((matcher.hasValue() && matcher.getValue() != nullptr) ^
+          (input != nullptr)))
+      return op->emitOpError()
+             << "expects either an `op` operand or a `matcher` attribute";
+
+    return success();
+  }
+};
+} // namespace mlir
 
 #define GET_OP_CLASSES
 #include "Dialects/LinalgTransform/LinalgTransformOps.h.inc"

--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -45,32 +45,18 @@ def SequenceOp : Linalg_Transform_Operation<"sequence",
   }];
 }
 
-def ApplyOp : Linalg_Transform_Operation<"apply", [NoTerminator]> {
-  let description = [{A container operation that connects a sequence of
-  transformations to apply to the condition at which the operation should
-  be applied. The condition should be a PDLMatchOp producing the root
-  operation, which is forwarded as the unique basic block argument to the
-  `transforms` region of the operation.}];
-
-  let regions = (region SizedRegion<1>:$transforms, SizedRegion<1>:$condition);
-  let assemblyFormat = "$transforms `when` $condition attr-dict-with-keyword";
-}
-
-def PDLMatchOp : Linalg_Transform_Operation<"pdl_match"> {
-  let description = [{Specifies the name of the PDL pattern used to match the
-  root operation on which the transformations are applied.}];
-
-  let arguments = (ins SymbolRefAttr:$pattern);
-  let assemblyFormat = "$pattern attr-dict";
-}
-
 //===----------------------------------------------------------------------===//
 
-def TileOp : Linalg_Transform_Operation<"tile"> {
+def TargetableOpTrait : NativeOpTrait<"TargetableTransformOpTrait"> {
+  let cppNamespace = "::mlir";
+}
+
+def TileOp : Linalg_Transform_Operation<"tile", [TargetableOpTrait]> {
   let description = [{Indicates that ops of a specific kind in the given
   function should be tiled with the options provided as attributes.}];
 
-  let arguments = (ins PDL_Operation:$op,
+  let arguments = (ins Optional<PDL_Operation>:$op,
+                   OptionalAttr<SymbolRefAttr>:$matcher,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$sizes,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$interchange,
                    DefaultValuedAttr<BoolAttr, "false">:$pad,
@@ -81,7 +67,7 @@ def TileOp : Linalg_Transform_Operation<"tile"> {
                   );
   let results = (outs PDL_Operation:$transformed);
 
-  let assemblyFormat = "$op attr-dict";
+  let assemblyFormat = "($op^)? (`when` $matcher^)? attr-dict";
 }
 
 def BufferizeOp : Linalg_Transform_Operation<"bufferize"> {
@@ -95,16 +81,17 @@ def DecomposeOp : Linalg_Transform_Operation<"decompose"> {
   let assemblyFormat = "attr-dict";
 }
 
-def VectorizeOp : Linalg_Transform_Operation<"vectorize"> {
+def VectorizeOp : Linalg_Transform_Operation<"vectorize", [TargetableOpTrait]> {
   let description = [{Indiactes that ops of a specific kind in the given
   function should be vectorized with the options provided as attributes.}];
 
-  let arguments = (ins PDL_Operation:$op,
+  let arguments = (ins Optional<PDL_Operation>:$op,
+                   OptionalAttr<SymbolRefAttr>:$matcher,
                    DefaultValuedAttr<BoolAttr, "false">:$vectorize_padding
                   );
   let results = (outs PDL_Operation:$transformed);
 
-  let assemblyFormat = "$op attr-dict";
+  let assemblyFormat = "($op^)? (`when` $matcher^)? attr-dict";
 }
 
 def LowerVectorsOp : Linalg_Transform_Operation<"lower_vectors"> {

--- a/include/Dialects/LinalgTransform/TrackingCSE.h
+++ b/include/Dialects/LinalgTransform/TrackingCSE.h
@@ -10,7 +10,7 @@ class DominanceInfo;
 class Value;
 
 void eliminateCommonSubexpressionsWithTrackedOps(
-    Operation *root, DenseMap<Value, Operation *> &trackedOps,
+    Operation *root, DenseMap<Value, SmallVector<Operation *, 4>> &trackedOps,
     DominanceInfo *domInfo = nullptr);
 } // namespace mlir
 

--- a/include/Dialects/LinalgTransform/TrackingRewriteDriver.h
+++ b/include/Dialects/LinalgTransform/TrackingRewriteDriver.h
@@ -21,7 +21,8 @@ namespace mlir {
 /// must be replaced with Linalg operations and must not be erased in the
 /// patterns.
 LogicalResult applyPatternsTrackAndFoldGreedily(
-    Operation *root, DenseMap<Value, Operation *> &trackedOperations,
+    Operation *root,
+    DenseMap<Value, SmallVector<Operation *, 4>> &trackedOperations,
     const FrozenRewritePatternSet &patterns,
     GreedyRewriteConfig config = GreedyRewriteConfig());
 } // namespace mlir

--- a/lib/Dialects/LinalgTransform/Transforms/TrackingCSE.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TrackingCSE.cpp
@@ -47,11 +47,13 @@ struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
 // -------------------------------------------------------------------------- //
 
 struct TrackingCSE {
-  TrackingCSE(DominanceInfo *domInfo,
-              const DenseMap<Value, Operation *> &trackedOperations)
+  TrackingCSE(
+      DominanceInfo *domInfo,
+      const DenseMap<Value, SmallVector<Operation *, 4>> &trackedOperations)
       : domInfo(domInfo) {
-    for (auto &pair : trackedOperations)
-      trackedOps.insert(pair.second);
+    for (auto &pair : trackedOperations) {
+      trackedOps.insert(pair.second.begin(), pair.second.end());
+    }
   }
 
   void simplify(Operation *root);
@@ -277,7 +279,7 @@ void TrackingCSE::simplify(Operation *root) {
 }
 
 void mlir::eliminateCommonSubexpressionsWithTrackedOps(
-    Operation *root, DenseMap<Value, Operation *> &trackedOps,
+    Operation *root, DenseMap<Value, SmallVector<Operation *, 4>> &trackedOps,
     DominanceInfo *domInfo) {
   assert(root->hasTrait<OpTrait::IsIsolatedFromAbove>() &&
          "can only do CSE on isolated-from-above ops");

--- a/test/LinalgTransform/bufferize.mlir
+++ b/test/LinalgTransform/bufferize.mlir
@@ -8,7 +8,7 @@
 func @matmul_tensors(
   %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
     -> tensor<128x128xf32> {
-  // CHECK: linalg.matmul {{.*}} ins(%[[TA]], %[[TB]] : memref{{.*}}, memref{{.*}} outs(%[[TC]] : memref{{.*}})
+  // CHECK: linalg.matmul ins(%[[TA]], %[[TB]] : memref{{.*}}, memref{{.*}} outs(%[[TC]] : memref{{.*}})
   %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
                      outs(%arg2: tensor<128x128xf32>)
     -> tensor<128x128xf32>
@@ -29,11 +29,6 @@ pdl.pattern @pdl_target : benefit(1) {
   pdl.rewrite %0 with "linalg_transform.apply"
 }
 
-linalg_transform.apply {
-^bb0(%arg0: !pdl.operation):
-  linalg_transform.sequence {
-    bufferize
-  }
-} when {
-  linalg_transform.pdl_match @pdl_target
+linalg_transform.sequence {
+  bufferize
 }

--- a/test/LinalgTransform/roundtrip.mlir
+++ b/test/LinalgTransform/roundtrip.mlir
@@ -1,29 +1,24 @@
 // RUN: mlir-proto-opt %s | FileCheck %s
 
-// CHECK: linalg_transform.apply
-linalg_transform.apply {
-  // CHECK: linalg_transform.sequence
-  linalg_transform.sequence {
-  // CHECK: ^{{.*}}(%[[ARG0:.*]]: !pdl.operation)
-  ^bb0(%arg0: !pdl.operation):
-    // CHECK: %[[TILED:.*]] = tile %[[ARG0]] {
-    // CHECK_DAG: pad = false
-    // CHECK-DAG: sizes = [4, 4, 4]
-    // CHECK: }
-    %1 = tile %arg0 {sizes = [4, 4, 4], pad = false}
-    // CHECK: decompose
-    decompose
-    // CHECK: %{{.*}} = vectorize %[[TILED]] {vectorize_padding = true}
-    %2 = vectorize %1 {vectorize_padding = true}
-    // CHECK: bufferize
-    bufferize
-    // CHECK: lower_vectors {multireduction_lowering = "innerreduce"}
-    lower_vectors { multireduction_lowering = "innerreduce"}
-    // CHECK: lower_to_llvm
-    lower_to_llvm
-  }
-// CHECK: when
-} when {
-  // CHECK: linalg_transform.pdl_match @match
-  linalg_transform.pdl_match @match
+// CHECK: linalg_transform.sequence
+linalg_transform.sequence {
+  // CHECK: %[[TILED:.*]] = tile when @match1 {
+  // CHECK_DAG: pad = false
+  // CHECK-DAG: sizes = [4, 4, 4]
+  // CHECK: }
+  %1 = tile when @match1 {sizes = [4, 4, 4], pad = false}
+  // CHECK: %[[TILED2:.*]] = tile %[[TILED]]
+  %2 = tile %1 {sizes = [2, 2, 2], pad = true}
+  // CHECK: decompose
+  decompose
+  // CHECK: %{{.*}} = vectorize %[[TILED2]] {vectorize_padding = true}
+  %3 = vectorize %2 {vectorize_padding = true}
+  // CHECK: %{{.*}} = vectorize when @match2
+  vectorize when @match2
+  // CHECK: bufferize
+  bufferize
+  // CHECK: lower_vectors {multireduction_lowering = "innerreduce"}
+  lower_vectors { multireduction_lowering = "innerreduce"}
+  // CHECK: lower_to_llvm
+  lower_to_llvm
 }

--- a/test/LinalgTransform/selective-targeting.mlir
+++ b/test/LinalgTransform/selective-targeting.mlir
@@ -1,0 +1,69 @@
+// RUN: mlir-proto-opt %s -linalg-interp-transforms | FileCheck %s
+
+// CHECK-LABEL: func @matmul_tensors(
+func @matmul_tensors(
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>,
+  %arg3: tensor<128x128xf32>, %arg4: tensor<128x128xf32>, %arg5: tensor<128x128xf32>,
+  %arg6: tensor<128x128xf32> {linalg.inplaceable = true})
+    -> tensor<128x128xf32> {
+  // This operation is marked for tiling only.
+  // CHECK-COUNT-3: scf.for
+  // CHECK-COUNT-3: tensor.extract_slice
+  // CHECK: linalg.matmul
+  // CHECK-SAME: -> tensor<4x4xf32>
+  %0 = linalg.matmul { test.attrA} 
+                      ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
+                     outs(%arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32>
+
+  // This operation is marked for tiling and vectorization.
+  // CHECK-COUNT-3: scf.for
+  // CHECK-COUNT-3: vector.transfer_read
+  // CHECK: vector.contract
+  // CHECK-NOT: linalg.matmul
+  // CHECK: vector.transfer_write
+  %1 = linalg.matmul { test.attrA, test.attrC}
+                      ins(%arg3, %arg4: tensor<128x128xf32>, tensor<128x128xf32>)
+                     outs(%arg5: tensor<128x128xf32>)
+    -> tensor<128x128xf32>
+
+  // This operation is marked for vectorization only.
+  // CHECK-NOT: scf.for
+  // CHECK-COUNT-3: vector.transfer_read
+  // CHECK: vector.contract
+  // CHECK-SAME: into vector<128x128xf32>
+  // CHECK: vector.transfer_write
+  %2 = linalg.matmul { test.attrC}
+                      ins(%0, %1: tensor<128x128xf32>, tensor<128x128xf32>)
+                     outs(%arg6: tensor<128x128xf32>)
+    -> tensor<128x128xf32>
+
+  return %2 : tensor<128x128xf32>
+}
+
+// Match matmul operations inside @matmul_tensors with test.attrA set.
+pdl.pattern @pdl_target_attrA : benefit(1) {
+  %args = pdl.operands
+  %results = pdl.types
+  %attr = pdl.attribute
+  %0 = pdl.operation "linalg.matmul"(%args : !pdl.range<value>) {"test.attrA" = %attr}-> (%results : !pdl.range<type>)
+  pdl.apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  pdl.rewrite %0 with "linalg_transform.apply"
+}
+
+// Match matmul operations inside @matmul_tensors with test.attrC set.
+pdl.pattern @pdl_target_attrC : benefit(1) {
+  %args = pdl.operands
+  %results = pdl.types
+  %attr = pdl.attribute
+  %0 = pdl.operation "linalg.matmul"(%args : !pdl.range<value>) {"test.attrC" = %attr}-> (%results : !pdl.range<type>)
+  pdl.apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  pdl.rewrite %0 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  tile when @pdl_target_attrA {sizes = [4, 4, 4], pad = false}
+  vectorize when @pdl_target_attrC
+}

--- a/test/LinalgTransform/single-tiling-full-script.mlir
+++ b/test/LinalgTransform/single-tiling-full-script.mlir
@@ -23,15 +23,10 @@ pdl.pattern @pdl_target : benefit(1) {
   pdl.rewrite %0 with "linalg_transform.apply"
 }
 
-linalg_transform.apply {
-^bb0(%arg0: !pdl.operation):
-  linalg_transform.sequence {
-    %0 = tile %arg0 {sizes = [4, 4, 4]}
-    %1 = vectorize %0 {vectorize_padding = true}
-    bufferize
-    lower_vectors { multireduction_lowering = "innerreduce"}
-    lower_to_llvm
-  }
-} when {
-  linalg_transform.pdl_match @pdl_target
+linalg_transform.sequence {
+  %0 = tile when @pdl_target {sizes = [4, 4, 4]}
+  %1 = vectorize %0 {vectorize_padding = true}
+  bufferize
+  lower_vectors { multireduction_lowering = "innerreduce"}
+  lower_to_llvm
 }

--- a/test/LinalgTransform/tile.mlir
+++ b/test/LinalgTransform/tile.mlir
@@ -38,11 +38,6 @@ pdl.pattern @pdl_target : benefit(1) {
   pdl.rewrite %0 with "linalg_transform.apply"
 }
 
-linalg_transform.apply {
-^bb0(%arg0: !pdl.operation):
-  linalg_transform.sequence {
-    %0 = tile %arg0 {sizes = [4, 4, 4], pad = false}
-  }
-} when {
-  linalg_transform.pdl_match @pdl_target
+linalg_transform.sequence {
+  %0 = tile when @pdl_target {sizes = [4, 4, 4], pad = false}
 }

--- a/test/LinalgTransform/vectorize.mlir
+++ b/test/LinalgTransform/vectorize.mlir
@@ -30,14 +30,6 @@ pdl.pattern @pdl_target : benefit(1) {
   pdl.rewrite %0 with "linalg_transform.apply"
 }
 
-linalg_transform.apply {
-^bb0(%arg0: !pdl.operation):
-  linalg_transform.sequence {
-    %1 = vectorize %arg0 {vectorize_padding = true}
-    //bufferize
-    //lower_vectors { multireduction_lowering = "innerreduce"}
-    //lower_to_llvm
-  }
-} when {
-  linalg_transform.pdl_match @pdl_target
+linalg_transform.sequence {
+  %1 = vectorize when @pdl_target {vectorize_padding = true}
 }


### PR DESCRIPTION
The transform dialect progressively relaxes the current approach in
codegen strategy that applies identical transformations to all
operations of the same kind in a given function. After introducing
PDL-based matching mechanism, now make this mechanism applicable for
each targetable operation directly instead of only the first operation
in a sequence. This makes it possible to apply transformations with
different options to different operations transparently.