### PR TITLE
Make plot path controlable from command line.

### DIFF
--- a/python/examples/conv/conv_1d_bench.py
+++ b/python/examples/conv/conv_1d_bench.py
@@ -69,7 +69,8 @@ def main():
                test_sizes(keys, args.problem_sizes_list),
                test_experts(all_experts, all_names, args.expert_list),
                n_iters=n_iters,
-               function_name=fun_name)
+               function_name=fun_name,
+               plot_path=args.plot_path)
 
 
 if __name__ == '__main__':

--- a/python/examples/conv/conv_2d_bench.py
+++ b/python/examples/conv/conv_2d_bench.py
@@ -75,7 +75,7 @@ def main():
       function_name=fun_name,
       dump_ir_to_file='/tmp/abcd.mlir',
       dump_obj_to_file='/tmp/abcd.o',
-  )
+      plot_path=args.plot_path)
 
 
 if __name__ == '__main__':

--- a/python/examples/conv/conv_3d_bench.py
+++ b/python/examples/conv/conv_3d_bench.py
@@ -63,7 +63,8 @@ def main():
                test_sizes(keys, args.problem_sizes_list),
                test_experts(all_experts, all_names, args.expert_list),
                n_iters=n_iters,
-               function_name=fun_name)
+               function_name=fun_name,
+               plot_path=args.plot_path)
 
 
 if __name__ == '__main__':

--- a/python/examples/core/harness.py
+++ b/python/examples/core/harness.py
@@ -465,6 +465,11 @@ def test_argparser(benchmark_name: str,
                       nargs='+',
                       help='problem specifications (e.g., -s mk,kn km,kn)',
                       default=default_spec_list)
+  parser.add_argument('--plot_path',
+                      type=str,
+                      nargs='?',
+                      help='plot path (e.g., --plot_path /tmp/matmul)',
+                      default='')
   return parser.parse_args(sys.argv[1:])
 
 
@@ -601,8 +606,11 @@ def test_harness(problem_factory: Callable[
         measurements.append('pytorch', np_types, dynamic_at_compile_time_sizes,
                             runtime_problem_sizes_dict, timing_results)
 
-    if 'plot_path' in kwargs:
-      measurements.plot(kwargs.get('plot_path'),
+    plot_path = kwargs.get('plot_path', '')
+    if plot_path != '':
+      if not os.path.exists(plot_path):
+        os.makedirs(plot_path)
+      measurements.plot(plot_path,
                         'gflop_per_s_per_iter',
                         'compute throughput [GFlop/s]')
 

--- a/python/examples/depthwise_conv/depthwise_conv_1d_bench.py
+++ b/python/examples/depthwise_conv/depthwise_conv_1d_bench.py
@@ -66,7 +66,7 @@ def main():
       function_name=fun_name,
       dump_ir_to_file='/tmp/abcd.mlir',
       dump_obj_to_file='/tmp/abcd.o',
-  )
+      plot_path=args.plot_path)
 
 
 if __name__ == '__main__':

--- a/python/examples/depthwise_conv/depthwise_conv_2d_bench.py
+++ b/python/examples/depthwise_conv/depthwise_conv_2d_bench.py
@@ -103,7 +103,7 @@ def main():
       function_name=fun_name,
       dump_ir_to_file='/tmp/abcd.mlir',
       dump_obj_to_file='/tmp/abcd.o',
-  )
+      plot_path=args.plot_path)
 
 
 if __name__ == '__main__':

--- a/python/examples/matmul/bench.py
+++ b/python/examples/matmul/bench.py
@@ -152,7 +152,8 @@ def main():
                    dump_ir_to_file='/tmp/abc.mlir',
                    dump_obj_to_file='/tmp/abc.o',
                    numpy_benchmark=numpy_kernel,
-                   pytorch_benchmark=pytorch_kernel)
+                   pytorch_benchmark=pytorch_kernel,
+                   plot_path=args.plot_path)
 
 
 if __name__ == '__main__':

--- a/python/examples/matvec/bench.py
+++ b/python/examples/matvec/bench.py
@@ -81,7 +81,8 @@ def main():
       n_iters=n_iters,
       function_name='matvec_on_tensors',
       numpy_benchmark=numpy_kernel,
-      pytorch_benchmark=pytorch_kernel)
+      pytorch_benchmark=pytorch_kernel,
+      plot_path=args.plot_path)
 
 if __name__ == '__main__':
   main()

--- a/python/examples/padding/padded_conv1d_bench.py
+++ b/python/examples/padding/padded_conv1d_bench.py
@@ -56,7 +56,8 @@ def main():
                test_sizes(keys, args.problem_sizes_list),
                test_experts(all_experts, all_names, args.expert_list),
                n_iters=n_iters,
-               function_name=fun_name)
+               function_name=fun_name,
+               plot_path=args.plot_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a command line argument to control the plot path. By default the benchmarks create no plots. If a plot path is set the directory will be created if it does not exists and the plots are stored to the directory.

Example:
`python -m python.examples.depthwise_conv.depthwise_conv_2d_bench --plot_path '/tmp/conv'`  will plot the benchmark results to /tmp/conv/.