### PR TITLE
Introduce a ScopeOp

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -17,6 +17,7 @@
 include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/Dialect/PDL/IR/PDLTypes.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 
 def Linalg_Transform_Dialect : Dialect {
   let name = "linalg_transform";
@@ -34,6 +35,29 @@ def Linalg_Transform_Dialect : Dialect {
 class Linalg_Transform_Operation<string name, list<OpTrait> props = []>
     : Op<Linalg_Transform_Dialect, name, props> {
   let cppNamespace = "::mlir::linalg::transform";
+}
+
+//===----------------------------------------------------------------------===//
+
+def ScopeOp : Linalg_Transform_Operation<"util.scope",
+    [IsolatedFromAbove, DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
+  let description = [{An operation to restrict transformation scopes.}];
+
+  let regions = (region AnyRegion:$body);
+  let arguments = (ins Variadic<AnyType>:$ins);
+  let results = (outs Variadic<AnyType>:$outs);
+  let assemblyFormat = "`(` operands `)` attr-dict-with-keyword $body `:` functional-type(operands, results)";
+
+  let verifier = [{ return RegionBranchOpInterface::verifyTypes(*this); }];
+}
+
+def ForwardOp : Linalg_Transform_Operation<"util.forward",
+                                           [Terminator, HasParent<"ScopeOp">]> {
+  let description = [{Terminator for a scope operation, indicating the results
+                      that should be forwarded out of the scope.}];
+
+  let arguments = (ins Variadic<AnyType>:$ins);
+  let assemblyFormat = "operands attr-dict `:` type(operands)";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/Dialects/LinalgTransform/ScopedTransform.h
+++ b/include/Dialects/LinalgTransform/ScopedTransform.h
@@ -1,0 +1,33 @@
+//===-- ScopedTransform.h - Utilities for scoped transformations ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef IREE_LLVM_SANDBOX_DIALECTS_LINALGTRANSFORM_SCOPEDTRANSFORM_H
+#define IREE_LLVM_SANDBOX_DIALECTS_LINALGTRANSFORM_SCOPEDTRANSFORM_H
+
+#include "Dialects/LinalgTransform/LinalgTransformOps.h"
+
+namespace mlir {
+namespace linalg {
+namespace transform {
+ScopeOp wrapInScope(Operation *op);
+FailureOr<SmallVector<Operation *>> unwrapScope(ScopeOp scope);
+
+template <typename TransformT>
+auto scoped(Operation *target, TransformT &&transform) {
+  auto scope = wrapInScope(target);
+  Operation &op = *scope.body().front().begin();
+  auto result = transform(scope, &op);
+  if (failed(unwrapScope(scope)) || failed(result))
+    return decltype(result)(failure());
+  return result;
+}
+} // namespace transform
+} // namespace linalg
+} // namespace mlir
+
+#endif // IREE_LLVM_SANDBOX_DIALECTS_LINALGTRANSFORM_SCOPEDTRANSFORM_H

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -75,6 +75,7 @@ add_mlir_library(IREELinalgTensorSandboxRegistration
   ${IREE_LINALG_TENSOR_SANDBOX_LIBRARIES}
 
   # Tests.
+  MLIRLinalgTransformTestPasses
   MLIRTransformsExtTestPasses
   MLIRVectorExtTestPasses
 

--- a/lib/Dialects/LinalgTransform/IR/CMakeLists.txt
+++ b/lib/Dialects/LinalgTransform/IR/CMakeLists.txt
@@ -7,4 +7,5 @@ add_mlir_library(MLIRLinalgTransformOps
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRPDL
+  MLIRControlFlowInterfaces
 )

--- a/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -9,14 +9,27 @@
 #include "Dialects/LinalgTransform/LinalgTransformOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Transforms/InliningUtils.h"
 
 #include "Dialects/LinalgTransform/LinalgTransformOpsDialect.cpp.inc"
 
-void mlir::linalg::transform::LinalgTransformDialect::initialize() {
+using namespace mlir;
+using namespace mlir::linalg;
+
+void transform::LinalgTransformDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "Dialects/LinalgTransform/LinalgTransformOps.cpp.inc"
       >();
+}
+
+void transform::ScopeOp::getSuccessorRegions(
+    Optional<unsigned> index, ArrayRef<Attribute> operands,
+    SmallVectorImpl<RegionSuccessor> &regions) {
+  if (index)
+    regions.emplace_back(getResults());
+  else
+    regions.emplace_back(&body());
 }
 
 #define GET_OP_CLASSES

--- a/lib/Dialects/LinalgTransform/Transforms/CMakeLists.txt
+++ b/lib/Dialects/LinalgTransform/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_library(MLIRLinalgTransformTransforms
+  ScopedTransform.cpp
   TrackingCSE.cpp
   TrackingRewriteDriver.cpp
   TransformInterpreter.cpp

--- a/lib/Dialects/LinalgTransform/Transforms/ScopedTransform.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/ScopedTransform.cpp
@@ -1,0 +1,82 @@
+//===-- ScopedTransform.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialects/LinalgTransform/ScopedTransform.h"
+#include "mlir/Transforms/InliningUtils.h"
+
+using namespace mlir;
+
+namespace {
+struct Rewriter : public PatternRewriter {
+  Rewriter(MLIRContext *ctx) : PatternRewriter(ctx) {}
+};
+} // namespace
+
+linalg::transform::ScopeOp linalg::transform::wrapInScope(Operation *op) {
+  Rewriter rewriter(op->getContext());
+  rewriter.setInsertionPoint(op);
+
+  auto scope = rewriter.create<linalg::transform::ScopeOp>(
+      op->getLoc(), op->getResultTypes(), op->getOperands());
+  Region &body = scope.body();
+  rewriter.setInsertionPointToStart(&body.emplaceBlock());
+  BlockAndValueMapping bv;
+  bv.map(op->getOperands(), body.addArguments(op->getOperandTypes()));
+
+  Operation *cloneInScope = rewriter.clone(*op, bv);
+  rewriter.create<ForwardOp>(op->getLoc(), cloneInScope->getResults());
+
+  rewriter.replaceOp(op, scope.getResults());
+  return scope;
+}
+
+namespace {
+/// Instruct the inliner to inline everything. Scopes have no semantic meaning
+/// so moving operations in and out of them, regardless of whether their
+/// dialects have implemented an inliner interface, is valid.
+struct ScopeInliner : public InlinerInterface {
+  using InlinerInterface::InlinerInterface;
+
+  bool isLegalToInline(Operation *call, Operation *callable,
+                       bool wouldBeCloned) const override {
+    return true;
+  }
+  bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
+                       BlockAndValueMapping &valueMapping) const override {
+    return true;
+  }
+  bool isLegalToInline(Operation *op, Region *dest, bool wouldBeCloned,
+                       BlockAndValueMapping &valueMapping) const override {
+    return true;
+  }
+
+  /// Don't recursively analyze operations, because they can all be "inlined".
+  bool shouldAnalyzeRecursively(Operation *op) const override { return false; }
+
+  /// Replace uses of the results with the `forward` op's operands.
+  void handleTerminator(Operation *op,
+                        ArrayRef<Value> valuesToRepl) const override {
+    assert(isa<linalg::transform::ForwardOp>(op));
+    for (auto value : llvm::zip(op->getOperands(), valuesToRepl))
+      std::get<1>(value).replaceAllUsesWith(std::get<0>(value));
+  }
+};
+} // namespace
+
+FailureOr<SmallVector<Operation *>>
+linalg::transform::unwrapScope(linalg::transform::ScopeOp scope) {
+  ScopeInliner interface(scope->getContext());
+  SmallVector<Operation *> ops;
+  scope.body().walk([&](Operation *op) { ops.push_back(op); });
+  if (failed(inlineRegion(interface, &scope.body(), scope, scope.getOperands(),
+                          scope.getResults(), /*inlineLoc=*/{},
+                          /*shouldCloneInlinedRegion=*/false)))
+    return failure();
+  Rewriter(scope->getContext()).eraseOp(scope);
+  return ops;
+}

--- a/lib/Registration.cpp
+++ b/lib/Registration.cpp
@@ -68,6 +68,7 @@ namespace test_ext {
 void registerTestStagedPatternRewriteDriver();
 void registerTestVectorMaskingUtils();
 void registerTestListenerPasses();
+void registerTestLinalgTransformWrapScope();
 } // namespace test_ext
 } // namespace mlir
 
@@ -75,6 +76,7 @@ void registerTestPasses() {
   mlir::test_ext::registerTestStagedPatternRewriteDriver();
   mlir::test_ext::registerTestVectorMaskingUtils();
   mlir::test_ext::registerTestListenerPasses();
+  mlir::test_ext::registerTestLinalgTransformWrapScope();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/LinalgTransform/scoped.mlir
+++ b/test/LinalgTransform/scoped.mlir
@@ -1,0 +1,30 @@
+// RUN: mlir-proto-opt -test-wrap-scope='opname=arith.addi' %s | FileCheck %s --check-prefix WRAP
+// RUN: mlir-proto-opt -test-unwrap-scope %s | FileCheck %s --check-prefix UNWRAP
+
+// WRAP-LABEL: @test_wrap
+// WRAP-SAME: (%[[ARG0:.*]]: i32) -> i32
+func @test_wrap(%arg0: i32) -> i32 {
+  // WRAP: %[[V:.*]] = linalg_transform.util.scope(%[[ARG0]], %[[ARG0]]) {
+  // WRAP-NEXT: ^[[B:.*]](%[[ARG1:.*]]: i32, %[[ARG2:.*]]: i32):
+  // WRAP-NEXT: %[[ADD:.*]] = arith.addi %[[ARG2]], %[[ARG2]]
+  // WRAP-NEXT: linalg_transform.util.forward %[[ADD]]
+  // WRAP-NEXT: } : (i32, i32) -> i32
+  %0 = arith.addi %arg0, %arg0 : i32
+  // WRAP: return %[[V]]
+  return %0 : i32
+}
+
+// UNWRAP-LABEL: @test_unwrap
+// UNWRAP-SAME: (%[[ARG0:.*]]: i32) -> (i32, i32)
+func @test_unwrap(%arg0: i32) -> (i32, i32) {
+  // UNWRAP: %[[V0:.*]] = arith.addi %[[ARG0]], %[[ARG0]]
+  // UNWRAP-NEXT: %[[V1:.*]] = arith.addi %[[V0]], %[[ARG0]]
+  %0:2 = linalg_transform.util.scope(%arg0) {
+  ^bb0(%arg1: i32):
+    %1 = arith.addi %arg1, %arg1 : i32
+    %2 = arith.addi %1, %arg1 : i32
+    linalg_transform.util.forward %1, %2 : i32, i32
+  } : (i32) -> (i32, i32)
+  // UNWRAP-NEXT: return %[[V0]], %[[V1]]
+  return %0#0, %0#1 : i32, i32
+}

--- a/test/lib/Dialect/CMakeLists.txt
+++ b/test/lib/Dialect/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(LinalgTransform)
 add_subdirectory(VectorExt)

--- a/test/lib/Dialect/LinalgTransform/CMakeLists.txt
+++ b/test/lib/Dialect/LinalgTransform/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_mlir_library(MLIRLinalgTransformTestPasses
+  TestScopedTransform.cpp
+
+  EXCLUDE_FROM_LIBMLIR
+
+  LINK_LIBS PUBLIC
+  MLIRPass
+  MLIRLinalgTransformTransforms
+  )

--- a/test/lib/Dialect/LinalgTransform/TestScopedTransform.cpp
+++ b/test/lib/Dialect/LinalgTransform/TestScopedTransform.cpp
@@ -1,0 +1,57 @@
+//===-- TestScopedTransform.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialects/LinalgTransform/ScopedTransform.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+using namespace mlir::linalg;
+
+namespace {
+struct TestWrapScopePass : public PassWrapper<TestWrapScopePass, Pass> {
+  TestWrapScopePass() = default;
+  TestWrapScopePass(const TestWrapScopePass &other) : PassWrapper(other) {}
+
+  StringRef getArgument() const final { return "test-wrap-scope"; }
+  StringRef getDescription() const final { return "Test wrap scope pass."; }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::transform::LinalgTransformDialect>();
+  }
+
+  void runOnOperation() override {
+    getOperation()->walk([&](Operation *op) {
+      if (op->getName().getStringRef() != opToWrap)
+        return;
+      linalg::transform::wrapInScope(op);
+    });
+  }
+
+  Pass::Option<std::string> opToWrap{*this, "opname",
+                                     llvm::cl::desc("Op to wrap")};
+};
+
+struct TestUnwrapScopePass : public PassWrapper<TestUnwrapScopePass, Pass> {
+  StringRef getArgument() const final { return "test-unwrap-scope"; }
+  StringRef getDescription() const final { return "Test unwrap scope pass."; }
+
+  void runOnOperation() override {
+    getOperation()->walk(
+        [](linalg::transform::ScopeOp scope) { (void)unwrapScope(scope); });
+  }
+};
+} // namespace
+
+namespace mlir {
+namespace test_ext {
+void registerTestLinalgTransformWrapScope() {
+  PassRegistration<TestWrapScopePass>();
+  PassRegistration<TestUnwrapScopePass>();
+}
+} // namespace test_ext
+} // namespace mlir


### PR DESCRIPTION
Depends on https://github.com/google/iree-llvm-sandbox/pull/155

`ScopeOp` is an isolated from above operation that can be used to perform finer-grain application of transformations. Adds two utility functions to wrap a single operation into a scope and then unwrap a scope of many operations.