### PR TITLE
Implement Listeners in CSE and Greedy Pattern Rewriter

### DIFF
--- a/include/Transforms/Listener.h
+++ b/include/Transforms/Listener.h
@@ -1,0 +1,125 @@
+//===- Listener.h - Transformation Listener ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines a transformation listener and associated utilities.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef IREE_LLVM_SANDBOX_TRANSFORMS_LISTENER_H
+#define IREE_LLVM_SANDBOX_TRANSFORMS_LISTENER_H
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+
+//===----------------------------------------------------------------------===//
+// RewriteListener
+//===----------------------------------------------------------------------===//
+
+/// This class represents a listener that can be used to hook on to various
+/// rewrite events in an `OpBuilder` or `PatternRewriter`. The class is notified
+/// by when:
+///
+/// - an operation is removed
+/// - an operation is inserted
+/// - an operation is replaced
+/// - a block is created
+///
+/// Listeners can be used to track IR mutations throughout pattern rewrites.
+struct RewriteListener {
+  virtual ~RewriteListener();
+
+  /// These are the callback methods that subclasses can choose to implement if
+  /// they would like to be notified about certain types of mutations.
+
+  /// Notification handler for when an operation is inserted into the builder.
+  /// op` is the operation that was inserted.
+  virtual void notifyOperationInserted(Operation *op) {}
+
+  /// Notification handler for when a block is created using the builder.
+  /// `block` is the block that was created.
+  virtual void notifyBlockCreated(Block *block) {}
+
+  /// Notification handler for when the specified operation is about to be
+  /// replaced with another set of operations. This is called before the uses of
+  /// the operation have been replaced with the specific values.
+  virtual void notifyOperationReplaced(Operation *op, ValueRange newValues) {}
+
+  /// Notification handler for when an the specified operation is about to be
+  /// deleted. At this point, the operation has zero uses.
+  virtual void notifyOperationRemoved(Operation *op) {}
+
+  /// Notify the listener that a pattern failed to match the given operation,
+  /// and provide a callback to populate a diagnostic with the reason why the
+  /// failure occurred. This method allows for derived listeners to optionally
+  /// hook into the reason why a rewrite failed, and display it to users.
+  virtual void
+  notifyMatchFailure(Operation *op,
+                     function_ref<void(Diagnostic &)> reasonCallback) {}
+};
+
+//===----------------------------------------------------------------------===//
+// ListenerList
+//===----------------------------------------------------------------------===//
+
+/// This class contains multiple listeners to which rewrite events can be sent.
+class ListenerList : public RewriteListener {
+public:
+  /// Add a listener to the list.
+  void addListener(RewriteListener *listener) { listeners.push_back(listener); }
+
+  /// Send notification of an operation being inserted to all listeners.
+  void notifyOperationInserted(Operation *op) override;
+  /// Send notification of a block being created to all listeners.
+  void notifyBlockCreated(Block *block) override;
+  /// Send notification that an operation has been replaced to all listeners.
+  void notifyOperationReplaced(Operation *op, ValueRange newValues) override;
+  /// Send notification that an operation is about to be deleted to all
+  /// listeners.
+  void notifyOperationRemoved(Operation *op) override;
+  /// Notify all listeners that a pattern match failed.
+  void
+  notifyMatchFailure(Operation *op,
+                     function_ref<void(Diagnostic &)> reasonCallback) override;
+
+private:
+  /// The list of listeners to send events to.
+  SmallVector<RewriteListener *, 1> listeners;
+};
+
+//===----------------------------------------------------------------------===//
+// PatternRewriterListener
+//===----------------------------------------------------------------------===//
+
+/// This class implements a pattern rewriter with a rewrite listener. Rewrite
+/// events are forwarded to the provided rewrite listener.
+class PatternRewriterListener : public PatternRewriter, public ListenerList {
+public:
+  PatternRewriterListener(MLIRContext *context) : PatternRewriter(context) {}
+
+  /// When an operation is about to be replaced, send out an event to all
+  /// attached listeners.
+  void replaceOp(Operation *op, ValueRange newValues) override {
+    notifyOperationReplaced(op, newValues);
+    PatternRewriter::replaceOp(op, newValues);
+  }
+
+  void notifyOperationInserted(Operation *op) override {
+    ListenerList::notifyOperationInserted(op);
+  }
+  void notifyBlockCreated(Block *block) override {
+    ListenerList::notifyBlockCreated(block);
+  }
+  void notifyOperationRemoved(Operation *op) override {
+    ListenerList::notifyOperationRemoved(op);
+  }
+};
+
+} // namespace mlir
+
+#endif // IREE_LLVM_SANDBOX_TRANSFORMS_LISTENER_H

--- a/include/Transforms/ListenerCSE.h
+++ b/include/Transforms/ListenerCSE.h
@@ -1,0 +1,23 @@
+//===-- ListenerCSE.h - Common subexpr elimination with a listener --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_IREE_SANDBOX_TRANSFORMS_LISTENERCSE_H
+#define LLVM_IREE_SANDBOX_TRANSFORMS_LISTENERCSE_H
+
+#include "Transforms/Listener.h"
+
+namespace mlir {
+class DominanceInfo;
+class Operation;
+
+LogicalResult eliminateCommonSubexpressions(Operation *op,
+                                            DominanceInfo *domInfo,
+                                            RewriteListener *listener);
+} // namespace mlir
+
+#endif // LLVM_IREE_SANDBOX_TRANSFORMS_LISTENERCSE_H

--- a/include/Transforms/ListenerGreedyPatternRewriteDriver.h
+++ b/include/Transforms/ListenerGreedyPatternRewriteDriver.h
@@ -1,0 +1,32 @@
+//===- ListenerGreedyPatternRewriteDriver.h - A greedy rewriter -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Transforms/Listener.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+
+namespace mlir {
+struct GreedyRewriteConfig;
+
+/// Applies the specified patterns on `op` alone while also trying to fold it,
+/// by selecting the highest benefits patterns in a greedy manner. Returns
+/// success if no more patterns can be matched. `erased` is set to true if `op`
+/// was folded away or erased as a result of becoming dead. Note: This does not
+/// apply any patterns recursively to the regions of `op`. Accepts a listener
+/// so the caller can be notified of rewrite events.
+LogicalResult applyPatternsAndFoldGreedily(
+    MutableArrayRef<Region> regions, const FrozenRewritePatternSet &patterns,
+    const GreedyRewriteConfig &config, RewriteListener *listener);
+LogicalResult applyPatternsAndFoldGreedily(
+    Operation *op, const FrozenRewritePatternSet &patterns,
+    const GreedyRewriteConfig &config, RewriteListener *listener) {
+  return applyPatternsAndFoldGreedily(op->getRegions(), patterns, config,
+                                      listener);
+}
+
+} // namespace mlir

--- a/lib/Registration.cpp
+++ b/lib/Registration.cpp
@@ -67,12 +67,14 @@ namespace mlir {
 namespace test_ext {
 void registerTestStagedPatternRewriteDriver();
 void registerTestVectorMaskingUtils();
+void registerTestListenerPasses();
 } // namespace test_ext
 } // namespace mlir
 
 void registerTestPasses() {
   mlir::test_ext::registerTestStagedPatternRewriteDriver();
   mlir::test_ext::registerTestVectorMaskingUtils();
+  mlir::test_ext::registerTestListenerPasses();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -4,6 +4,9 @@ add_mlir_library(IREELinalgTensorSandboxTransforms
   ConvertToGPUDialect.cpp
   FuseFillIntoReduction.cpp
   LinalgTileAndFuse.cpp
+  Listener.cpp
+  ListenerCSE.cpp
+  ListenerGreedyPatternRewriteDriver.cpp
   StagedPatternRewriteDriver.cpp
   VectorDistribution.cpp
 

--- a/lib/Transforms/Listener.cpp
+++ b/lib/Transforms/Listener.cpp
@@ -1,0 +1,50 @@
+//===- Listener.cpp - Transformation Listener -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Transforms/Listener.h"
+
+namespace mlir {
+
+//===----------------------------------------------------------------------===//
+// RewriteListener
+//===----------------------------------------------------------------------===//
+
+RewriteListener::~RewriteListener() = default;
+
+//===----------------------------------------------------------------------===//
+// ListenerList
+//===----------------------------------------------------------------------===//
+
+void ListenerList::notifyOperationInserted(Operation *op) {
+  for (RewriteListener *listener : listeners)
+    listener->notifyOperationInserted(op);
+}
+
+void ListenerList::notifyBlockCreated(Block *block) {
+  for (RewriteListener *listener : listeners)
+    listener->notifyBlockCreated(block);
+}
+
+void ListenerList::notifyOperationReplaced(Operation *op,
+                                           ValueRange newValues) {
+  for (RewriteListener *listener : listeners)
+    listener->notifyOperationReplaced(op, newValues);
+}
+
+void ListenerList::notifyOperationRemoved(Operation *op) {
+  for (RewriteListener *listener : listeners)
+    listener->notifyOperationRemoved(op);
+}
+
+void ListenerList::notifyMatchFailure(
+    Operation *op, function_ref<void(Diagnostic &)> reasonCallback) {
+  for (RewriteListener *listener : listeners)
+    listener->notifyMatchFailure(op, reasonCallback);
+}
+
+} // namespace mlir

--- a/lib/Transforms/ListenerCSE.cpp
+++ b/lib/Transforms/ListenerCSE.cpp
@@ -1,0 +1,310 @@
+//===-- ListenerCSE.cpp - Common subexpr elimination with a listener ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Transforms/ListenerCSE.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/ScopedHashTable.h"
+#include "llvm/Support/RecyclingAllocator.h"
+#include <deque>
+
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+namespace {
+struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
+  static unsigned getHashValue(const Operation *opC) {
+    return OperationEquivalence::computeHash(
+        const_cast<Operation *>(opC),
+        /*hashOperands=*/OperationEquivalence::directHashValue,
+        /*hashResults=*/OperationEquivalence::ignoreHashValue,
+        OperationEquivalence::IgnoreLocations);
+  }
+  static bool isEqual(const Operation *lhsC, const Operation *rhsC) {
+    auto *lhs = const_cast<Operation *>(lhsC);
+    auto *rhs = const_cast<Operation *>(rhsC);
+    if (lhs == rhs)
+      return true;
+    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
+        rhs == getTombstoneKey() || rhs == getEmptyKey())
+      return false;
+    return OperationEquivalence::isEquivalentTo(
+        const_cast<Operation *>(lhsC), const_cast<Operation *>(rhsC),
+        /*mapOperands=*/OperationEquivalence::exactValueMatch,
+        /*mapResults=*/OperationEquivalence::ignoreValueEquivalence,
+        OperationEquivalence::IgnoreLocations);
+  }
+};
+} // namespace
+
+namespace {
+/// Simple common sub-expression elimination.
+struct CSE {
+  /// Shared implementation of operation elimination and scoped map definitions.
+  using AllocatorTy = llvm::RecyclingAllocator<
+      llvm::BumpPtrAllocator,
+      llvm::ScopedHashTableVal<Operation *, Operation *>>;
+  using ScopedMapTy = llvm::ScopedHashTable<Operation *, Operation *,
+                                            SimpleOperationInfo, AllocatorTy>;
+
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+  CSE(DominanceInfo *domInfo, RewriteListener *listener)
+      : domInfo(domInfo), listener(listener) {}
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+
+  /// Represents a single entry in the depth first traversal of a CFG.
+  struct CFGStackNode {
+    CFGStackNode(ScopedMapTy &knownValues, DominanceInfoNode *node)
+        : scope(knownValues), node(node), childIterator(node->begin()),
+          processed(false) {}
+
+    /// Scope for the known values.
+    ScopedMapTy::ScopeTy scope;
+
+    DominanceInfoNode *node;
+    DominanceInfoNode::const_iterator childIterator;
+
+    /// If this node has been fully processed yet or not.
+    bool processed;
+  };
+
+  /// Attempt to eliminate a redundant operation. Returns success if the
+  /// operation was marked for removal, failure otherwise.
+  LogicalResult simplifyOperation(ScopedMapTy &knownValues, Operation *op,
+                                  bool hasSSADominance);
+  void simplifyBlock(ScopedMapTy &knownValues, Block *bb, bool hasSSADominance);
+  void simplifyRegion(ScopedMapTy &knownValues, Region &region);
+  /// Return the number of erased operations.
+  unsigned simplify(Operation *rootOp);
+
+private:
+  /// Operations marked as dead and to be erased.
+  std::vector<Operation *> opsToErase;
+
+  /// The dominance info to use.
+  DominanceInfo *domInfo;
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+  /// An optional listener to notify of replaced or erased operations.
+  RewriteListener *listener;
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+};
+
+} // namespace
+
+/// Attempt to eliminate a redundant operation.
+LogicalResult CSE::simplifyOperation(ScopedMapTy &knownValues, Operation *op,
+                                     bool hasSSADominance) {
+  // Don't simplify terminator operations.
+  if (op->hasTrait<OpTrait::IsTerminator>())
+    return failure();
+
+  // If the operation is already trivially dead just add it to the erase list.
+  if (isOpTriviallyDead(op)) {
+    opsToErase.push_back(op);
+    return success();
+  }
+
+  // Don't simplify operations with nested blocks. We don't currently model
+  // equality comparisons correctly among other things. It is also unclear
+  // whether we would want to CSE such operations.
+  if (op->getNumRegions() != 0)
+    return failure();
+
+  // TODO: We currently only eliminate non side-effecting
+  // operations.
+  if (!MemoryEffectOpInterface::hasNoEffect(op))
+    return failure();
+
+  // Look for an existing definition for the operation.
+  if (auto *existing = knownValues.lookup(op)) {
+
+    // If we find one then replace all uses of the current operation with the
+    // existing one and mark it for deletion. We can only replace an operand in
+    // an operation if it has not been visited yet.
+    if (hasSSADominance) {
+      // If the region has SSA dominance, then we are guaranteed to have not
+      // visited any use of the current operation.
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+      if (listener)
+        listener->notifyOperationReplaced(op, existing->getResults());
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+      op->replaceAllUsesWith(existing);
+      opsToErase.push_back(op);
+    } else {
+      // When the region does not have SSA dominance, we need to check if we
+      // have visited a use before replacing any use.
+      for (auto it : llvm::zip(op->getResults(), existing->getResults())) {
+        std::get<0>(it).replaceUsesWithIf(
+            std::get<1>(it), [&](OpOperand &operand) {
+              return !knownValues.count(operand.getOwner());
+            });
+      }
+
+      // There may be some remaining uses of the operation.
+      if (op->use_empty())
+        opsToErase.push_back(op);
+    }
+
+    // If the existing operation has an unknown location and the current
+    // operation doesn't, then set the existing op's location to that of the
+    // current op.
+    if (existing->getLoc().isa<UnknownLoc>() &&
+        !op->getLoc().isa<UnknownLoc>()) {
+      existing->setLoc(op->getLoc());
+    }
+
+    return success();
+  }
+
+  // Otherwise, we add this operation to the known values map.
+  knownValues.insert(op, op);
+  return failure();
+}
+
+void CSE::simplifyBlock(ScopedMapTy &knownValues, Block *bb,
+                        bool hasSSADominance) {
+  for (auto &op : *bb) {
+    // If the operation is simplified, we don't process any held regions.
+    if (succeeded(simplifyOperation(knownValues, &op, hasSSADominance)))
+      continue;
+
+    // Most operations don't have regions, so fast path that case.
+    if (op.getNumRegions() == 0)
+      continue;
+
+    // If this operation is isolated above, we can't process nested regions with
+    // the given 'knownValues' map. This would cause the insertion of implicit
+    // captures in explicit capture only regions.
+    if (op.mightHaveTrait<OpTrait::IsIsolatedFromAbove>()) {
+      ScopedMapTy nestedKnownValues;
+      for (auto &region : op.getRegions())
+        simplifyRegion(nestedKnownValues, region);
+      continue;
+    }
+
+    // Otherwise, process nested regions normally.
+    for (auto &region : op.getRegions())
+      simplifyRegion(knownValues, region);
+  }
+}
+
+void CSE::simplifyRegion(ScopedMapTy &knownValues, Region &region) {
+  // If the region is empty there is nothing to do.
+  if (region.empty())
+    return;
+
+  bool hasSSADominance = domInfo->hasSSADominance(&region);
+
+  // If the region only contains one block, then simplify it directly.
+  if (region.hasOneBlock()) {
+    ScopedMapTy::ScopeTy scope(knownValues);
+    simplifyBlock(knownValues, &region.front(), hasSSADominance);
+    return;
+  }
+
+  // If the region does not have dominanceInfo, then skip it.
+  // TODO: Regions without SSA dominance should define a different
+  // traversal order which is appropriate and can be used here.
+  if (!hasSSADominance)
+    return;
+
+  // Note, deque is being used here because there was significant performance
+  // gains over vector when the container becomes very large due to the
+  // specific access patterns. If/when these performance issues are no
+  // longer a problem we can change this to vector. For more information see
+  // the llvm mailing list discussion on this:
+  // http://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20120116/135228.html
+  std::deque<std::unique_ptr<CFGStackNode>> stack;
+
+  // Process the nodes of the dom tree for this region.
+  stack.emplace_back(std::make_unique<CFGStackNode>(
+      knownValues, domInfo->getRootNode(&region)));
+
+  while (!stack.empty()) {
+    auto &currentNode = stack.back();
+
+    // Check to see if we need to process this node.
+    if (!currentNode->processed) {
+      currentNode->processed = true;
+      simplifyBlock(knownValues, currentNode->node->getBlock(),
+                    hasSSADominance);
+    }
+
+    // Otherwise, check to see if we need to process a child node.
+    if (currentNode->childIterator != currentNode->node->end()) {
+      auto *childNode = *(currentNode->childIterator++);
+      stack.emplace_back(
+          std::make_unique<CFGStackNode>(knownValues, childNode));
+    } else {
+      // Finally, if the node and all of its children have been processed
+      // then we delete the node.
+      stack.pop_back();
+    }
+  }
+}
+
+unsigned CSE::simplify(Operation *rootOp) {
+  /// A scoped hash table of defining operations within a region.
+  ScopedMapTy knownValues;
+
+  for (auto &region : rootOp->getRegions())
+    simplifyRegion(knownValues, region);
+
+  /// Erase any operations that were marked as dead during simplification.
+  for (auto *op : opsToErase) {
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+    if (listener)
+      listener->notifyOperationRemoved(op);
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+    op->erase();
+  }
+
+  return opsToErase.size();
+}
+
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/CSE.cpp
+//===----------------------------------------------------------------------===//
+
+/// Run CSE on the provided operation
+LogicalResult mlir::eliminateCommonSubexpressions(Operation *op,
+                                                  DominanceInfo *domInfo,
+                                                  RewriteListener *listener) {
+  assert(op->hasTrait<OpTrait::IsIsolatedFromAbove>() &&
+         "can only do CSE on isolated-from-above ops");
+
+  Optional<DominanceInfo> defaultDomInfo;
+  if (domInfo == nullptr) {
+    defaultDomInfo.emplace(op);
+    domInfo = &*defaultDomInfo;
+  }
+
+  CSE cse(domInfo, listener);
+  cse.simplify(op);
+  return success();
+}

--- a/lib/Transforms/ListenerGreedyPatternRewriteDriver.cpp
+++ b/lib/Transforms/ListenerGreedyPatternRewriteDriver.cpp
@@ -1,0 +1,436 @@
+//===- ListenerGreedyPatternRewriteDriver.cpp - A greedy rewriter --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Transforms/ListenerGreedyPatternRewriteDriver.h"
+#include "Transforms/Listener.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Rewrite/PatternApplicator.h"
+#include "mlir/Transforms/FoldUtils.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ScopedPrinter.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+#define DEBUG_TYPE "listener-greedy-rewriter"
+
+//===----------------------------------------------------------------------===//
+// GreedyPatternRewriteDriver
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// This is a worklist-driven driver for the PatternMatcher, which repeatedly
+/// applies the locally optimal patterns in a roughly "bottom up" way.
+class GreedyPatternRewriteDriver : public RewriteListener {
+public:
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+  explicit GreedyPatternRewriteDriver(MLIRContext *ctx,
+                                      const FrozenRewritePatternSet &patterns,
+                                      const GreedyRewriteConfig &config,
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+                                      RewriteListener *listener);
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+
+  /// Simplify the operations within the given regions.
+  bool simplify(MutableArrayRef<Region> regions);
+
+  /// Add the given operation to the worklist.
+  void addToWorklist(Operation *op);
+
+  /// Pop the next operation from the worklist.
+  Operation *popFromWorklist();
+
+  /// If the specified operation is in the worklist, remove it.
+  void removeFromWorklist(Operation *op);
+
+protected:
+  // Implement the hook for inserting operations, and make sure that newly
+  // inserted ops are added to the worklist for processing.
+  void notifyOperationInserted(Operation *op) override;
+
+  // Look over the provided operands for any defining operations that should
+  // be re-added to the worklist. This function should be called when an
+  // operation is modified or removed, as it may trigger further
+  // simplifications.
+  template <typename Operands>
+  void addToWorklist(Operands &&operands);
+
+  // If an operation is about to be removed, make sure it is not in our
+  // worklist anymore because we'd get dangling references to it.
+  void notifyOperationRemoved(Operation *op) override;
+
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+  // When the root of a pattern is about to be replaced, it can trigger
+  // simplifications to its users - make sure to add them to the worklist
+  // before the root is changed.
+  void notifyOperationReplaced(Operation *op, ValueRange newValues) override;
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+
+  /// PatternRewriter hook for notifying match failure reasons.
+  void
+  notifyMatchFailure(Operation *op,
+                     function_ref<void(Diagnostic &)> reasonCallback) override;
+
+  /// The low-level pattern applicator.
+  PatternApplicator matcher;
+
+  /// The worklist for this transformation keeps track of the operations that
+  /// need to be revisited, plus their index in the worklist.  This allows us to
+  /// efficiently remove operations from the worklist when they are erased, even
+  /// if they aren't the root of a pattern.
+  std::vector<Operation *> worklist;
+  DenseMap<Operation *, unsigned> worklistMap;
+
+  /// Non-pattern based folder for operations.
+  OperationFolder folder;
+
+private:
+  /// Configuration information for how to simplify.
+  GreedyRewriteConfig config;
+
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+  /// The pattern rewriter to use.
+  PatternRewriterListener rewriter;
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+
+#ifndef NDEBUG
+  /// A logger used to emit information during the application process.
+  llvm::ScopedPrinter logger{llvm::dbgs()};
+#endif
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+GreedyPatternRewriteDriver::GreedyPatternRewriteDriver(
+    MLIRContext *ctx, const FrozenRewritePatternSet &patterns,
+    const GreedyRewriteConfig &config, RewriteListener *listener)
+    : matcher(patterns), folder(ctx), config(config), rewriter(ctx) {
+  // Add self as a listener and the user-provided listener.
+  rewriter.addListener(this);
+  if (listener)
+    rewriter.addListener(listener);
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+
+  worklist.reserve(64);
+
+  // Apply a simple cost model based solely on pattern benefit.
+  matcher.applyDefaultCostModel();
+}
+
+bool GreedyPatternRewriteDriver::simplify(MutableArrayRef<Region> regions) {
+#ifndef NDEBUG
+  const char *logLineComment =
+      "//===-------------------------------------------===//\n";
+
+  /// A utility function to log a process result for the given reason.
+  auto logResult = [&](StringRef result, const llvm::Twine &msg = {}) {
+    logger.unindent();
+    logger.startLine() << "} -> " << result;
+    if (!msg.isTriviallyEmpty())
+      logger.getOStream() << " : " << msg;
+    logger.getOStream() << "\n";
+  };
+  auto logResultWithLine = [&](StringRef result, const llvm::Twine &msg = {}) {
+    logResult(result, msg);
+    logger.startLine() << logLineComment;
+  };
+#endif
+
+  bool changed = false;
+  unsigned iteration = 0;
+  do {
+    worklist.clear();
+    worklistMap.clear();
+
+    if (!config.useTopDownTraversal) {
+      // Add operations to the worklist in postorder.
+      for (auto &region : regions)
+        region.walk([this](Operation *op) { addToWorklist(op); });
+    } else {
+      // Add all nested operations to the worklist in preorder.
+      for (auto &region : regions)
+        region.walk<WalkOrder::PreOrder>(
+            [this](Operation *op) { worklist.push_back(op); });
+
+      // Reverse the list so our pop-back loop processes them in-order.
+      std::reverse(worklist.begin(), worklist.end());
+      // Remember the reverse index.
+      for (size_t i = 0, e = worklist.size(); i != e; ++i)
+        worklistMap[worklist[i]] = i;
+    }
+
+    // These are scratch vectors used in the folding loop below.
+    SmallVector<Value, 8> originalOperands, resultValues;
+
+    changed = false;
+    while (!worklist.empty()) {
+      auto *op = popFromWorklist();
+
+      // Nulls get added to the worklist when operations are removed, ignore
+      // them.
+      if (op == nullptr)
+        continue;
+
+      LLVM_DEBUG({
+        logger.getOStream() << "\n";
+        logger.startLine() << logLineComment;
+        logger.startLine() << "Processing operation : '" << op->getName()
+                           << "'(" << op << ") {\n";
+        logger.indent();
+
+        // If the operation has no regions, just print it here.
+        if (op->getNumRegions() == 0) {
+          op->print(
+              logger.startLine(),
+              OpPrintingFlags().printGenericOpForm().elideLargeElementsAttrs());
+          logger.getOStream() << "\n\n";
+        }
+      });
+
+      // If the operation is trivially dead - remove it.
+      if (isOpTriviallyDead(op)) {
+        rewriter.notifyOperationRemoved(op);
+        op->erase();
+        changed = true;
+
+        LLVM_DEBUG(logResultWithLine("success", "operation is trivially dead"));
+        continue;
+      }
+
+      // Collects all the operands and result uses of the given `op` into work
+      // list. Also remove `op` and nested ops from worklist.
+      originalOperands.assign(op->operand_begin(), op->operand_end());
+      auto preReplaceAction = [&](Operation *op) {
+        // Add the operands to the worklist for visitation.
+        addToWorklist(originalOperands);
+
+        // Add all the users of the result to the worklist so we make sure
+        // to revisit them.
+        for (auto result : op->getResults())
+          for (auto *userOp : result.getUsers())
+            addToWorklist(userOp);
+
+        rewriter.notifyOperationRemoved(op);
+      };
+
+      // Add the given operation to the worklist.
+      auto collectOps = [this](Operation *op) { addToWorklist(op); };
+
+      // Try to fold this op.
+      bool inPlaceUpdate;
+      if ((succeeded(folder.tryToFold(op, collectOps, preReplaceAction,
+                                      &inPlaceUpdate)))) {
+        LLVM_DEBUG(logResultWithLine("success", "operation was folded"));
+
+        changed = true;
+        if (!inPlaceUpdate)
+          continue;
+      }
+
+      // Try to match one of the patterns. The rewriter is automatically
+      // notified of any necessary changes, so there is nothing else to do
+      // here.
+#ifndef NDEBUG
+      auto canApply = [&](const Pattern &pattern) {
+        LLVM_DEBUG({
+          logger.getOStream() << "\n";
+          logger.startLine() << "* Pattern " << pattern.getDebugName() << " : '"
+                             << op->getName() << " -> (";
+          llvm::interleaveComma(pattern.getGeneratedOps(), logger.getOStream());
+          logger.getOStream() << ")' {\n";
+          logger.indent();
+        });
+        return true;
+      };
+      auto onFailure = [&](const Pattern &pattern) {
+        LLVM_DEBUG(logResult("failure", "pattern failed to match"));
+      };
+      auto onSuccess = [&](const Pattern &pattern) {
+        LLVM_DEBUG(logResult("success", "pattern applied successfully"));
+        return success();
+      };
+
+      LogicalResult matchResult =
+          matcher.matchAndRewrite(op, rewriter, canApply, onFailure, onSuccess);
+      if (succeeded(matchResult))
+        LLVM_DEBUG(logResultWithLine("success", "pattern matched"));
+      else
+        LLVM_DEBUG(logResultWithLine("failure", "pattern failed to match"));
+#else
+      LogicalResult matchResult = matcher.matchAndRewrite(op, rewriter);
+#endif
+      changed |= succeeded(matchResult);
+    }
+
+    // After applying patterns, make sure that the CFG of each of the regions
+    // is kept up to date.
+    if (config.enableRegionSimplification)
+      changed |= succeeded(simplifyRegions(rewriter, regions));
+  } while (changed &&
+           (++iteration < config.maxIterations ||
+            config.maxIterations == GreedyRewriteConfig::kNoIterationLimit));
+
+  // Whether the rewrite converges, i.e. wasn't changed in the last iteration.
+  return !changed;
+}
+
+void GreedyPatternRewriteDriver::addToWorklist(Operation *op) {
+  // Check to see if the worklist already contains this op.
+  if (worklistMap.count(op))
+    return;
+
+  worklistMap[op] = worklist.size();
+  worklist.push_back(op);
+}
+
+Operation *GreedyPatternRewriteDriver::popFromWorklist() {
+  auto *op = worklist.back();
+  worklist.pop_back();
+
+  // This operation is no longer in the worklist, keep worklistMap up to date.
+  if (op)
+    worklistMap.erase(op);
+  return op;
+}
+
+void GreedyPatternRewriteDriver::removeFromWorklist(Operation *op) {
+  auto it = worklistMap.find(op);
+  if (it != worklistMap.end()) {
+    assert(worklist[it->second] == op && "malformed worklist data structure");
+    worklist[it->second] = nullptr;
+    worklistMap.erase(it);
+  }
+}
+
+void GreedyPatternRewriteDriver::notifyOperationInserted(Operation *op) {
+  LLVM_DEBUG({
+    logger.startLine() << "** Insert  : '" << op->getName() << "'(" << op
+                       << ")\n";
+  });
+  addToWorklist(op);
+}
+
+template <typename Operands>
+void GreedyPatternRewriteDriver::addToWorklist(Operands &&operands) {
+  for (Value operand : operands) {
+    // If the use count of this operand is now < 2, we re-add the defining
+    // operation to the worklist.
+    // TODO: This is based on the fact that zero use operations
+    // may be deleted, and that single use values often have more
+    // canonicalization opportunities.
+    if (!operand || (!operand.use_empty() && !operand.hasOneUse()))
+      continue;
+    if (auto *defOp = operand.getDefiningOp())
+      addToWorklist(defOp);
+  }
+}
+
+void GreedyPatternRewriteDriver::notifyOperationRemoved(Operation *op) {
+  LLVM_DEBUG({
+    logger.startLine() << "** Erase   : '" << op->getName() << "'(" << op
+                       << ")\n";
+  });
+  addToWorklist(op->getOperands());
+  op->walk([this](Operation *operation) {
+    removeFromWorklist(operation);
+    folder.notifyRemoval(operation);
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+void GreedyPatternRewriteDriver::notifyOperationReplaced(Operation *op,
+                                                         ValueRange newValues) {
+  LLVM_DEBUG({
+    logger.startLine() << "** Replace : '" << op->getName() << "'(" << op
+                       << ")\n";
+  });
+  for (auto result : op->getResults())
+    for (auto *user : result.getUsers())
+      addToWorklist(user);
+}
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+
+void GreedyPatternRewriteDriver::notifyMatchFailure(
+    Operation *op, function_ref<void(Diagnostic &)> reasonCallback) {
+  LLVM_DEBUG({
+    Diagnostic diag(op->getLoc(), DiagnosticSeverity::Remark);
+    reasonCallback(diag);
+    logger.startLine() << "** Failure : " << diag.str() << "\n";
+  });
+}
+
+/// Rewrite the regions of the specified operation, which must be isolated from
+/// above, by repeatedly applying the highest benefit patterns in a greedy
+/// work-list driven manner. Return success if no more patterns can be matched
+/// in the result operation regions. Note: This does not apply patterns to the
+/// top-level operation itself.
+///
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+LogicalResult mlir::applyPatternsAndFoldGreedily(
+    MutableArrayRef<Region> regions, const FrozenRewritePatternSet &patterns,
+    const GreedyRewriteConfig &config, RewriteListener *listener) {
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+  if (regions.empty())
+    return success();
+
+  // The top-level operation must be known to be isolated from above to
+  // prevent performing canonicalizations on operations defined at or above
+  // the region containing 'op'.
+  auto regionIsIsolated = [](Region &region) {
+    return region.getParentOp()->hasTrait<OpTrait::IsIsolatedFromAbove>();
+  };
+  (void)regionIsIsolated;
+  assert(llvm::all_of(regions, regionIsIsolated) &&
+         "patterns can only be applied to operations IsolatedFromAbove");
+
+  // Start the pattern driver.
+//===----------------------------------------------------------------------===//
+// END copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+  GreedyPatternRewriteDriver driver(regions[0].getContext(), patterns, config,
+                                    listener);
+//===----------------------------------------------------------------------===//
+// BEGIN copied from mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+//===----------------------------------------------------------------------===//
+  bool converged = driver.simplify(regions);
+  LLVM_DEBUG(if (!converged) {
+    llvm::dbgs() << "The pattern rewrite doesn't converge after scanning "
+                 << config.maxIterations << " times\n";
+  });
+  return success(converged);
+}

--- a/test/Transforms/test-listener-canonicalize.mlir
+++ b/test/Transforms/test-listener-canonicalize.mlir
@@ -1,0 +1,102 @@
+// RUN: mlir-proto-opt %s -allow-unregistered-dialect -test-listener-canonicalize --split-input-file | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Everything below copied from mlir/test/Dialect/Standard/canonicalize.mlir
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @select_same_val
+//       CHECK:   return %arg1
+func @select_same_val(%arg0: i1, %arg1: i64) -> i64 {
+  %0 = select %arg0, %arg1, %arg1 : i64
+  return %0 : i64
+}
+
+// -----
+
+// CHECK-LABEL: @select_cmp_eq_select
+//       CHECK:   return %arg1
+func @select_cmp_eq_select(%arg0: i64, %arg1: i64) -> i64 {
+  %0 = arith.cmpi eq, %arg0, %arg1 : i64
+  %1 = select %0, %arg0, %arg1 : i64
+  return %1 : i64
+}
+
+// -----
+
+// CHECK-LABEL: @select_cmp_ne_select
+//       CHECK:   return %arg0
+func @select_cmp_ne_select(%arg0: i64, %arg1: i64) -> i64 {
+  %0 = arith.cmpi ne, %arg0, %arg1 : i64
+  %1 = select %0, %arg0, %arg1 : i64
+  return %1 : i64
+}
+
+// -----
+
+// CHECK-LABEL: @select_extui
+//       CHECK:   %[[res:.+]] = arith.extui %arg0 : i1 to i64
+//       CHECK:   return %[[res]]
+func @select_extui(%arg0: i1) -> i64 {
+  %c0_i64 = arith.constant 0 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %res = select %arg0, %c1_i64, %c0_i64 : i64
+  return %res : i64
+}
+
+// CHECK-LABEL: @select_extui2
+// CHECK-DAG:  %true = arith.constant true
+// CHECK-DAG:  %[[xor:.+]] = arith.xori %arg0, %true : i1
+// CHECK-DAG:  %[[res:.+]] = arith.extui %[[xor]] : i1 to i64
+//       CHECK:   return %[[res]]
+func @select_extui2(%arg0: i1) -> i64 {
+  %c0_i64 = arith.constant 0 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %res = select %arg0, %c0_i64, %c1_i64 : i64
+  return %res : i64
+}
+
+// -----
+
+// CHECK-LABEL: @select_extui_i1
+//  CHECK-NEXT:   return %arg0
+func @select_extui_i1(%arg0: i1) -> i1 {
+  %c0_i1 = arith.constant false
+  %c1_i1 = arith.constant true
+  %res = select %arg0, %c1_i1, %c0_i1 : i1
+  return %res : i1
+}
+
+// -----
+
+// CHECK-LABEL: @branchCondProp
+//       CHECK:       %[[trueval:.+]] = arith.constant true
+//       CHECK:       %[[falseval:.+]] = arith.constant false
+//       CHECK:       "test.consumer1"(%[[trueval]]) : (i1) -> ()
+//       CHECK:       "test.consumer2"(%[[falseval]]) : (i1) -> ()
+func @branchCondProp(%arg0: i1) {
+  cond_br %arg0, ^trueB, ^falseB
+
+^trueB:
+  "test.consumer1"(%arg0) : (i1) -> ()
+  br ^exit
+
+^falseB:
+  "test.consumer2"(%arg0) : (i1) -> ()
+  br ^exit
+
+^exit:
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @selToNot
+//       CHECK:       %[[trueval:.+]] = arith.constant true
+//       CHECK:       %{{.+}} = arith.xori %arg0, %[[trueval]] : i1
+func @selToNot(%arg0: i1) -> i1 {
+  %true = arith.constant true
+  %false = arith.constant false
+  %res = select %arg0, %false, %true : i1
+  return %res : i1
+}
+

--- a/test/Transforms/test-listener-cse.mlir
+++ b/test/Transforms/test-listener-cse.mlir
@@ -1,0 +1,250 @@
+// RUN: mlir-proto-opt -allow-unregistered-dialect %s -pass-pipeline='builtin.func(test-listener-cse)' | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Everything below copied from mlir/test/Transforms/cse.mlir
+//===----------------------------------------------------------------------===//
+
+// CHECK-DAG: #[[$MAP:.*]] = affine_map<(d0) -> (d0 mod 2)>
+#map0 = affine_map<(d0) -> (d0 mod 2)>
+
+// CHECK-LABEL: @simple_constant
+func @simple_constant() -> (i32, i32) {
+  // CHECK-NEXT: %c1_i32 = arith.constant 1 : i32
+  %0 = arith.constant 1 : i32
+
+  // CHECK-NEXT: return %c1_i32, %c1_i32 : i32, i32
+  %1 = arith.constant 1 : i32
+  return %0, %1 : i32, i32
+}
+
+// CHECK-LABEL: @basic
+func @basic() -> (index, index) {
+  // CHECK: %c0 = arith.constant 0 : index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 0 : index
+
+  // CHECK-NEXT: %0 = affine.apply #[[$MAP]](%c0)
+  %0 = affine.apply #map0(%c0)
+  %1 = affine.apply #map0(%c1)
+
+  // CHECK-NEXT: return %0, %0 : index, index
+  return %0, %1 : index, index
+}
+
+// CHECK-LABEL: @many
+func @many(f32, f32) -> (f32) {
+^bb0(%a : f32, %b : f32):
+  // CHECK-NEXT: %0 = arith.addf %arg0, %arg1 : f32
+  %c = arith.addf %a, %b : f32
+  %d = arith.addf %a, %b : f32
+  %e = arith.addf %a, %b : f32
+  %f = arith.addf %a, %b : f32
+
+  // CHECK-NEXT: %1 = arith.addf %0, %0 : f32
+  %g = arith.addf %c, %d : f32
+  %h = arith.addf %e, %f : f32
+  %i = arith.addf %c, %e : f32
+
+  // CHECK-NEXT: %2 = arith.addf %1, %1 : f32
+  %j = arith.addf %g, %h : f32
+  %k = arith.addf %h, %i : f32
+
+  // CHECK-NEXT: %3 = arith.addf %2, %2 : f32
+  %l = arith.addf %j, %k : f32
+
+  // CHECK-NEXT: return %3 : f32
+  return %l : f32
+}
+
+/// Check that operations are not eliminated if they have different operands.
+// CHECK-LABEL: @different_ops
+func @different_ops() -> (i32, i32) {
+  // CHECK: %c0_i32 = arith.constant 0 : i32
+  // CHECK: %c1_i32 = arith.constant 1 : i32
+  %0 = arith.constant 0 : i32
+  %1 = arith.constant 1 : i32
+
+  // CHECK-NEXT: return %c0_i32, %c1_i32 : i32, i32
+  return %0, %1 : i32, i32
+}
+
+/// Check that operations are not eliminated if they have different result
+/// types.
+// CHECK-LABEL: @different_results
+func @different_results(%arg0: tensor<*xf32>) -> (tensor<?x?xf32>, tensor<4x?xf32>) {
+  // CHECK: %0 = tensor.cast %arg0 : tensor<*xf32> to tensor<?x?xf32>
+  // CHECK-NEXT: %1 = tensor.cast %arg0 : tensor<*xf32> to tensor<4x?xf32>
+  %0 = tensor.cast %arg0 : tensor<*xf32> to tensor<?x?xf32>
+  %1 = tensor.cast %arg0 : tensor<*xf32> to tensor<4x?xf32>
+
+  // CHECK-NEXT: return %0, %1 : tensor<?x?xf32>, tensor<4x?xf32>
+  return %0, %1 : tensor<?x?xf32>, tensor<4x?xf32>
+}
+
+/// Check that operations are not eliminated if they have different attributes.
+// CHECK-LABEL: @different_attributes
+func @different_attributes(index, index) -> (i1, i1, i1) {
+^bb0(%a : index, %b : index):
+  // CHECK: %0 = arith.cmpi slt, %arg0, %arg1 : index
+  %0 = arith.cmpi slt, %a, %b : index
+
+  // CHECK-NEXT: %1 = arith.cmpi ne, %arg0, %arg1 : index
+  /// Predicate 1 means inequality comparison.
+  %1 = arith.cmpi ne, %a, %b : index
+  %2 = "arith.cmpi"(%a, %b) {predicate = 1} : (index, index) -> i1
+
+  // CHECK-NEXT: return %0, %1, %1 : i1, i1, i1
+  return %0, %1, %2 : i1, i1, i1
+}
+
+/// Check that operations with side effects are not eliminated.
+// CHECK-LABEL: @side_effect
+func @side_effect() -> (memref<2x1xf32>, memref<2x1xf32>) {
+  // CHECK: %0 = memref.alloc() : memref<2x1xf32>
+  %0 = memref.alloc() : memref<2x1xf32>
+
+  // CHECK-NEXT: %1 = memref.alloc() : memref<2x1xf32>
+  %1 = memref.alloc() : memref<2x1xf32>
+
+  // CHECK-NEXT: return %0, %1 : memref<2x1xf32>, memref<2x1xf32>
+  return %0, %1 : memref<2x1xf32>, memref<2x1xf32>
+}
+
+/// Check that operation definitions are properly propagated down the dominance
+/// tree.
+// CHECK-LABEL: @down_propagate_for
+func @down_propagate_for() {
+  // CHECK: %c1_i32 = arith.constant 1 : i32
+  %0 = arith.constant 1 : i32
+
+  // CHECK-NEXT: affine.for {{.*}} = 0 to 4 {
+  affine.for %i = 0 to 4 {
+    // CHECK-NEXT: "foo"(%c1_i32, %c1_i32) : (i32, i32) -> ()
+    %1 = arith.constant 1 : i32
+    "foo"(%0, %1) : (i32, i32) -> ()
+  }
+  return
+}
+
+// CHECK-LABEL: @down_propagate
+func @down_propagate() -> i32 {
+  // CHECK-NEXT: %c1_i32 = arith.constant 1 : i32
+  %0 = arith.constant 1 : i32
+
+  // CHECK-NEXT: %true = arith.constant true
+  %cond = arith.constant true
+
+  // CHECK-NEXT: cond_br %true, ^bb1, ^bb2(%c1_i32 : i32)
+  cond_br %cond, ^bb1, ^bb2(%0 : i32)
+
+^bb1: // CHECK: ^bb1:
+  // CHECK-NEXT: br ^bb2(%c1_i32 : i32)
+  %1 = arith.constant 1 : i32
+  br ^bb2(%1 : i32)
+
+^bb2(%arg : i32):
+  return %arg : i32
+}
+
+/// Check that operation definitions are NOT propagated up the dominance tree.
+// CHECK-LABEL: @up_propagate_for
+func @up_propagate_for() -> i32 {
+  // CHECK: affine.for {{.*}} = 0 to 4 {
+  affine.for %i = 0 to 4 {
+    // CHECK-NEXT: %c1_i32_0 = arith.constant 1 : i32
+    // CHECK-NEXT: "foo"(%c1_i32_0) : (i32) -> ()
+    %0 = arith.constant 1 : i32
+    "foo"(%0) : (i32) -> ()
+  }
+
+  // CHECK: %c1_i32 = arith.constant 1 : i32
+  // CHECK-NEXT: return %c1_i32 : i32
+  %1 = arith.constant 1 : i32
+  return %1 : i32
+}
+
+// CHECK-LABEL: func @up_propagate
+func @up_propagate() -> i32 {
+  // CHECK-NEXT:  %c0_i32 = arith.constant 0 : i32
+  %0 = arith.constant 0 : i32
+
+  // CHECK-NEXT: %true = arith.constant true
+  %cond = arith.constant true
+
+  // CHECK-NEXT: cond_br %true, ^bb1, ^bb2(%c0_i32 : i32)
+  cond_br %cond, ^bb1, ^bb2(%0 : i32)
+
+^bb1: // CHECK: ^bb1:
+  // CHECK-NEXT: %c1_i32 = arith.constant 1 : i32
+  %1 = arith.constant 1 : i32
+
+  // CHECK-NEXT: br ^bb2(%c1_i32 : i32)
+  br ^bb2(%1 : i32)
+
+^bb2(%arg : i32): // CHECK: ^bb2
+  // CHECK-NEXT: %c1_i32_0 = arith.constant 1 : i32
+  %2 = arith.constant 1 : i32
+
+  // CHECK-NEXT: %1 = arith.addi %0, %c1_i32_0 : i32
+  %add = arith.addi %arg, %2 : i32
+
+  // CHECK-NEXT: return %1 : i32
+  return %add : i32
+}
+
+/// The same test as above except that we are testing on a cfg embedded within
+/// an operation region.
+// CHECK-LABEL: func @up_propagate_region
+func @up_propagate_region() -> i32 {
+  // CHECK-NEXT: %0 = "foo.region"
+  %0 = "foo.region"() ({
+    // CHECK-NEXT:  %c0_i32 = arith.constant 0 : i32
+    // CHECK-NEXT: %true = arith.constant true
+    // CHECK-NEXT: cond_br
+
+    %1 = arith.constant 0 : i32
+    %true = arith.constant true
+    cond_br %true, ^bb1, ^bb2(%1 : i32)
+
+  ^bb1: // CHECK: ^bb1:
+    // CHECK-NEXT: %c1_i32 = arith.constant 1 : i32
+    // CHECK-NEXT: br
+
+    %c1_i32 = arith.constant 1 : i32
+    br ^bb2(%c1_i32 : i32)
+
+  ^bb2(%arg : i32): // CHECK: ^bb2(%1: i32):
+    // CHECK-NEXT: %c1_i32_0 = arith.constant 1 : i32
+    // CHECK-NEXT: %2 = arith.addi %1, %c1_i32_0 : i32
+    // CHECK-NEXT: "foo.yield"(%2) : (i32) -> ()
+
+    %c1_i32_0 = arith.constant 1 : i32
+    %2 = arith.addi %arg, %c1_i32_0 : i32
+    "foo.yield" (%2) : (i32) -> ()
+  }) : () -> (i32)
+  return %0 : i32
+}
+
+/// This test checks that nested regions that are isolated from above are
+/// properly handled.
+// CHECK-LABEL: @nested_isolated
+func @nested_isolated() -> i32 {
+  // CHECK-NEXT: arith.constant 1
+  %0 = arith.constant 1 : i32
+
+  // CHECK-NEXT: @nested_func
+  builtin.func @nested_func() {
+    // CHECK-NEXT: arith.constant 1
+    %foo = arith.constant 1 : i32
+    "foo.yield"(%foo) : (i32) -> ()
+  }
+
+  // CHECK: "foo.region"
+  "foo.region"() ({
+    // CHECK-NEXT: arith.constant 1
+    %foo = arith.constant 1 : i32
+    "foo.yield"(%foo) : (i32) -> ()
+  }) : () -> ()
+
+  return %0 : i32
+}

--- a/test/Transforms/test-with-listener.mlir
+++ b/test/Transforms/test-with-listener.mlir
@@ -1,0 +1,20 @@
+// RUN: mlir-proto-opt -test-listener-canonicalize='listener=1' %s | FileCheck %s --check-prefix CANON
+// RUN: mlir-proto-opt -test-listener-cse='listener=1' %s | FileCheck %s --check-prefix CSE
+
+func @test_canonicalize(%arg0: i32) -> (i32, i32) {
+  // CANON: REPLACED arith.addi
+  // CANON: REMOVED arith.addi
+  %c5 = arith.constant -5 : i32
+  %0 = arith.addi %c5, %arg0 : i32
+  %1 = arith.addi %c5, %0 : i32
+  return %0, %1 : i32, i32
+}
+
+func @test_cse(%arg0: i32) -> (i32, i32) {
+  // CSE: REPLACED arith.addi
+  // CSE: REMOVED arith.addi
+  %c5 = arith.constant -5 : i32
+  %0 = arith.addi %c5, %arg0 : i32
+  %1 = arith.addi %c5, %arg0 : i32
+  return %0, %1 : i32, i32
+}

--- a/test/lib/Transforms/CMakeLists.txt
+++ b/test/lib/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_library(MLIRTransformsExtTestPasses
+  TestListenerPasses.cpp
   TestStagedRewriteDriver.cpp
 
   EXCLUDE_FROM_LIBMLIR

--- a/test/lib/Transforms/TestListenerPasses.cpp
+++ b/test/lib/Transforms/TestListenerPasses.cpp
@@ -1,0 +1,94 @@
+//===- TestListenerPasses.cpp - Test passes with listeners ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Transforms/Listener.h"
+#include "Transforms/ListenerCSE.h"
+#include "Transforms/ListenerGreedyPatternRewriteDriver.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+namespace {
+
+/// The test listener prints stuff to `stdout` so that it can be checked by lit
+/// tests.
+struct TestListener : public RewriteListener {
+  void notifyOperationReplaced(Operation *op, ValueRange newValues) override {
+    llvm::outs() << "REPLACED " << op->getName() << "\n";
+  }
+  void notifyOperationRemoved(Operation *op) override {
+    llvm::outs() << "REMOVED " << op->getName() << "\n";
+  }
+};
+
+struct TestListenerCanonicalizePass : public PassWrapper<TestListenerCanonicalizePass, Pass> {
+  TestListenerCanonicalizePass() = default;
+  TestListenerCanonicalizePass(const TestListenerCanonicalizePass &other)
+      : PassWrapper(other) {}
+
+  StringRef getArgument() const final { return "test-listener-canonicalize"; }
+  StringRef getDescription() const final { return "Test canonicalize pass."; }
+
+  void runOnOperation() override {
+    TestListener listener;
+    RewriteListener *listenerToUse = nullptr;
+    if (withListener)
+      listenerToUse = &listener;
+
+    RewritePatternSet patterns(&getContext());
+    for (Dialect *dialect : getContext().getLoadedDialects())
+      dialect->getCanonicalizationPatterns(patterns);
+    for (RegisteredOperationName op : getContext().getRegisteredOperations())
+      op.getCanonicalizationPatterns(patterns, &getContext());
+
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
+                                            GreedyRewriteConfig(),
+                                            listenerToUse)))
+      signalPassFailure();
+  }
+
+  Pass::Option<bool> withListener{
+      *this, "listener", llvm::cl::desc("Whether to run with a test listener"),
+      llvm::cl::init(false)};
+};
+
+struct TestListenerCSEPass : public PassWrapper<TestListenerCSEPass, Pass> {
+  TestListenerCSEPass() = default;
+  TestListenerCSEPass(const TestListenerCSEPass &other) : PassWrapper(other) {}
+
+  StringRef getArgument() const final { return "test-listener-cse"; }
+  StringRef getDescription() const final { return "Test CSE pass."; }
+
+  void runOnOperation() override {
+    TestListener listener;
+    RewriteListener *listenerToUse = nullptr;
+    if (withListener)
+      listenerToUse = &listener;
+
+    if (failed(eliminateCommonSubexpressions(getOperation(),
+                                             /*domInfo=*/nullptr,
+                                             listenerToUse)))
+      signalPassFailure();
+  }
+
+  Pass::Option<bool> withListener{
+      *this, "listener", llvm::cl::desc("Whether to run with a test listener"),
+      llvm::cl::init(false)};
+};
+
+} // namespace
+
+namespace mlir {
+namespace test_ext {
+void registerTestListenerPasses() {
+  PassRegistration<TestListenerCanonicalizePass>();
+  PassRegistration<TestListenerCSEPass>();
+}
+} // namespace test_ext
+} // namespace mlir


### PR DESCRIPTION
In this PR, I've made a demo functional pattern implementation in C++ used it in parts of the LinalgTransform interpreter. Notably, the use of attribute filters and `findMarkedOps` is no longer needed. Although, these specific cases were uninteresting: since the `execute*` functions were passed the Operation handle directly... why not just call the pattern on the handle?

Ideally, mapping `Value` to operations would not be needed at all and the operation handles can be passed around directly. However, since not all of the interpreter transformations are targetable (yet) and I am unsure as to what certain transformations should be returning, I left them as is. If these issues are resolved, the interpreter will disappear entirely and `linalg_transform` operations will just be a description on how to construct and chain the functional patterns.

A few other things to note: I added a small scoping mechanism to restrict the application of patterns, and I reimplemented the tracking greedy rewriting using a listener. I also implemented a rollback mechanism for applying chains of patterns, but it's not used anywhere. It's very inefficient (maintains copies of the IR and associates them) because the dialect conversion system is unwieldy. 