### PR TITLE
Introduce an "expert" operation and its expansion with PDL

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -147,4 +147,20 @@ def LowerToLLVMOp : Linalg_Transform_Operation<"lower_to_llvm"> {
   let assemblyFormat = "attr-dict";
 }
 
+//===----------------------------------------------------------------------===//
+
+def ExpertOp : Linalg_Transform_Operation<"expert", [TargetableOpTrait]> {
+  let description = [{A "transformation expert" that can be lowered to a
+  sequence of transformations. The details of the lowering depend on the name
+  and are expressed declaratively.}];
+
+  let arguments = (ins Optional<PDL_Operation>:$target,
+                   OptionalAttr<SymbolRefAttr>:$targetMatcher,
+                   StrAttr:$expertName);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "`apply` $expertName (`to` $target^)? "
+                       "(`when` $targetMatcher^)? attr-dict";
+}
+
 #endif // LINALG_TRANSFORM_OPS

--- a/include/Dialects/LinalgTransform/Passes.h
+++ b/include/Dialects/LinalgTransform/Passes.h
@@ -3,6 +3,7 @@ namespace linalg {
 namespace transform {
 
 void registerLinalgTransformInterpreterPass();
+void registerLinalgTransformExpertExpansionPass();
 
 } // namespace transform
 } // namespace linalg

--- a/include/Dialects/LinalgTransform/SimplePatternRewriter.h
+++ b/include/Dialects/LinalgTransform/SimplePatternRewriter.h
@@ -1,0 +1,22 @@
+//===-- SimplePatternRewriter.h - Utility for IR rewrites -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+
+class MLIRContext;
+
+/// The only purpose of this class is to enable creation of PatternRewriter
+/// instances as the base class doesn't have a public constructor.
+class SimplePatternRewriter : public PatternRewriter {
+public:
+  explicit SimplePatternRewriter(MLIRContext *ctx) : PatternRewriter(ctx) {}
+};
+
+} // namespace mlir

--- a/lib/Dialects/LinalgTransform/Transforms/CMakeLists.txt
+++ b/lib/Dialects/LinalgTransform/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_library(MLIRLinalgTransformTransforms
+  ExpertExpansion.cpp
   ScopedTransform.cpp
   TrackingCSE.cpp
   TrackingRewriteDriver.cpp

--- a/lib/Dialects/LinalgTransform/Transforms/ExpertExpansion.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/ExpertExpansion.cpp
@@ -1,0 +1,108 @@
+//===-- ExpertExpansion.cpp - Expand "expert"s to transforms with PDL -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialects/LinalgTransform/LinalgTransformOps.h"
+#include "Dialects/LinalgTransform/Passes.h"
+#include "Dialects/LinalgTransform/SimplePatternRewriter.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Rewrite/PatternApplicator.h"
+#include "llvm/Support/Debug.h"
+#include <memory>
+
+#define DEBUG_TYPE "expert-expansion"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]")
+
+using namespace mlir;
+using namespace mlir::linalg;
+
+/// Expands the linalg::transform::ExpertOp instances in the `module` into lists
+/// of transformations as described by the `expansions` module that contains
+/// PDL.
+static void expandStrategyOps(ModuleOp module, ModuleOp expansions) {
+  OwningModuleRef clonedExpansions(cast<ModuleOp>(expansions->clone()));
+  RewritePatternSet patterns(std::move(clonedExpansions));
+  FrozenRewritePatternSet frozen(std::move(patterns));
+  PatternApplicator applicator(frozen);
+  applicator.applyDefaultCostModel();
+
+  SimplePatternRewriter rewriter(module.getContext());
+  module.walk([&](transform::ExpertOp expertOp) {
+    rewriter.setInsertionPoint(expertOp);
+    if (failed(applicator.matchAndRewrite(expertOp, rewriter))) {
+      LLVM_DEBUG(DBGS() << "failed to rewrite strategy \""
+                        << expertOp.expertName() << "\"\n");
+    }
+  });
+}
+
+namespace {
+struct ExpertExpansion : public PassWrapper<ExpertExpansion, Pass> {
+  Pass::Option<std::string> strategyModuleName{
+      *this, "strategy-module-name", llvm::cl::init("strategies"),
+      llvm::cl::desc(
+          "Name of the nested module containing expert strategies.")};
+
+  explicit ExpertExpansion(StringRef name = "strategies")
+      : PassWrapper<ExpertExpansion, Pass>() {
+    strategyModuleName = name.str();
+  }
+  ExpertExpansion(const ExpertExpansion &other)
+      : PassWrapper<ExpertExpansion, Pass>(other) {
+    strategyModuleName = other.strategyModuleName.getValue();
+  }
+
+  StringRef getArgument() const final {
+    return "linalg-transform-expert-expansion";
+  }
+  StringRef getDescription() const final {
+    return "Expands transformation experts into individual transformations";
+  }
+
+  void runOnOperation() override {
+    auto module = dyn_cast<ModuleOp>(getOperation());
+    if (!module)
+      return signalPassFailure();
+
+    ModuleOp strategyModule = nullptr;
+    for (auto nestedModule : module.getOps<ModuleOp>()) {
+      Optional<StringRef> name = nestedModule.sym_name();
+      if (!name)
+        continue;
+
+      if (*name == strategyModuleName) {
+        if (!strategyModule) {
+          strategyModule = nestedModule;
+          continue;
+        }
+        InFlightDiagnostic diag = nestedModule->emitError()
+                                  << "more than one strategy module provided";
+        diag.attachNote(strategyModule->getLoc()) << "previous strategy module";
+        return signalPassFailure();
+      }
+    }
+
+    if (!strategyModule) {
+      module->emitError() << "expected a nested strategy module";
+      return signalPassFailure();
+    }
+
+    expandStrategyOps(module, strategyModule);
+    strategyModule->erase();
+  }
+};
+} // namespace
+
+void mlir::linalg::transform::registerLinalgTransformExpertExpansionPass() {
+  PassRegistration<ExpertExpansion>(
+      []() { return std::make_unique<ExpertExpansion>(); });
+}

--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -15,6 +15,7 @@
 #include "Dialects/LinalgTransform/LinalgTransformOps.h"
 #include "Dialects/LinalgTransform/Passes.h"
 #include "Dialects/LinalgTransform/ScopedTransform.h"
+#include "Dialects/LinalgTransform/SimplePatternRewriter.h"
 #include "Dialects/LinalgTransform/TrackingCSE.h"
 #include "Dialects/LinalgTransform/TrackingRewriteDriver.h"
 #include "Transforms/Functional.h"

--- a/lib/Registration.cpp
+++ b/lib/Registration.cpp
@@ -91,6 +91,7 @@ void mlir::registerOutsideOfDialectRegistry() {
   registerExperimentalPasses();
   registerTestPasses();
   transform::registerLinalgTransformInterpreterPass();
+  transform::registerLinalgTransformExpertExpansionPass();
 }
 
 void mlir::registerIntoDialectRegistry(DialectRegistry &registry) {

--- a/test/LinalgTransform/expert.mlir
+++ b/test/LinalgTransform/expert.mlir
@@ -1,0 +1,177 @@
+// RUN: mlir-proto-opt -linalg-transform-expert-expansion -split-input-file %s | FileCheck %s --check-prefix=EXPAND
+// RUN: mlir-proto-opt -linalg-transform-expert-expansion -linalg-interp-transforms -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func @matmul_tensors
+// CHECK-NOT: linalg
+// CHECK: llvm
+func @matmul_tensors(
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+    -> tensor<128x128xf32> {
+  %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
+                     outs(%arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32>
+
+  return %0 : tensor<128x128xf32>
+}
+
+pdl.pattern @pdl_target : benefit(1) {
+  %args = pdl.operands
+  %results = pdl.types
+  %0 = pdl.operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  pdl.apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  pdl.rewrite %0 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  // This should match the strategy below.
+  // EXPAND-NOT: expert apply
+  // EXPAND: %[[HANDLE:.*]] = tile when @pdl_target {sizes = [4, 4, 4]}
+  // EXPAND: %[[HANDLE2:.*]] = vectorize %[[HANDLE]] {vectorize_padding = true}
+  // EXPAND: bufferize
+  // EXPAND: lower_vectors {multireduction_lowering = "innerreduce"}
+  // EXPAND: lower_to_llvm
+  expert apply "single_tiling" when @pdl_target
+  {
+    tile_sizes = [4, 4, 4],
+    vectorize_padding = true,
+    multireduction_lowering = "innerreduce"
+  }
+}
+
+// CHECK-NOT: @strategies
+// EXPAND-NOT: @strategies
+module @strategies {
+  pdl.pattern @single_tiling_matcher : benefit(1) {
+    %tile_sizes = pdl.attribute
+    %vectorize_padding = pdl.attribute
+    %multireduction_lowering = pdl.attribute
+    %name = pdl.attribute : "single_tiling"
+    %target = pdl.attribute
+    %transformed = pdl.type
+    %root = pdl.operation "linalg_transform.expert" {
+      "expertName" = %name,
+      "targetMatcher" = %target,
+      "tile_sizes" = %tile_sizes,
+      "vectorize_padding" = %vectorize_padding,
+      "multireduction_lowering" = %multireduction_lowering
+    } -> (%transformed : !pdl.type)
+
+    pdl.rewrite %root {
+      %tile = pdl.operation "linalg_transform.tile"  {
+        "targetMatcher" = %target,
+        "sizes" = %tile_sizes
+      } -> (%transformed : !pdl.type)
+      %handle = pdl.result 0 of %tile
+
+      %vectorize = pdl.operation "linalg_transform.vectorize"(%handle : !pdl.value) {
+        "vectorize_padding" = %vectorize_padding
+      } -> (%transformed : !pdl.type)
+      %handle2 = pdl.result 0 of %vectorize
+
+      // FIXME: must explicitly query results, otherwise the op is not produced
+      %bufferize = pdl.operation "linalg_transform.bufferize"
+      pdl.results of %bufferize
+
+      // FIXME: must explicitly query results, otherwise the op is not produced
+      %lower_vectors = pdl.operation "linalg_transform.lower_vectors" {
+        "multireduction_lowering" = %multireduction_lowering
+      }
+      pdl.results of %lower_vectors
+
+      // FIXME: must explicitly query results, otherwise the op is not produced
+      %lower_to_llvm = pdl.operation "linalg_transform.lower_to_llvm"
+      pdl.results of %lower_to_llvm
+
+      pdl.replace %root with (%handle2 : !pdl.value)
+    }
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func @matmul_tensors2
+// CHECK-NOT: linalg
+// CHECK: llvm
+func @matmul_tensors2(
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+    -> tensor<128x128xf32> {
+  %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
+                     outs(%arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32>
+
+  return %0 : tensor<128x128xf32>
+}
+
+pdl.pattern @pdl_target2 : benefit(1) {
+  %args = pdl.operands
+  %results = pdl.types
+  %0 = pdl.operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  pdl.apply_native_constraint "nestedInFunc"[@matmul_tensors2](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  pdl.rewrite %0 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  // This should match the strategy below.
+  // EXPAND-NOT: expert apply
+  // EXPAND: %[[HANDLE:.*]] = tile when @pdl_target2 {sizes = [32, 8, 8]}
+  // EXPAND: %[[HANDLE2:.*]] = tile %[[HANDLE]] {sizes = [4, 4, 4]}
+  // EXPAND: %[[HANDLE3:.*]] = vectorize %[[HANDLE2]] {vectorize_padding = false}
+  // EXPAND: bufferize
+  // EXPAND: lower_vectors {multireduction_lowering = "innerparallel"}
+  // EXPAND: lower_to_llvm
+  %0 = tile when @pdl_target2 {sizes = [32, 8, 8]}
+  expert apply "single_tiling" to %0
+  {
+    tile_sizes = [4, 4, 4],
+    vectorize_padding = false,
+    multireduction_lowering = "innerparallel"
+  }
+}
+
+module @strategies {
+  pdl.pattern @single_tiling_operand : benefit(1) {
+    %tile_sizes = pdl.attribute
+    %vectorize_padding = pdl.attribute
+    %multireduction_lowering = pdl.attribute
+    %name = pdl.attribute : "single_tiling"
+    %type = pdl.type : !pdl.operation
+    %target = pdl.operand : %type
+    %transformed = pdl.type
+    %root = pdl.operation "linalg_transform.expert"(%target : !pdl.value) {
+      "expertName" = %name,
+      "tile_sizes" = %tile_sizes,
+      "vectorize_padding" = %vectorize_padding,
+      "multireduction_lowering" = %multireduction_lowering
+    } -> (%transformed : !pdl.type)
+
+    pdl.rewrite %root {
+      %tile = pdl.operation "linalg_transform.tile"(%target : !pdl.value)  {
+        "sizes" = %tile_sizes
+      } -> (%transformed : !pdl.type)
+      %handle = pdl.result 0 of %tile
+
+      %vectorize = pdl.operation "linalg_transform.vectorize"(%handle : !pdl.value) {
+        "vectorize_padding" = %vectorize_padding
+      } -> (%transformed : !pdl.type)
+      %handle2 = pdl.result 0 of %vectorize
+
+      // FIXME: must explicitly query results, otherwise the op is not produced
+      %bufferize = pdl.operation "linalg_transform.bufferize"
+      pdl.results of %bufferize
+
+      // FIXME: must explicitly query results, otherwise the op is not produced
+      %lower_vectors = pdl.operation "linalg_transform.lower_vectors" {
+        "multireduction_lowering" = %multireduction_lowering
+      }
+      pdl.results of %lower_vectors
+
+      // FIXME: must explicitly query results, otherwise the op is not produced
+      %lower_to_llvm = pdl.operation "linalg_transform.lower_to_llvm"
+      pdl.results of %lower_to_llvm
+
+      pdl.replace %root with (%handle2 : !pdl.value)
+    }
+  }
+}


### PR DESCRIPTION
Introduce a new "expert" operation into the LinalgTransform dialect.
This operation provides a mechanism to associate expert names with lists
of transformations, all described using the PDL dialect. In future, the
PDL IR can be generated from some higher-level frontend.