### PR TITLE
Make Python harness compatible with Python 3.7

### DIFF
--- a/python/examples/core/harness.py
+++ b/python/examples/core/harness.py
@@ -1,3 +1,5 @@
+# Make dict a generic (type-subscriptable) type for Python <3.9.
+from __future__ import annotations
 import argparse
 import re
 import sys


### PR DESCRIPTION
Otherwise, the requirement would be Python 3.9.