### PR TITLE
Bufferize InParallelOp

### DIFF
--- a/include/Dialects/LinalgExt/LinalgExtBufferization.h
+++ b/include/Dialects/LinalgExt/LinalgExtBufferization.h
@@ -1,0 +1,23 @@
+//===-- LinalgExtBufferization.h - Linalg Extension bufferization ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DIALECTS_LINALGEXT_BUFFERIZATION_H
+#define DIALECTS_LINALGEXT_BUFFERIZATION_H
+
+namespace mlir {
+
+class DialectRegistry;
+
+namespace linalg_ext {
+
+void registerBufferizableOpInterfaceExternalModels(DialectRegistry &registry);
+
+} // namespace linalg_ext
+} // namespace mlir
+
+#endif // DIALECTS_LINALGEXT_BUFFERIZATION_H

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(Transforms)
 
 set(IREE_LINALG_TENSOR_SANDBOX_LIBRARIES
   MLIRLinalgExt
+  MLIRLinalgExtOpInterfaceImpl
   MLIRLinalgExtTransforms
   MLIRLinalgTransformOps
   MLIRLinalgTransformTransforms
@@ -44,6 +45,7 @@ add_mlir_library(IREELinalgTensorSandboxDriver
   MLIRAsync
   MLIRGPUOps
   MLIRLinalg
+  MLIRLinalgExtOpInterfaceImpl
   MLIRLinalgTransforms
   MLIRAffineToStandard
   MLIRMemRefTransforms

--- a/lib/Dialects/LinalgExt/Transforms/CMakeLists.txt
+++ b/lib/Dialects/LinalgExt/Transforms/CMakeLists.txt
@@ -30,3 +30,12 @@ add_mlir_library(MLIRLinalgExtTransforms
   MLIRSCF
   MLIRTransforms
 )
+
+add_mlir_library(MLIRLinalgExtOpInterfaceImpl
+  LinalgExtBufferization.cpp
+
+  PARTIAL_SOURCES_INTENDED
+  LINK_LIBS PUBLIC
+  MLIRBufferizableOpInterface
+  MLIRLinalgExt
+)

--- a/lib/Dialects/LinalgExt/Transforms/LinalgExtBufferization.cpp
+++ b/lib/Dialects/LinalgExt/Transforms/LinalgExtBufferization.cpp
@@ -1,0 +1,338 @@
+//===-- LinalgExtBufferization.cpp - Linalg Extension bufferization -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <mlir/IR/BuiltinOps.h>
+
+#include "Dialects/LinalgExt/LinalgExtBufferization.h"
+#include "Dialects/LinalgExt/LinalgExtOps.h"
+#include "mlir/Dialect/Linalg/ComprehensiveBufferize/BufferizableOpInterface.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+
+using linalg::comprehensive_bufferize::BufferizableOpInterface;
+using linalg::comprehensive_bufferize::BufferizationAliasInfo;
+using linalg::comprehensive_bufferize::BufferizationState;
+using linalg::comprehensive_bufferize::BufferRelation;
+using linalg::comprehensive_bufferize::replaceOpWithBufferizedValues;
+using linalg::comprehensive_bufferize::replaceOpWithNewBufferizedOp;
+using linalg::comprehensive_bufferize::getDynamicMemRefType;
+using tensor::ExtractSliceOp;
+
+namespace linalg_ext {
+
+/// Return the destinations that an InParallelOp is inserting into. One per
+/// ParallelInsertSliceOp.
+static SmallVector<OpOperand *> getInsertionDest(InParallelOp inParallelOp) {
+  Operation *terminator = inParallelOp.region().front().getTerminator();
+  auto performConcOp = dyn_cast<PerformConcurrentlyOp>(terminator);
+  assert(performConcOp && "expected PerformConcurrentlyOp as terminator");
+
+  SmallVector<OpOperand *> result;
+  performConcOp.walk([&](ParallelInsertSliceOp insertOp) {
+    result.push_back(&insertOp->getOpOperand(1) /*dest*/);
+  });
+
+  return result;
+}
+
+/// Bufferization of InParallelOp. This also bufferizes the terminator of the
+/// region. There are op interfaces for the terminators (PerformConcurrentlyOp
+/// and ParallelInsertSliceOp), but these are only used during analysis. Not
+/// for bufferization.
+struct InParallelOpInterface
+    : public BufferizableOpInterface::ExternalModel<InParallelOpInterface,
+                                                    InParallelOp> {
+  SmallVector<OpOperand *> getAliasingOpOperand(
+      Operation *op, OpResult opResult,
+      const BufferizationState &state) const {
+    // Get OpOperand (dest) from corresponding ParallelInsertSliceOp.
+    auto inParallelOp = cast<InParallelOp>(op);
+    return {getInsertionDest(inParallelOp)[opResult.getResultNumber()]};
+  }
+
+  bool isMemoryWrite(
+      Operation *op, OpResult opResult,
+      const BufferizationState &state) const {
+    // This op is a memory write. Stop lookup here to avoid finding false
+    // conflicts involving this op and one of the ops in the region. This is
+    // similar to how scf.if ops are analyzed.
+    return true;
+  }
+
+  BufferRelation bufferRelation(Operation *op, OpResult opResult,
+                                const BufferizationAliasInfo &aliasInfo,
+                                const BufferizationState &state) const {
+    return BufferRelation::Equivalent;
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &b,
+                          const BufferizationState &state) const {
+    OpBuilder::InsertionGuard g(b);
+    auto inParallelOp = cast<InParallelOp>(op);
+    Block *body = &inParallelOp.region().front();
+    Operation *oldTerminator = body->getTerminator();
+    assert(isa<PerformConcurrentlyOp>(oldTerminator)
+           && "unexpected terminator");
+
+    // Gather new results of the InParallelOp.
+    SmallVector<Value> newResults;
+    for (OpResult opResult : inParallelOp->getOpResults()) {
+      SmallVector<OpOperand *> insertDestOperands =
+          state.getAliasingOpOperand(opResult);
+      assert(insertDestOperands.size() == 1 &&
+             "expected exactly one aliasing OpOperand");
+      // Insert copies right before the PerformConcurrentlyOp terminator. They
+      // should not be inside terminator (which would be the default insertion
+      // point).
+      Value buffer = *state.getBuffer(
+          b, *insertDestOperands.front(), /*forceInPlace=*/false,
+          /*customCopyInsertionPoint=*/oldTerminator);
+      newResults.push_back(buffer);
+      Value destTensor = insertDestOperands.front()->get();
+
+      // Replace all uses of the insert dest tensor inside the InParallelOp
+      // with the result buffer.
+      OpBuilder::InsertionGuard g(b);
+      b.setInsertionPointToStart(body);
+      Value toTensorOp =
+          b.create<bufferization::ToTensorOp>(inParallelOp.getLoc(), buffer);
+      for (OpOperand &use : destTensor.getUses())
+        if (body->findAncestorOpInBlock(*use.getOwner()))
+          // This is a use inside the InParallelOp.
+          use.set(toTensorOp);
+    }
+
+    // Create new InParallelOp without any results.
+    TypeRange newResultTypes;
+    auto newInParallelOp = b.create<InParallelOp>(
+        inParallelOp.getLoc(), newResultTypes, inParallelOp.num_threads());
+
+    // Delete terminator.
+    newInParallelOp.getBody()->getTerminator()->erase();
+
+    // Move over block contents of the old op.
+    b.mergeBlocks(inParallelOp.getBody(), newInParallelOp.getBody(),
+                  {newInParallelOp.getBody()->getArgument(0)});
+
+    // Bufferize terminator.
+    auto performConcurrentlyOp = cast<PerformConcurrentlyOp>(
+        newInParallelOp.getBody()->getTerminator());
+    b.setInsertionPoint(performConcurrentlyOp);
+    performConcurrentlyOp.walk([&](ParallelInsertSliceOp insertOp) {
+      Location loc = insertOp.getLoc();
+      Type srcType = getDynamicMemRefType(
+          insertOp.source().getType().cast<RankedTensorType>());
+      Type destType = getDynamicMemRefType(
+          insertOp.dest().getType().cast<RankedTensorType>());
+      // ParallelInsertSliceOp bufferizes to a copy.
+      auto srcMemref =
+          b.create<bufferization::ToMemrefOp>(loc, srcType, insertOp.source());
+      auto destMemref =
+          b.create<bufferization::ToMemrefOp>(loc, destType, insertOp.dest());
+      Value subview = b.create<memref::SubViewOp>(
+        loc, destMemref, insertOp.getMixedOffsets(), insertOp.getMixedSizes(),
+        insertOp.getMixedStrides());
+      // This memcpy will fold away if everything bufferizes in-place.
+      state.createMemCpy(b, insertOp.getLoc(), srcMemref, subview);
+      b.eraseOp(insertOp);
+    });
+
+    // Replace the op.
+    replaceOpWithBufferizedValues(b, op, newResults);
+
+    return success();
+  }
+};
+
+/// Nothing to do for PerformConcurrentlyOp.
+struct PerformConcurrentlyOpInterface
+    : public BufferizableOpInterface::ExternalModel<
+          PerformConcurrentlyOpInterface, PerformConcurrentlyOp> {
+  LogicalResult bufferize(Operation *op, RewriterBase &b,
+                          const BufferizationState &state) const {
+    llvm_unreachable("op does not have any tensor OpOperands / OpResults");
+    return failure();
+  }
+};
+
+/// Return true if the (ExtractSliceOp, ParallelInsertSliceOp) pair match (i.e.
+/// equivalent operand / result and same offset/sizes/strides specification).
+static bool
+areEquivalentExtractSliceOps(const BufferizationAliasInfo &aliasInfo,
+                             ExtractSliceOp st, ParallelInsertSliceOp sti) {
+  if (!st || !sti)
+    return false;
+  if (!aliasInfo.areEquivalentBufferizedValues(st.source(), sti.dest()))
+    return false;
+  if (!sameOffsetsSizesAndStrides(st, sti, isEqualConstantIntOrValue))
+    return false;
+  return true;
+}
+
+/// Return true if `value` is originating from an ExtractSliceOp that matches
+/// the given InsertSliceOp.
+static bool hasMatchingExtractSliceOp(const BufferizationAliasInfo &aliasInfo,
+                                      const BufferizationState &state,
+                                      Value value, ParallelInsertSliceOp insertOp) {
+  auto condition = [&](Value val) {
+    if (auto extractOp = val.getDefiningOp<ExtractSliceOp>())
+      if (areEquivalentExtractSliceOps(aliasInfo, extractOp, insertOp))
+        return true;
+    return false;
+  };
+
+  return llvm::all_of(state.findValueInReverseUseDefChain(value, condition),
+                      condition);
+}
+
+/// Analysis of ParallelInsertSliceOp.
+struct ParallelInsertSliceOpInterface
+    : public BufferizableOpInterface::ExternalModel<
+          ParallelInsertSliceOpInterface, ParallelInsertSliceOp> {
+  OpResult getAliasingOpResult(
+      Operation *op, OpOperand &opOperand,
+      const BufferizationState &state) const {
+    if (&opOperand != &op->getOpOperand(1) /*dest*/)
+      return OpResult();
+
+    // ParallelInsertSliceOp itself has no results. Tensors are returned via
+    // the parent op.
+    auto inParallelOp = op->getParentOfType<InParallelOp>();
+    assert(inParallelOp
+           && "could not find valid owner of parallel_insert_slice");
+
+    // The i-th ParallelInsertSliceOp result is returned via the i-th OpResult
+    // of the parent InParallelOp.
+    Block *block = op->getBlock();
+    unsigned int opIdx = 0;
+    for (ParallelInsertSliceOp insertOp
+        : block->getOps<ParallelInsertSliceOp>()) {
+      if (insertOp.getOperation() == op)
+        break;
+      ++opIdx;
+    }
+    assert(opIdx < inParallelOp->getNumResults()
+           && "could not find op inside terminator op");
+
+    return  inParallelOp->getResult(opIdx);
+  }
+
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const BufferizationState &state) const {
+    return true;
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const BufferizationState &state) const {
+    return &opOperand == &op->getOpOperand(1) /*dest*/;
+  }
+
+  BufferRelation bufferRelation(Operation *op, OpResult opResult,
+                                const BufferizationAliasInfo &aliasInfo,
+                                const BufferizationState &state) const {
+    return BufferRelation::Equivalent;
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &b,
+                          const BufferizationState &state) const {
+    // Will be bufferized as part of InParallelOp.
+    return failure();
+  }
+
+  // TODO: This is copied from TensorInterfaceImpl.cpp. Find a way to share
+  // the code.
+  bool isNotConflicting(Operation *op, OpOperand *uRead,
+                        OpOperand *uConflictingWrite,
+                        const BufferizationState &state,
+                        const BufferizationAliasInfo &aliasInfo) const {
+    Operation *readingOp = uRead->getOwner();
+    Operation *conflictingWritingOp = uConflictingWrite->getOwner();
+
+    // Special rules for matching ExtractSliceOp/InsertSliceOp pairs. If
+    // uRead is an InsertSliceOp...
+    if (auto insertSliceOp = dyn_cast<ParallelInsertSliceOp>(readingOp)) {
+      // As an example, consider the following IR.
+      //
+      // %0 = tensor.extract_slice %t[%a, %b][%c, %d][1, 1] {inplace = [true] }
+      // %1 = linalg.fill %cst, %0 {inplace= [true] }
+      // %2 = tensor.insert_slice %1 into %t[%a, %b][%c, %d][1, 1]
+      //     {inplace= [true] }
+
+      // TODO: Use insertSliceOp.getDestOpOperand etc. when available.
+      if (uRead == &insertSliceOp->getOpOperand(1) /*dest*/ &&
+          hasMatchingExtractSliceOp(aliasInfo, state, uConflictingWrite->get(),
+                                    insertSliceOp))
+        // Case 1: The main insight is that InsertSliceOp reads only part of
+        // the destination tensor. The overwritten area is not read. If
+        // uConflictingWrite writes into exactly the memory location that is
+        // being read by uRead, this is not a conflict.
+        //
+        // In the above example:
+        // uRead             = OpOperand 1 (%t) of tensor.insert_slice
+        // uConflictingWrite = OpOperand 1 (%0) of linalg.fill
+        //
+        // The read of %t does not conflict with the write of the FillOp
+        // (same aliases!) because the area that the FillOp operates on is
+        // exactly the one that is *not* read via %t.
+        return true;
+
+      if (uRead == &insertSliceOp->getOpOperand(0) /*source*/ &&
+          uConflictingWrite == &insertSliceOp->getOpOperand(1) /*dest*/ &&
+          hasMatchingExtractSliceOp(aliasInfo, state, uRead->get(),
+                                    insertSliceOp))
+        // Case 2: The read of the source tensor and the write to the dest
+        // tensor via an InsertSliceOp is not a conflict if the read is
+        // reading exactly that part of an equivalent tensor that the
+        // InsertSliceOp is writing.
+        //
+        // In the above example:
+        // uRead             = OpOperand 0 (%1) of tensor.insert_slice
+        // uConflictingWrite = OpOperand 1 (%t) of tensor.insert_slice
+        return true;
+    }
+
+    // If uConflictingWrite is an InsertSliceOp...
+    if (auto insertSliceOp = dyn_cast<ParallelInsertSliceOp>(conflictingWritingOp))
+      // As an example, consider the following IR.
+      //
+      // %0 = tensor.extract_slice %t[%a, %b][%c, %d][1, 1] {inplace = [true] }
+      // %1 = linalg.fill %cst, %0 {inplace= [true] }
+      // %2 = tensor.insert_slice %1 into %t[%a, %b][%c, %d][1, 1]
+      //     {inplace= [true] }
+      // %3 = vector.transfer_read %1, %cst
+      //
+      // In the above example:
+      // uRead             = OpOperand 0 (%1) of vector.transfer_read
+      // uConflictingWrite = OpOperand 1 (%t) of tensor.insert_slice
+      // lastWrite         = %1
+      //
+      // This is not a conflict because the InsertSliceOp overwrites the
+      // memory segment of %1 with the exact same data. (Effectively, there
+      // is no memory write here.)
+      if (uConflictingWrite == &insertSliceOp->getOpOperand(1) /*dest*/ &&
+          aliasInfo.areEquivalentBufferizedValues(uRead->get(),
+                                                  insertSliceOp.source()) &&
+          hasMatchingExtractSliceOp(aliasInfo, state, insertSliceOp.source(),
+                                    insertSliceOp))
+        return true;
+
+    return false;
+  }
+};
+} // namespace linalg_ext
+} // namespace mlir
+
+void mlir::linalg_ext::registerBufferizableOpInterfaceExternalModels(
+    DialectRegistry &registry) {
+  registry.addOpInterface<InParallelOp, InParallelOpInterface>();
+  registry.addOpInterface<PerformConcurrentlyOp, PerformConcurrentlyOpInterface>();
+  registry.addOpInterface<linalg_ext::ParallelInsertSliceOp,
+                          linalg_ext::ParallelInsertSliceOpInterface>();
+}

--- a/lib/LinalgTensorCodegenDriver.cpp
+++ b/lib/LinalgTensorCodegenDriver.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Dialects/LinalgExt/LinalgExtBufferization.h"
+#include "Dialects/LinalgExt/LinalgExtDialect.h"
 #include "Transforms/PassDetail.h"
 #include "Transforms/Passes.h"
 #include "Transforms/Transforms.h"

--- a/lib/Registration.cpp
+++ b/lib/Registration.cpp
@@ -5,6 +5,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Registration.h"
+#include "Dialects/LinalgExt/LinalgExtBufferization.h"
 #include "Dialects/LinalgExt/LinalgExtDialect.h"
 #include "Dialects/LinalgExt/Passes.h"
 #include "Dialects/LinalgTransform/LinalgTransformOps.h"
@@ -120,4 +121,5 @@ void mlir::registerIntoDialectRegistry(DialectRegistry &registry) {
       registerBufferizableOpInterfaceExternalModels(registry);
   linalg::comprehensive_bufferize::vector_ext::
       registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::linalg_ext::registerBufferizableOpInterfaceExternalModels(registry);
 }

--- a/python/examples/core/transforms.py
+++ b/python/examples/core/transforms.py
@@ -221,7 +221,8 @@ class LinalgExtTileToInParallel(Transform):
     self._parse_variables_in_kwargs(kwargs)
 
     pipeline = (f'linalg-tile-to-in-parallel,'
-                f'linalg-in-parallel-to-sequential-for,'
+                # TODO: when bufferization works, no more need to go through sequential for
+                # f'linalg-in-parallel-to-sequential-for,'
                 f'canonicalize,'
                 f'cse')
     self.pipeline = (f'builtin.func({pipeline})')

--- a/test/LinalgExt/bufferize-in-parallel.mlir
+++ b/test/LinalgExt/bufferize-in-parallel.mlir
@@ -1,0 +1,91 @@
+// RUN: mlir-proto-opt %s -linalg-bufferization-driver -canonicalize | FileCheck %s
+
+// CHECK-LABEL: func @parallel_insert_slice_no_conflict(
+//  CHECK-SAME:     %[[idx:.*]]: index, %[[idx2:.*]]: index,
+//  CHECK-SAME:     %[[arg1:.*]]: memref<?xf32, #{{.*}}>,
+//  CHECK-SAME:     %[[arg2:.*]]: memref<?xf32, #{{.*}}>
+func @parallel_insert_slice_no_conflict(
+    %idx: index, %idx2: index,
+    %arg1: tensor<?xf32> {linalg.inplaceable=true},
+    %arg2: tensor<?xf32> {linalg.inplaceable=true}) -> (tensor<?xf32>, f32)
+{
+  %cst = arith.constant 4.200000e+01 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: linalg_ext.in_parallel %[[idx2]]  -> ()
+  %2 = linalg_ext.in_parallel %idx2  -> (tensor<?xf32>) {
+    ^bb0(%arg3: index):  // no predecessors
+      // CHECK: %[[subview:.*]] = memref.subview %[[arg2]][5] [%[[idx]]] [1]
+      %6 = tensor.extract_slice %arg2[5] [%idx] [%c1] : tensor<?xf32> to tensor<?xf32>
+      // CHECK: linalg.fill(%{{.*}}, %[[subview]])
+      %8 = linalg.fill (%cst, %6) : f32, tensor<?xf32> -> tensor<?xf32>
+
+      // CHECK: linalg_ext.perform_concurrently
+      // CHECK-NOT: parallel_insert_slice
+      linalg_ext.perform_concurrently {
+        linalg_ext.parallel_insert_slice %8 into %arg2[5] [%idx] [%c1] : tensor<?xf32> into tensor<?xf32>
+      }
+  }
+
+  // CHECK: %[[load:.*]] = memref.load %[[arg2]]
+  %f = tensor.extract %2[%c0] : tensor<?xf32>
+
+  // CHECK: return %[[load]] : f32
+  return %2, %f : tensor<?xf32>, f32
+}
+
+// -----
+
+// CHECK-LABEL: func @parallel_insert_slice_with_conflict(
+//  CHECK-SAME:     %[[idx:.*]]: index, %[[idx2:.*]]: index,
+//  CHECK-SAME:     %[[arg1:.*]]: memref<?xf32, #{{.*}}>,
+//  CHECK-SAME:     %[[arg2:.*]]: memref<?xf32, #{{.*}}>
+func @parallel_insert_slice_with_conflict(
+    %idx: index, %idx2: index,
+    %arg1: tensor<?xf32> {linalg.inplaceable=true},
+    %arg2: tensor<?xf32> {linalg.inplaceable=true}) -> (f32, f32)
+{
+  %cst = arith.constant 4.200000e+01 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // The parallel_insert_slice_op bufferizes out-of-place, so we need an allocation.
+  // CHECK: %[[alloc1:.*]] = memref.alloc
+  // CHECK: linalg_ext.in_parallel %[[idx2]]  -> ()
+  %2 = linalg_ext.in_parallel %idx2  -> (tensor<?xf32>) {
+    ^bb0(%arg3: index):  // no predecessors
+      // Another alloc for the extract_slice op.
+      // CHECK: %[[alloc2:.*]] = memref.alloc
+      // CHECK: %[[subview2:.*]] = memref.subview %[[arg2]][5] [%[[idx]]] [1]
+      // CHECK: memref.copy %[[subview2]], %[[alloc2]]
+      %6 = tensor.extract_slice %arg2[5] [%idx] [%c1] : tensor<?xf32> to tensor<?xf32>
+
+      // CHECK: linalg.fill(%{{.*}}, %[[alloc2]])
+      %8 = linalg.fill (%cst, %6) : f32, tensor<?xf32> -> tensor<?xf32>
+
+      // parallel_insert_slice buffer was already allocated but not copied yet.
+      // CHECK: memref.copy %[[arg2]], %[[alloc1]]
+
+      // Now the copy of the actual insert_slice.
+      // CHECK: %[[subview1:.*]] = memref.subview %[[alloc1]][5] [%[[idx]]] [1]
+      // CHECK: memref.copy %[[alloc2]], %[[subview1]]
+      // CHECK: memref.dealloc %[[alloc2]]
+
+      // The terminator is empty.
+      // CHECK: linalg_ext.perform_concurrently
+      // CHECK-NOT: parallel_insert_slice
+      linalg_ext.perform_concurrently {
+        linalg_ext.parallel_insert_slice %8 into %arg2[5] [%idx] [%c1] : tensor<?xf32> into tensor<?xf32>
+      }
+  }
+
+  // CHECK: %[[load:.*]] = memref.load %[[arg2]]
+  // CHECK: %[[load2:.*]] = memref.load %[[alloc1]]
+  // CHECK: memref.dealloc %[[alloc1]]
+  %f = tensor.extract %arg2[%c0] : tensor<?xf32>
+  %f2 = tensor.extract %2[%c0] : tensor<?xf32>
+
+  // CHECK: return %[[load2]], %[[load]] : f32, f32
+  return %f2, %f : f32, f32
+}


### PR DESCRIPTION
The InsertSliceOp is bufferized together with its terminator. By
default, a copy is inserted for every ParallelInsertSliceOp. If the
insertion op bufferizes in-place, the copy will fold away.

The implementation strategy for this op closely follows the one of
InsertSliceOp and we may be able to share some of the code with that op
in the future.