### PR TITLE
Add patterns to propagate ops out of warp_execute_on_lane_0 op

### DIFF
--- a/include/Dialects/VectorExt/VectorExtWarpUtils.h
+++ b/include/Dialects/VectorExt/VectorExtWarpUtils.h
@@ -1,0 +1,25 @@
+//===---- VectorWarpUtils.h - Utilities for vector warp ops -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DIALECT_VECTOREXT_VECTORWARPUTILS_H_
+#define DIALECT_VECTOREXT_VECTORWARPUTILS_H_
+
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir {
+class RewritePatternSet;
+
+namespace vector_ext {
+
+/// Collect patterns to propagate warp distribution.
+void populatePropagateVectorDistributionPatterns(RewritePatternSet &pattern);
+
+} // namespace vector_ext
+} // namespace mlir
+
+#endif // DIALECT_VECTOREXT_VECTORWARPUTILS_H_

--- a/lib/Dialects/VectorExt/Transform/CMakeLists.txt
+++ b/lib/Dialects/VectorExt/Transform/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_OPTIONAL_SOURCES
 
 add_mlir_library(MLIRVectorExtTransform
   VectorMaskingUtils.cpp
+  VectorWarpUtils.cpp
 
   DEPENDS
   mlir-headers

--- a/lib/Dialects/VectorExt/Transform/VectorWarpUtils.cpp
+++ b/lib/Dialects/VectorExt/Transform/VectorWarpUtils.cpp
@@ -31,9 +31,9 @@ static Operation *cloneOpWithOperandsAndTypes(OpBuilder &builder, Location loc,
 
 /// Helper to create a new WarpSingleLaneOp regions with different signature.
 static WarpSingleLaneOp
-moveRegionToNewWarpOpAndOverrideReturns(OpBuilder &b, WarpSingleLaneOp warpOp,
-                                        ValueRange newYieldedValues,
-                                        TypeRange newReturnTypes) {
+moveRegionToNewWarpOpAndReplaceReturns(OpBuilder &b, WarpSingleLaneOp warpOp,
+                                       ValueRange newYieldedValues,
+                                       TypeRange newReturnTypes) {
   // Create a new op before the existing one, with the extra operands.
   OpBuilder::InsertionGuard g(b);
   b.setInsertionPoint(warpOp);
@@ -64,7 +64,7 @@ moveRegionToNewWarpOpAndAppendReturns(OpBuilder &b, WarpSingleLaneOp warpOp,
                                  yield.getOperands().end());
   yieldValues.append(newYieldedValues.begin(), newYieldedValues.end());
   WarpSingleLaneOp newWarpOp =
-      moveRegionToNewWarpOpAndOverrideReturns(b, warpOp, yieldValues, types);
+      moveRegionToNewWarpOpAndReplaceReturns(b, warpOp, yieldValues, types);
   for (auto it :
        llvm::zip(warpOp.getResults(),
                  newWarpOp.getResults().take_front(warpOp.getNumResults())))
@@ -245,7 +245,7 @@ struct WarpOpDeadResult : public OpRewritePattern<WarpSingleLaneOp> {
     }
     if (yield.getNumOperands() == yieldValues.size())
       return failure();
-    WarpSingleLaneOp newWarpOp = moveRegionToNewWarpOpAndOverrideReturns(
+    WarpSingleLaneOp newWarpOp = moveRegionToNewWarpOpAndReplaceReturns(
         rewriter, warpOp, yieldValues, resultTypes);
     unsigned resultIndex = 0;
     for (OpResult result : warpOp.getResults()) {

--- a/lib/Dialects/VectorExt/Transform/VectorWarpUtils.cpp
+++ b/lib/Dialects/VectorExt/Transform/VectorWarpUtils.cpp
@@ -1,0 +1,264 @@
+//===- VectorWarpUtils.cpp - Utilities vector warp ops --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialects/VectorExt/VectorExtOps.h"
+#include "Dialects/VectorExt/VectorExtWarpUtils.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Vector/VectorOps.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/Support/LogicalResult.h"
+
+using namespace mlir;
+using namespace mlir::vector;
+using namespace mlir::vector_ext;
+
+// Clones `op` into a new operations that takes `operands` and returns
+// `resultTypes`.
+static Operation *cloneOpWithOperandsAndTypes(OpBuilder &builder, Location loc,
+                                              Operation *op,
+                                              ArrayRef<Value> operands,
+                                              ArrayRef<Type> resultTypes) {
+  OperationState res(loc, op->getName().getStringRef(), operands, resultTypes,
+                     op->getAttrs());
+  return builder.createOperation(res);
+}
+
+/// Helper to create a new WarpSingleLaneOp regions with different signature.
+static WarpSingleLaneOp
+moveRegionToNewWarpOpAndOverrideReturns(OpBuilder &b, WarpSingleLaneOp warpOp,
+                                        ValueRange newYieldedValues,
+                                        TypeRange newReturnTypes) {
+  // Create a new op before the existing one, with the extra operands.
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(warpOp);
+  auto newWarpOp = b.create<WarpSingleLaneOp>(warpOp.getLoc(), newReturnTypes,
+                                              warpOp.laneid());
+
+  Region &opBody = warpOp.getBodyRegion();
+  Region &newOpBody = newWarpOp.getBodyRegion();
+  newOpBody.takeBody(opBody);
+  auto yield =
+      cast<vector_ext::YieldOp>(newOpBody.getBlocks().begin()->getTerminator());
+  yield.operandsMutable().assign(newYieldedValues);
+  return newWarpOp;
+}
+
+/// Helper to create a new WarpSingleLaneOp region with extra outputs.
+static WarpSingleLaneOp
+moveRegionToNewWarpOpAndAppendReturns(OpBuilder &b, WarpSingleLaneOp warpOp,
+                                      ValueRange newYieldedValues,
+                                      TypeRange newReturnTypes) {
+
+  SmallVector<Type> types(warpOp.getResultTypes().begin(),
+                          warpOp.getResultTypes().end());
+  types.append(newReturnTypes.begin(), newReturnTypes.end());
+  auto yield = cast<vector_ext::YieldOp>(
+      warpOp.getBodyRegion().getBlocks().begin()->getTerminator());
+  SmallVector<Value> yieldValues(yield.getOperands().begin(),
+                                 yield.getOperands().end());
+  yieldValues.append(newYieldedValues.begin(), newYieldedValues.end());
+  WarpSingleLaneOp newWarpOp =
+      moveRegionToNewWarpOpAndOverrideReturns(b, warpOp, yieldValues, types);
+  for (auto it :
+       llvm::zip(warpOp.getResults(),
+                 newWarpOp.getResults().take_front(warpOp.getNumResults())))
+    std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
+  return newWarpOp;
+}
+
+llvm::Optional<std::pair<Operation *, unsigned>>
+getWarpResult(WarpSingleLaneOp warpOp, std::function<bool(Operation *)> fn) {
+  auto yield = cast<vector_ext::YieldOp>(
+      warpOp.getBodyRegion().getBlocks().begin()->getTerminator());
+  for (OpOperand &yieldOperand : yield->getOpOperands()) {
+    Value yieldValues = yieldOperand.get();
+    Operation *definedOp = yieldValues.getDefiningOp();
+    if (definedOp && fn(definedOp)) {
+      if (!warpOp.getResult(yieldOperand.getOperandNumber()).use_empty())
+        return std::make_pair(definedOp, yieldOperand.getOperandNumber());
+    }
+  }
+  return {};
+}
+
+/// Currently the distribution map is implicit based on the vector shape. In the
+/// future it will be part of the op.
+/// Example:
+/// ```
+/// %0 = vector_ext.warp_execute_on_lane_0(%arg0) -> (vector<1x16x2xf32>) {
+///   ...
+///   vector_ext.yield %3 : vector<32x16x64xf32>
+/// }
+/// ```
+/// Would have an implicit map of:
+/// `(d0, d1, d2) -> (d0, d2)`
+static AffineMap calculateImplicitMap(Value yield, Value ret) {
+  auto srcType = yield.getType().cast<VectorType>();
+  auto dstType = ret.getType().cast<VectorType>();
+  SmallVector<AffineExpr, 4> perm;
+  // Check which dimension have a multiplicity greater than 1 and associated
+  // them to the IDs in order.
+  for (unsigned i = 0, e = srcType.getRank(); i < e; i++) {
+    if (srcType.getDimSize(i) != dstType.getDimSize(i))
+      perm.push_back(getAffineDimExpr(i, yield.getContext()));
+  }
+  auto map = AffineMap::get(srcType.getRank(), 0, perm, yield.getContext());
+  return map;
+}
+
+/// Sink out elementwise op feeding into a warp op yield.
+/// ```
+/// %0 = vector_ext.warp_execute_on_lane_0(%arg0) -> (vector<1xf32>) {
+///   ...
+///   %3 = arith.addf %1, %2 : vector<32xf32>
+///   vector_ext.yield %3 : vector<32xf32>
+/// }
+/// ```
+/// To
+/// ```
+/// %r:3 = vector_ext.warp_execute_on_lane_0(%arg0) -> (vector<1xf32>,
+/// vector<1xf32>, vector<1xf32>) {
+///   ...
+///   %4 = arith.addf %2, %3 : vector<32xf32>
+///   vector_ext.yield %4, %2, %3 : vector<32xf32>, vector<32xf32>,
+///   vector<32xf32>
+/// }
+/// %0 = arith.addf %r#1, %r#2 : vector<1xf32>
+struct WarpOpElementwise : public OpRewritePattern<WarpSingleLaneOp> {
+  using OpRewritePattern<WarpSingleLaneOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(WarpSingleLaneOp warpOp,
+                                PatternRewriter &rewriter) const override {
+    auto yieldOperand = getWarpResult(warpOp, [](Operation *op) {
+      return OpTrait::hasElementwiseMappableTraits(op);
+    });
+    if (!yieldOperand)
+      return failure();
+    Operation *elementWise = yieldOperand->first;
+    Value distributedVal = warpOp.getResult(yieldOperand->second);
+    SmallVector<Value> yieldValues;
+    SmallVector<Type> retTypes;
+    for (OpOperand &operand : elementWise->getOpOperands()) {
+      auto targetType = VectorType::get(
+          distributedVal.getType().cast<VectorType>().getShape(),
+          operand.get().getType().cast<VectorType>().getElementType());
+      retTypes.push_back(targetType);
+      yieldValues.push_back(operand.get());
+    }
+    WarpSingleLaneOp newWarpOp = moveRegionToNewWarpOpAndAppendReturns(
+        rewriter, warpOp, yieldValues, retTypes);
+    SmallVector<Value> newOperands(elementWise->getOperands().begin(),
+                                   elementWise->getOperands().end());
+    for (unsigned i : llvm::seq(unsigned(0), elementWise->getNumOperands())) {
+      newOperands[i] = newWarpOp.getResult(i + warpOp.getNumResults());
+    }
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPointAfter(newWarpOp);
+    Operation *newOp = cloneOpWithOperandsAndTypes(
+        rewriter, warpOp.getLoc(), elementWise, newOperands,
+        {warpOp.getResult(yieldOperand->second).getType()});
+    newWarpOp.getResult(yieldOperand->second)
+        .replaceAllUsesWith(newOp->getResult(0));
+    rewriter.eraseOp(warpOp);
+    return success();
+  }
+};
+
+/// Sink out transfer_read op feeding into a warp op yield.
+/// ```
+/// %0 = vector_ext.warp_execute_on_lane_0(%arg0) -> (vector<1xf32>) {
+///   ...
+//    %2 = vector.transfer_read %src[%c0], %cst : memref<1024xf32>,
+//    vector<32xf32>
+///   vector_ext.yield %2 : vector<32xf32>
+/// }
+/// ```
+/// To
+/// ```
+/// %dead = vector_ext.warp_execute_on_lane_0(%arg0) -> (vector<1xf32>,
+/// vector<1xf32>, vector<1xf32>) {
+///   ...
+///   %2 = vector.transfer_read %src[%c0], %cst : memref<1024xf32>,
+///   vector<32xf32> vector_ext.yield %2 : vector<32xf32>
+/// }
+/// %0 = vector.transfer_read %src[%c0], %cst : memref<1024xf32>, vector<1xf32>
+struct WarpOpTransferRead : public OpRewritePattern<WarpSingleLaneOp> {
+  using OpRewritePattern<WarpSingleLaneOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(WarpSingleLaneOp warpOp,
+                                PatternRewriter &rewriter) const override {
+    auto operand = getWarpResult(
+        warpOp, [](Operation *op) { return isa<vector::TransferReadOp>(op); });
+    if (!operand)
+      return failure();
+    auto read = cast<vector::TransferReadOp>(operand->first);
+    Value distributedVal = warpOp.getResult(operand->second);
+
+    SmallVector<Value, 4> indices(read.indices().begin(), read.indices().end());
+    AffineMap map = calculateImplicitMap(read.getResult(), distributedVal);
+    AffineMap indexMap = map.compose(read.permutation_map());
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(warpOp);
+    for (auto it : llvm::zip(indexMap.getResults(), map.getResults())) {
+      AffineExpr d0, d1;
+      bindDims(read.getContext(), d0, d1);
+      auto indexExpr = std::get<0>(it).dyn_cast<AffineDimExpr>();
+      if (!indexExpr)
+        continue;
+      unsigned indexPos = indexExpr.getPosition();
+      unsigned vectorPos = std::get<1>(it).cast<AffineDimExpr>().getPosition();
+      int64_t scale =
+          distributedVal.getType().cast<VectorType>().getDimSize(vectorPos);
+      indices[indexPos] =
+          makeComposedAffineApply(rewriter, read.getLoc(), d0 + scale * d1,
+                                  {indices[indexPos], warpOp.laneid()});
+    }
+    Value newRead = rewriter.create<vector::TransferReadOp>(
+        read.getLoc(), distributedVal.getType(), read.source(), indices,
+        read.permutation_mapAttr(), read.padding(), read.mask(),
+        read.in_boundsAttr());
+    distributedVal.replaceAllUsesWith(newRead);
+    return success();
+  }
+};
+
+/// Remove any result that has no use along with the matching yieldOp operand.
+// TODO: Move this in WarpSingleLaneOp canonicalization.
+struct WarpOpDeadResult : public OpRewritePattern<WarpSingleLaneOp> {
+  using OpRewritePattern<WarpSingleLaneOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(WarpSingleLaneOp warpOp,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<Type> resultTypes;
+    SmallVector<Value> yieldValues;
+    auto yield = cast<vector_ext::YieldOp>(
+        warpOp.getBodyRegion().getBlocks().begin()->getTerminator());
+    for (OpResult result : warpOp.getResults()) {
+      if (result.use_empty())
+        continue;
+      resultTypes.push_back(result.getType());
+      yieldValues.push_back(yield.getOperand(result.getResultNumber()));
+    }
+    if (yield.getNumOperands() == yieldValues.size())
+      return failure();
+    WarpSingleLaneOp newWarpOp = moveRegionToNewWarpOpAndOverrideReturns(
+        rewriter, warpOp, yieldValues, resultTypes);
+    unsigned resultIndex = 0;
+    for (OpResult result : warpOp.getResults()) {
+      if (result.use_empty())
+        continue;
+      result.replaceAllUsesWith(newWarpOp.getResult(resultIndex++));
+    }
+    rewriter.eraseOp(warpOp);
+    return success();
+  }
+};
+
+void mlir::vector_ext::populatePropagateVectorDistributionPatterns(
+    RewritePatternSet &pattern) {
+  pattern.add<WarpOpElementwise, WarpOpTransferRead, WarpOpDeadResult>(
+      pattern.getContext());
+}

--- a/lib/Registration.cpp
+++ b/lib/Registration.cpp
@@ -71,6 +71,7 @@ void registerTestStagedPatternRewriteDriver();
 void registerTestVectorMaskingUtils();
 void registerTestListenerPasses();
 void registerTestLinalgTransformWrapScope();
+void registerTestVectorWarps();
 } // namespace test_ext
 } // namespace mlir
 
@@ -79,6 +80,7 @@ void registerTestPasses() {
   mlir::test_ext::registerTestVectorMaskingUtils();
   mlir::test_ext::registerTestListenerPasses();
   mlir::test_ext::registerTestLinalgTransformWrapScope();
+  mlir::test_ext::registerTestVectorWarps();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/VectorExt/warp.mlir
+++ b/test/VectorExt/warp.mlir
@@ -1,0 +1,81 @@
+// RUN: mlir-proto-opt %s -allow-unregistered-dialect -split-input-file -test-vector-warp-distribute=propagate-distribution -canonicalize | FileCheck %s
+
+// CHECK-LABEL:   func @warp_dead_result(
+func @warp_dead_result(%laneid: index) -> (vector<1xf32>) {
+  // CHECK: %[[R:.*]] = vector_ext.warp_execute_on_lane_0(%{{.*}}) -> (vector<1xf32>)
+    %r:3 = vector_ext.warp_execute_on_lane_0(%laneid) -> 
+    (vector<1xf32>, vector<1xf32>, vector<1xf32>) {
+    %2 = "some_def"() : () -> (vector<32xf32>)
+    %3 = "some_def"() : () -> (vector<32xf32>)
+    %4 = "some_def"() : () -> (vector<32xf32>)
+  // CHECK:   vector_ext.yield %{{.*}} : vector<32xf32>
+    vector_ext.yield %2, %3, %4 : vector<32xf32>, vector<32xf32>, vector<32xf32>
+  }
+  // CHECK: return %[[R]] : vector<1xf32>
+  return %r#1 : vector<1xf32>
+}
+
+// -----
+
+#map0 = affine_map<()[s0] -> (s0 * 2)>
+
+// CHECK-LABEL:   func @warp_propagate_elementwise(
+func @warp_propagate_elementwise(%laneid: index, %dest: memref<1024xf32>) {
+  %c0 = arith.constant 0 : index
+  %c32 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[R:.*]]:4 = vector_ext.warp_execute_on_lane_0(%{{.*}}) -> (vector<1xf32>, vector<1xf32>, vector<2xf32>, vector<2xf32>)
+  %r:2 = vector_ext.warp_execute_on_lane_0(%laneid) -> 
+    (vector<1xf32>, vector<2xf32>) {
+    // CHECK: %[[V0:.*]] = "some_def"() : () -> vector<32xf32>
+    // CHECK: %[[V1:.*]] = "some_def"() : () -> vector<32xf32>
+    // CHECK: %[[V2:.*]] = "some_def"() : () -> vector<64xf32>
+    // CHECK: %[[V3:.*]] = "some_def"() : () -> vector<64xf32>
+    // CHECK: vector_ext.yield %[[V0]], %[[V1]], %[[V2]], %[[V3]] : vector<32xf32>, vector<32xf32>, vector<64xf32>, vector<64xf32>
+    %2 = "some_def"() : () -> (vector<32xf32>)
+    %3 = "some_def"() : () -> (vector<32xf32>)
+    %4 = "some_def"() : () -> (vector<64xf32>)
+    %5 = "some_def"() : () -> (vector<64xf32>)
+    %6 = arith.addf %2, %3 : vector<32xf32>
+    %7 = arith.addf %4, %5 : vector<64xf32>
+    vector_ext.yield %6, %7 : vector<32xf32>, vector<64xf32>
+  }
+  // CHECK: %[[A0:.*]] = arith.addf %[[R]]#2, %[[R]]#3 : vector<2xf32>
+  // CHECK: %[[A1:.*]] = arith.addf %[[R]]#0, %[[R]]#1 : vector<1xf32>
+  %id2 = affine.apply #map0()[%laneid] 
+  // CHECK: vector.transfer_write %[[A1]], {{.*}} : vector<1xf32>, memref<1024xf32>
+  // CHECK: vector.transfer_write %[[A0]], {{.*}} : vector<2xf32>, memref<1024xf32>
+  vector.transfer_write %r#0, %dest[%laneid] : vector<1xf32>, memref<1024xf32>
+  vector.transfer_write %r#1, %dest[%id2] : vector<2xf32>, memref<1024xf32>
+  return
+}
+
+
+// -----
+
+#map0 = affine_map<()[s0] -> (s0 * 2)>
+
+//  CHECK-DAG: #[[MAP0:.*]] = affine_map<()[s0] -> (s0 * 2)>
+
+// CHECK-LABEL:   func @warp_propagate_read
+//  CHECK-SAME:     (%[[ID:.*]]: index
+func @warp_propagate_read(%laneid: index, %src: memref<1024xf32>, %dest: memref<1024xf32>) {
+// CHECK-NOT: warp_execute_on_lane_0
+// CHECK: %[[R0:.*]] = vector.transfer_read %arg1[%[[ID]]], %{{.*}} : memref<1024xf32>, vector<1xf32>
+// CHECK: %[[ID2:.*]] = affine.apply #[[MAP0]]()[%[[ID]]]
+// CHECK: %[[R1:.*]] = vector.transfer_read %arg1[%[[ID2]]], %{{.*}} : memref<1024xf32>, vector<2xf32>
+// CHECK: vector.transfer_write %[[R0]], {{.*}} : vector<1xf32>, memref<1024xf32>
+// CHECK: vector.transfer_write %[[R1]], {{.*}} : vector<2xf32>, memref<1024xf32>
+  %c0 = arith.constant 0 : index
+  %c32 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %r:2 = vector_ext.warp_execute_on_lane_0(%laneid) ->(vector<1xf32>, vector<2xf32>) {
+    %2 = vector.transfer_read %src[%c0], %cst : memref<1024xf32>, vector<32xf32>
+    %3 = vector.transfer_read %src[%c32], %cst : memref<1024xf32>, vector<64xf32>
+    vector_ext.yield %2, %3 : vector<32xf32>, vector<64xf32>
+  }
+  %id2 = affine.apply #map0()[%laneid] 
+  vector.transfer_write %r#0, %dest[%laneid] : vector<1xf32>, memref<1024xf32>
+  vector.transfer_write %r#1, %dest[%id2] : vector<2xf32>, memref<1024xf32>
+  return
+}

--- a/test/lib/Dialect/VectorExt/CMakeLists.txt
+++ b/test/lib/Dialect/VectorExt/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(MLIRVectorExtTestPasses
   TestVectorMaskingUtils.cpp
+  TestVectorWarp.cpp
 
   EXCLUDE_FROM_LIBMLIR
 

--- a/test/lib/Dialect/VectorExt/TestVectorWarp.cpp
+++ b/test/lib/Dialect/VectorExt/TestVectorWarp.cpp
@@ -1,0 +1,56 @@
+//===- TestVectorWarp.cpp - Test vector warp ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dialects/VectorExt/VectorExtOps.h"
+#include "Dialects/VectorExt/VectorExtWarpUtils.h"
+#include "mlir/Dialect/Vector/VectorOps.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+using namespace mlir::vector;
+using namespace mlir::vector_ext;
+
+namespace {
+
+struct TestVectorWarp : public PassWrapper<TestVectorWarp, FunctionPass> {
+
+  TestVectorWarp() = default;
+  TestVectorWarp(const TestVectorWarp &pass) {}
+
+  StringRef getArgument() const final { return "test-vector-warp-distribute"; }
+  StringRef getDescription() const final {
+    return "Test vector warp transformations";
+  }
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<VectorDialect, VectorExtDialect>();
+  }
+
+  Option<bool> propagateDistribution{
+      *this, "propagate-distribution",
+      llvm::cl::desc("Test distribution propgation"), llvm::cl::init(false)};
+
+  void runOnFunction() override {
+    FuncOp funcOp = getFunction();
+    MLIRContext *ctx = &getContext();
+    if (propagateDistribution) {
+      RewritePatternSet patterns(ctx);
+      vector_ext::populatePropagateVectorDistributionPatterns(patterns);
+      (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace test_ext {
+void registerTestVectorWarps() { PassRegistration<TestVectorWarp>(); }
+} // namespace test_ext
+} // namespace mlir


### PR DESCRIPTION
Add patterns to remove dead output as well as patterns to sink out
element and transfer_read operation feeding into a vector_ext.yield