### PR TITLE
Fix build error when including iree-dialects

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,14 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
+if(SANDBOX_ENABLE_IREE_DIALECTS)
+  list(APPEND dialect_libs
+    IREEInputDialect
+    IREELinalgExtDialect
+    IREELinalgExtPasses
+  )
+endif()
+
 add_subdirectory(Dialects)
 add_subdirectory(Transforms)
 
@@ -76,7 +84,7 @@ add_mlir_public_c_api_library(IREELinalgTensorSandboxCAPI
   LINK_LIBS PRIVATE
   MLIRCAPIRegistration
   MLIRPass
-  
+
   # Sandbox libraries
   IREELinalgTensorSandboxDriver
   IREELinalgTensorSandboxRegistration

--- a/tools/mlir-proto-opt/CMakeLists.txt
+++ b/tools/mlir-proto-opt/CMakeLists.txt
@@ -1,11 +1,3 @@
-if(SANDBOX_ENABLE_IREE_DIALECTS)
-  list(APPEND dialect_libs
-    IREEInputDialect
-    IREELinalgExtDialect
-    IREELinalgExtPasses
-  )
-endif()
-
 if (SANDBOX_ENABLE_ALP)
   target_link_libraries(mlir-proto-opt
   PRIVATE


### PR DESCRIPTION
IREE dialects weren't being added as dependent libraries to the registration lib, causing the build to fail to find the generated header files.