### PR TITLE
Fix error while tiling Linalg operations using scf.for.

### DIFF
--- a/include/Dialects/LinalgExt/LinalgExtOps.h
+++ b/include/Dialects/LinalgExt/LinalgExtOps.h
@@ -16,6 +16,7 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/TilingInterface.h"
+#include "mlir/Support/LLVM.h"
 
 #define GET_OP_CLASSES
 #include "Dialects/LinalgExt/LinalgExtOps.h.inc"

--- a/include/Dialects/LinalgExt/LinalgExtOps.td
+++ b/include/Dialects/LinalgExt/LinalgExtOps.td
@@ -37,7 +37,8 @@ def LinalgExt_ReverseOp : LinalgExt_Op<"reverse", [
     DeclareOpInterfaceMethods<TilingInterface, [
         "getLoopIteratorTypes",
         "getIterationDomain",
-        "getTiledImplementation"]>]> {
+        "getTiledImplementation",
+        "getOutputTileSizes"]>]> {
   let summary = "Reverse operator";
   let description = [{
     Operation to reverse the values along specified dimension(s).

--- a/test/LinalgExt/tile-to-sequential-for.mlir
+++ b/test/LinalgExt/tile-to-sequential-for.mlir
@@ -46,3 +46,4 @@ func @static_tile(%chunk_size: index, %in: tensor<?xf32>, %out: tensor<?xf32>, %
   }
   return %0#0: tensor<?xf32>
 }
+

--- a/test/LinalgExt/tiling.mlir
+++ b/test/LinalgExt/tiling.mlir
@@ -1,5 +1,4 @@
-// RUN: mlir-proto-opt -linalg-ext-tiling="tile-sizes=10,20" -linalg \
-// RUN: -split-input-file -canonicalize -cse %s | FileCheck %s
+// RUN: mlir-proto-opt -linalg-ext-tiling="tile-sizes=10,20" %s | FileCheck %s
 
 func @reverse_1d_tensor(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %c0 = arith.constant 0 : index
@@ -42,5 +41,53 @@ func @reverse_1d_tensor(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
 // CHECK-SAME:           outs(%[[OUT_SLICE]]
 //      CHECK:       %[[INSERT_SLICE:.+]] = tensor.insert_slice %[[RESULT_SLICE]] into %[[ARG2]][%[[IV0]], %[[IV1]]] [%[[T0]], %[[T1]]]
 //      CHECK:       scf.yield %[[INSERT_SLICE]]
+//      CHECK:     scf.yield %[[YIELD]]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func @gemm(%lhs : tensor<?x?xf32>, %rhs : tensor<?x?xf32>,
+    %init : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = linalg.matmul
+      ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0)[s0] -> (10, -d0 + s0)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0)[s0] -> (20, -d0 + s0)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1)[s0] -> (d0, -d1 + s0)>
+//  CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0] -> (s0, s0)>
+//      CHECK: func @gemm
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[N:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//      CHECK:   %[[RESULT:.+]] = scf.for %[[IV0:[a-zA-Z0-9]+]] =
+// CHECK-SAME:       iter_args(%[[ARG4:.+]] = %[[ARG2]])
+//      CHECK:     %[[YIELD:.+]] = scf.for %[[IV1:[a-zA-Z0-9]+]] =
+// CHECK-SAME:         iter_args(%[[ARG6:.+]] = %[[ARG4]])
+//  CHECK-DAG:       %[[TILESIZE_Y:.+]] = affine.min #[[MAP0]](%[[IV0]])[%[[M]]]
+//  CHECK-DAG:       %[[TILESIZE_X:.+]] = affine.min #[[MAP1]](%[[IV1]])[%[[N]]]
+//  CHECK-DAG:       %[[M_1:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:       %[[K:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//  CHECK-DAG:       %[[N_1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//  CHECK-DAG:       %[[TILESIZE_Y_1:.+]] = affine.min #[[MAP2]](%[[TILESIZE_Y]], %[[IV0]])[%[[M_1]]]
+//  CHECK-DAG:       %[[K_1:.+]] = affine.min #[[MAP3]]()[%[[K]]]
+//  CHECK-DAG:       %[[LHS_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[IV0]], %[[C0]]] [%[[TILESIZE_Y_1]], %[[K_1]]]
+//  CHECK-DAG:       %[[K_2:.+]] = affine.min #[[MAP3]]()[%[[K]]]
+//  CHECK-DAG:       %[[TILESIZE_X_1:.+]] = affine.min #[[MAP2]](%[[TILESIZE_X]], %[[IV1]])[%[[N_1]]]
+//  CHECK-DAG:       %[[RHS_SLICE:.+]] = tensor.extract_slice %[[ARG1]][%[[C0]], %[[IV1]]] [%[[K_2]], %[[TILESIZE_X_1]]]
+//  CHECK-DAG:       %[[TILESIZE_Y_2:.+]] = affine.min #[[MAP2]](%[[TILESIZE_Y]], %[[IV0]])[%[[M_1]]]
+//  CHECK-DAG:       %[[TILESIZE_X_2:.+]] = affine.min #[[MAP2]](%[[TILESIZE_X]], %[[IV1]])[%[[N_1]]]
+//  CHECK-DAG:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[ARG2]][%[[IV0]], %[[IV1]]] [%[[TILESIZE_Y_2]], %[[TILESIZE_X_2]]]
+//      CHECK:       %[[RESULT_SLICE:.+]] = linalg.matmul
+// CHECK-SAME:           ins(%[[LHS_SLICE]], %[[RHS_SLICE]]
+// CHECK-SAME:           outs(%[[OUT_SLICE]]
+//      CHECK:       %[[YIELD_INNER:.+]] = tensor.insert_slice %[[RESULT_SLICE]] into %[[ARG6]]
+// CHECK-SAME:           [%[[IV0]], %[[IV1]]] [%[[TILESIZE_Y]], %[[TILESIZE_X]]]
+//      CHECK:       scf.yield %[[YIELD_INNER]]
 //      CHECK:     scf.yield %[[YIELD]]
 //      CHECK:   return %[[RESULT]]


### PR DESCRIPTION
Tiling using switch of op -> extract_slice can only give you the tile
sizes of the loops used to access the outputs. The tile sizes of the
other dimension have to be set to untiled values for tiling to work.