### PR TITLE
Implement ViewLikeInterface for ParallelInsertSliceOp

### DIFF
--- a/include/Dialects/LinalgExt/LinalgExtOps.td
+++ b/include/Dialects/LinalgExt/LinalgExtOps.td
@@ -14,6 +14,7 @@ include "Dialects/LinalgExt/LinalgExtInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/TilingInterface.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 
 class LinalgExt_PureOp<string mnemonic, list<OpTrait> traits = []> :
     Op<LinalgExt_Dialect, mnemonic, traits> {
@@ -286,7 +287,7 @@ def LinalgExt_EndPerformConcurrentlyOp : LinalgExt_PureOp<"end_perform_concurren
 }
 
 def LinalgExt_ParallelInsertSliceOp : LinalgExt_PureOp<"parallel_insert_slice", [
-       AttrSizedOperandSegments]> {
+       AttrSizedOperandSegments, OffsetSizeAndStrideOpInterface]> {
   let summary = "updates slices of a tensor concurrently";
   let description = [{
     Updates slices of a full tensor with multiple sub-slices concurrently.
@@ -313,16 +314,51 @@ def LinalgExt_ParallelInsertSliceOp : LinalgExt_PureOp<"parallel_insert_slice", 
     AnyRankedTensor:$dest,
     Variadic<Index>:$offsets,
     Variadic<Index>:$sizes,
-    Variadic<Index>:$strides
+    Variadic<Index>:$strides,
+    I64ArrayAttr:$static_offsets,
+    I64ArrayAttr:$static_sizes,
+    I64ArrayAttr:$static_strides
   );
   let assemblyFormat = [{
-    $source `into` $dest `[` $offsets `]` `[` $sizes `]` `[` $strides `]`
+    $source `into` $dest ``
+    custom<OperandsOrIntegersOffsetsOrStridesList>($offsets, $static_offsets)
+    custom<OperandsOrIntegersSizesList>($sizes, $static_sizes)
+    custom<OperandsOrIntegersOffsetsOrStridesList>($strides, $static_strides)
     attr-dict `:` type($source) `into` type($dest)
   }];
 
   let extraClassDeclaration = [{
     Type yieldedType() { return dest().getType(); }
+
+    RankedTensorType getSourceType() {
+      return source().getType().cast<RankedTensorType>();
+    }
+
+    /// Return the expected rank of each of the `static_offsets`, `static_sizes`
+    /// and `static_strides` attributes.
+    std::array<unsigned, 3> getArrayAttrMaxRanks() {
+      unsigned rank = getSourceType().getRank();
+      return {rank, rank, rank};
+    }
+
+    /// Return the number of leading operands before `offsets`, `sizes` and
+    /// `strides` operands.
+    static unsigned getOffsetSizeAndStrideStartOperandIndex() { return 1; }
   }];
+
+  let builders = [
+    // Build a ParallelInsertSliceOp with mixed static and dynamic entries.
+    OpBuilder<(ins "Value":$source, "Value":$dest,
+      "ArrayRef<OpFoldResult>":$offsets, "ArrayRef<OpFoldResult>":$sizes,
+      "ArrayRef<OpFoldResult>":$strides,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>,
+    // Build a ParallelInsertSliceOp with dynamic entries.
+    OpBuilder<(ins "Value":$source, "Value":$dest,
+      "ValueRange":$offsets, "ValueRange":$sizes, "ValueRange":$strides,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>
+  ];
+
+  let hasCanonicalizer = 1;
 }
 
 #endif // DIALECTS_LINALGEXT_LINALGEXTOPS

--- a/lib/Dialects/LinalgExt/Transforms/InParallelToSequentialFor.cpp
+++ b/lib/Dialects/LinalgExt/Transforms/InParallelToSequentialFor.cpp
@@ -78,8 +78,8 @@ struct InParallelOpToSCFRewriter
     rewriter.setInsertionPoint(performConcurrentlyOp);
     for (ParallelInsertSliceOp op : performConcurrentlyOp.yieldingOps()) {
       toYield.push_back(rewriter.createOrFold<tensor::InsertSliceOp>(
-          loc, op.source(), bvm.lookup(op.dest()), op.offsets(), op.sizes(),
-          op.strides()));
+          loc, op.source(), bvm.lookup(op.dest()), op.getMixedOffsets(),
+          op.getMixedSizes(), op.getMixedStrides()));
     }
 
     // performConcurrentlyOp.yieldedValues come from above, not from bbArgs.

--- a/test/LinalgExt/canonicalize.mlir
+++ b/test/LinalgExt/canonicalize.mlir
@@ -1,0 +1,22 @@
+// RUN: mlir-proto-opt %s -canonicalize | FileCheck %s
+
+// CHECK-LABEL: func @canonicalize_insert_slice_indices(
+//  CHECK-SAME:     %[[arg0:.*]]: tensor<?x?xf32>, %[[arg1:.*]]: tensor<?x?xf32>,
+//  CHECK-SAME:     %[[idx:.*]]: index
+func @canonicalize_insert_slice_indices(
+    %arg0 : tensor<?x?xf32>, %arg1: tensor<?x?xf32>,
+    %idx : index) -> tensor<?x?xf32>
+{
+  %cst = arith.constant 4.200000e+01 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  %2 = linalg_ext.in_parallel %idx  -> (tensor<?x?xf32>) {
+    ^bb0(%arg3: index):  // no predecessors
+      linalg_ext.perform_concurrently {
+        // CHECK: linalg_ext.parallel_insert_slice %[[arg0]] into %arg1[%[[idx]], 0] [1, 5] [1, 1]
+        linalg_ext.parallel_insert_slice %arg0 into %arg1[%idx, %c0] [%c1, 5] [%c1, %c1] : tensor<?x?xf32> into tensor<?x?xf32>
+      }
+  }
+  return %2 : tensor<?x?xf32>
+}


### PR DESCRIPTION
This is needed for bufferization to be able to match
ParallelInsertSliceOp/ExtractSliceOp equivalents.