### PR TITLE
Add warp_single_lane op to VectorExt dialect

### DIFF
--- a/include/Dialects/VectorExt/VectorExtOps.td
+++ b/include/Dialects/VectorExt/VectorExtOps.td
@@ -59,4 +59,72 @@ def VectorExt_YieldOp : VectorExt_Op<"yield", [
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }
 
+def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_single_lane",
+      [DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+       SingleBlockImplicitTerminator<"vector_ext::YieldOp">,
+       RecursiveSideEffects]> {
+  let summary = "vector.warp_single_lane operation";
+  let description = [{
+    Operation that encapsulate code that should be ran on a single lane within a
+    warp. Any code present in the region would only be executed on first lane
+    based on the laneid paramter. The op assumes `laneid` operand is an id to
+    identify the warp and it goes from 0 to warp_size.
+
+    // TODO: Add warp size as an attribute and support multiple dimensions lane
+    ids.
+
+    Operands are vector values distributed on all threads that may be used by
+    the single lane execution. The matching region argument is a vector of all
+    the values of those threads available to the single active lane. The
+    distributed dimension is implicit based on the shape of the operand and
+    argument. In the future this may be described by an affine map.
+
+    Return values are distributed on all threads using laneId as index. The
+    vector is distributed based on the shape ratio between the vector type of
+    the yield and the result type.
+    If the shapes are the same this means the value is broadcasted to all lanes.
+    In the future the distribution can be made more explicit using affine_maps
+    and will support having multiple Ids.
+
+    During lowering values passed as operands and return value need to be
+    visible to different lanes within the warp. This would usually be done by
+    going through memory.
+
+    Example:
+    ```
+    vector_ext.warp_single_lane (%laneid) {
+      ...
+    }
+
+    %0 = vector_ext.warp_single_lane(%laneid)
+    args(%v0 : vector<4xi32>) -> (vector<1xf32>) {
+    ^bb0(%arg0 : vector<128xi32>) :
+      ...
+      vector_ext.yield %1 : vector<32xf32>
+    }
+    ```
+
+    This may be lowered to an scf.if region as below:
+    ```
+      %cnd = arith.cmpi eq, %laneid, %c0 : index
+      scf.if %cnd {
+         ...
+      }
+    ```
+  }];
+
+  // TODO: Add verifier.
+
+  let arguments = (ins Index:$laneid, Variadic<AnyType>:$args);
+  let results = (outs Variadic<AnyType>:$results);
+  let regions = (region SizedRegion<1>:$warpRegion);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "Value":$laneid)>,
+    // TODO: Add arguments support in the builder.
+    OpBuilder<(ins "TypeRange":$resultTypes, "Value":$laneid)>
+  ];
+}
+
 #endif // DIALECTS_VECTOREXT_VECTOREXTOPS

--- a/include/Dialects/VectorExt/VectorExtOps.td
+++ b/include/Dialects/VectorExt/VectorExtOps.td
@@ -139,7 +139,7 @@ def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_execute_on_lane_0",
   }];
 
   // TODO: Add verifier to check type consistentcy at the region boundary based
-  on warp size and future permutation map.
+  // on warp size and future permutation map.
 
   let arguments = (ins Index:$laneid, Variadic<AnyType>:$args);
   let results = (outs Variadic<AnyType>:$results);

--- a/include/Dialects/VectorExt/VectorExtOps.td
+++ b/include/Dialects/VectorExt/VectorExtOps.td
@@ -59,11 +59,11 @@ def VectorExt_YieldOp : VectorExt_Op<"yield", [
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }
 
-def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_single_lane",
+def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_execute_on_lane_0",
       [DeclareOpInterfaceMethods<RegionBranchOpInterface>,
        SingleBlockImplicitTerminator<"vector_ext::YieldOp">,
        RecursiveSideEffects]> {
-  let summary = "vector.warp_single_lane operation";
+  let summary = "vector.warp_execute_on_lane_0 operation";
   let description = [{
     Operation that encapsulate code that should be ran on a single lane within a
     warp. Any code present in the region would only be executed on first lane
@@ -92,15 +92,8 @@ def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_single_lane",
 
     Example:
     ```
-    vector_ext.warp_single_lane (%laneid) {
+    vector_ext.warp_execute_on_lane_0 (%laneid) {
       ...
-    }
-
-    %0 = vector_ext.warp_single_lane(%laneid)
-    args(%v0 : vector<4xi32>) -> (vector<1xf32>) {
-    ^bb0(%arg0 : vector<128xi32>) :
-      ...
-      vector_ext.yield %1 : vector<32xf32>
     }
     ```
 
@@ -111,6 +104,33 @@ def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_single_lane",
          ...
       }
     ```
+
+    When the region has operands and/or return values:
+    ```
+    %0 = vector_ext.warp_execute_on_lane_0(%laneid)
+    args(%v0 : vector<4xi32>) -> (vector<1xf32>) {
+    ^bb0(%arg0 : vector<128xi32>) :
+      ...
+      vector_ext.yield %1 : vector<32xf32>
+    }
+    ```
+
+    values at the region boundary would go through memory:
+    ```
+    %tmp0 = memreg.alloc() : memref<32xf32, 3>
+    %tmp1 = memreg.alloc() : memref<32xf32, 3>
+    %cnd = arith.cmpi eq, %threadid, %c0 : index
+    vector.store %v0, %tmp0[%threadid] : memref<32xf32>, vector<1xf32>
+    warp_sync
+    scf.if %cnd {
+      %arg0 = vector.load %tmp0[%c0] : memref<32xf32>, vector<32xf32>
+      ...
+      vector.store %1, %tmp1[%c0] : memref<32xf32>, vector<32xf32>
+    }
+    warp_sync
+    %0 = vector.load %tmp1[%threadid] : memref<32xf32>, vector<32xf32>
+    ```
+
   }];
 
   // TODO: Add verifier.

--- a/include/Dialects/VectorExt/VectorExtOps.td
+++ b/include/Dialects/VectorExt/VectorExtOps.td
@@ -90,6 +90,11 @@ def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_execute_on_lane_0",
     visible to different lanes within the warp. This would usually be done by
     going through memory.
 
+    The region is *not* isolated from above. For values coming from the parent
+    region only the lane 0 value will be available so it generally only make
+    sense for uniform values. If all the lanes need to be accessible the value
+    needs to go through region argument.
+
     Example:
     ```
     vector_ext.warp_execute_on_lane_0 (%laneid) {
@@ -133,7 +138,8 @@ def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_execute_on_lane_0",
 
   }];
 
-  // TODO: Add verifier.
+  // TODO: Add verifier to check type consistentcy at the region boundary based
+  on warp size and future permutation map.
 
   let arguments = (ins Index:$laneid, Variadic<AnyType>:$args);
   let results = (outs Variadic<AnyType>:$results);

--- a/test/VectorExt/ops.mlir
+++ b/test/VectorExt/ops.mlir
@@ -29,3 +29,35 @@ func @predicate_results(%pred: vector<32xi1>) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
+
+// -----
+
+func @warp(%laneid: index) {
+  vector_ext.warp_single_lane (%laneid) {
+  }
+  return
+}
+
+// CHECK-LABEL:   func @warp(
+// CHECK-NEXT:      vector_ext.warp_single_lane(%{{.*}}) {
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// -----
+
+func @warp_operand_result(%laneid: index, %v0 : vector<4xi32>) -> (vector<4xi32>) {
+  %2 = vector_ext.warp_single_lane (%laneid)
+  args(%v0 : vector<4xi32>) -> (vector<4xi32>) {
+   ^bb0(%arg0 : vector<128xi32>) :
+    %0 = arith.constant dense<2>: vector<128xi32>
+    %1 = arith.addi %arg0, %0 : vector<128xi32>
+    vector_ext.yield %1 : vector<128xi32>
+  }
+  return %2 : vector<4xi32>
+}
+
+// CHECK-LABEL:   func @warp_operand_result(
+// CHECK-NEXT:      %{{.*}} = vector_ext.warp_single_lane(%{{.*}}) args(%{{.*}} : vector<4xi32>) -> (vector<4xi32>) {
+//      CHECK:        vector_ext.yield %{{.*}} : vector<128xi32>
+// CHECK-NEXT:      }

--- a/test/VectorExt/ops.mlir
+++ b/test/VectorExt/ops.mlir
@@ -33,13 +33,13 @@ func @predicate_results(%pred: vector<32xi1>) {
 // -----
 
 func @warp(%laneid: index) {
-  vector_ext.warp_single_lane (%laneid) {
+  vector_ext.warp_execute_on_lane_0 (%laneid) {
   }
   return
 }
 
 // CHECK-LABEL:   func @warp(
-// CHECK-NEXT:      vector_ext.warp_single_lane(%{{.*}}) {
+// CHECK-NEXT:      vector_ext.warp_execute_on_lane_0(%{{.*}}) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
@@ -47,7 +47,7 @@ func @warp(%laneid: index) {
 // -----
 
 func @warp_operand_result(%laneid: index, %v0 : vector<4xi32>) -> (vector<4xi32>) {
-  %2 = vector_ext.warp_single_lane (%laneid)
+  %2 = vector_ext.warp_execute_on_lane_0 (%laneid)
   args(%v0 : vector<4xi32>) -> (vector<4xi32>) {
    ^bb0(%arg0 : vector<128xi32>) :
     %0 = arith.constant dense<2>: vector<128xi32>
@@ -58,6 +58,6 @@ func @warp_operand_result(%laneid: index, %v0 : vector<4xi32>) -> (vector<4xi32>
 }
 
 // CHECK-LABEL:   func @warp_operand_result(
-// CHECK-NEXT:      %{{.*}} = vector_ext.warp_single_lane(%{{.*}}) args(%{{.*}} : vector<4xi32>) -> (vector<4xi32>) {
+// CHECK-NEXT:      %{{.*}} = vector_ext.warp_execute_on_lane_0(%{{.*}}) args(%{{.*}} : vector<4xi32>) -> (vector<4xi32>) {
 //      CHECK:        vector_ext.yield %{{.*}} : vector<128xi32>
 // CHECK-NEXT:      }


### PR DESCRIPTION
Add a new op that will be useful to do vector programming targeting GPU
warps.