### PR TITLE
Adding support for e2e execution with async dialect

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -212,7 +212,8 @@ def main(args):
   cmake_args = ["cmake", "--build", build_dir, "--target", \
                 "tools/sandbox/all", "mlir-opt", "mlir-translate", \
                 "mlir-cpu-runner", "mlir_runner_utils", "mlir_c_runner_utils", \
-                "llvm-mca", "llvm-objdump", "llc", "opt", "FileCheck"]
+                "mlir_async_runtime_copy", "llvm-mca", "llvm-objdump", "llc", "opt", \
+                "FileCheck"]
   print(f"-- Performing initial build: {' '.join(cmake_args)}")
   subprocess.check_call(cmake_args, cwd=build_dir)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,6 +10,7 @@ if(SANDBOX_ENABLE_IREE_DIALECTS)
 endif()
 
 add_subdirectory(Dialects)
+add_subdirectory(ExecutionEngine)
 add_subdirectory(Transforms)
 
 set(IREE_LINALG_TENSOR_SANDBOX_LIBRARIES
@@ -42,18 +43,23 @@ add_mlir_library(IREELinalgTensorSandboxDriver
 
   PARTIAL_SOURCES_INTENDED
   LINK_LIBS PRIVATE
+  # Dialects
   MLIRAsync
   MLIRGPUOps
   MLIRLinalg
   MLIRLinalgExtOpInterfaceImpl
+  # Transforms
+  MLIRAsyncTransforms
   MLIRLinalgTransforms
-  MLIRAffineToStandard
   MLIRMemRefTransforms
-  MLIRSCFToStandard
+  # Conversions
+  MLIRAsyncToLLVM
+  MLIRAffineToStandard
   MLIRLinalgToLLVM
-  MLIRVectorToLLVM
   MLIRMathToLLVM
   MLIRMemRefToLLVM
+  MLIRSCFToStandard
+  MLIRVectorToLLVM
 
   # Sandbox libraries
   ${IREE_LINALG_TENSOR_SANDBOX_LIBRARIES}

--- a/lib/ExecutionEngine/AsyncRuntime.cpp
+++ b/lib/ExecutionEngine/AsyncRuntime.cpp
@@ -1,0 +1,534 @@
+// This is a copy of the core MLIR AsyncRuntime.cpp which is built with
+// hidden symbols that make it hard to use woth python.
+// Ideally this should disappear but it is related to deeper destruction of
+// static ojects, dlopen/dlclose/atexit in a multi-threaded environment.
+// For now, copy to get off the ground.
+
+//===- AsyncRuntime.cpp - Async runtime reference implementation ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements basic Async runtime API for supporting Async dialect
+// to LLVM dialect lowering.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/ExecutionEngine/AsyncRuntime.h"
+
+#ifdef MLIR_ASYNCRUNTIME_DEFINE_FUNCTIONS
+
+#include <atomic>
+#include <cassert>
+#include <condition_variable>
+#include <functional>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/ThreadPool.h"
+
+using namespace mlir::runtime;
+
+//===----------------------------------------------------------------------===//
+// Async runtime API.
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace runtime {
+namespace {
+
+// Forward declare class defined below.
+class RefCounted;
+
+// -------------------------------------------------------------------------- //
+// AsyncRuntime orchestrates all async operations and Async runtime API is built
+// on top of the default runtime instance.
+// -------------------------------------------------------------------------- //
+
+class AsyncRuntime {
+public:
+  AsyncRuntime() : numRefCountedObjects(0) {}
+
+  ~AsyncRuntime() {
+    threadPool.wait(); // wait for the completion of all async tasks
+    assert(getNumRefCountedObjects() == 0 &&
+           "all ref counted objects must be destroyed");
+  }
+
+  int64_t getNumRefCountedObjects() {
+    return numRefCountedObjects.load(std::memory_order_relaxed);
+  }
+
+  llvm::ThreadPool &getThreadPool() { return threadPool; }
+
+private:
+  friend class RefCounted;
+
+  // Count the total number of reference counted objects in this instance
+  // of an AsyncRuntime. For debugging purposes only.
+  void addNumRefCountedObjects() {
+    numRefCountedObjects.fetch_add(1, std::memory_order_relaxed);
+  }
+  void dropNumRefCountedObjects() {
+    numRefCountedObjects.fetch_sub(1, std::memory_order_relaxed);
+  }
+
+  std::atomic<int64_t> numRefCountedObjects;
+  llvm::ThreadPool threadPool;
+};
+
+// -------------------------------------------------------------------------- //
+// A state of the async runtime value (token, value or group).
+// -------------------------------------------------------------------------- //
+
+class State {
+public:
+  enum StateEnum : int8_t {
+    // The underlying value is not yet available for consumption.
+    kUnavailable = 0,
+    // The underlying value is available for consumption. This state can not
+    // transition to any other state.
+    kAvailable = 1,
+    // This underlying value is available and contains an error. This state can
+    // not transition to any other state.
+    kError = 2,
+  };
+
+  /* implicit */ State(StateEnum s) : state(s) {}
+  /* implicit */ operator StateEnum() { return state; }
+
+  bool isUnavailable() const { return state == kUnavailable; }
+  bool isAvailable() const { return state == kAvailable; }
+  bool isError() const { return state == kError; }
+  bool isAvailableOrError() const { return isAvailable() || isError(); }
+
+  const char *debug() const {
+    switch (state) {
+    case kUnavailable:
+      return "unavailable";
+    case kAvailable:
+      return "available";
+    case kError:
+      return "error";
+    }
+  }
+
+private:
+  StateEnum state;
+};
+
+// -------------------------------------------------------------------------- //
+// A base class for all reference counted objects created by the async runtime.
+// -------------------------------------------------------------------------- //
+
+class RefCounted {
+public:
+  RefCounted(AsyncRuntime *runtime, int64_t refCount = 1)
+      : runtime(runtime), refCount(refCount) {
+    runtime->addNumRefCountedObjects();
+  }
+
+  virtual ~RefCounted() {
+    assert(refCount.load() == 0 && "reference count must be zero");
+    runtime->dropNumRefCountedObjects();
+  }
+
+  RefCounted(const RefCounted &) = delete;
+  RefCounted &operator=(const RefCounted &) = delete;
+
+  void addRef(int64_t count = 1) { refCount.fetch_add(count); }
+
+  void dropRef(int64_t count = 1) {
+    int64_t previous = refCount.fetch_sub(count);
+    assert(previous >= count && "reference count should not go below zero");
+    if (previous == count)
+      destroy();
+  }
+
+protected:
+  virtual void destroy() { delete this; }
+
+private:
+  AsyncRuntime *runtime;
+  std::atomic<int64_t> refCount;
+};
+
+} // namespace
+
+// Returns the default per-process instance of an async runtime.
+static std::unique_ptr<AsyncRuntime> &getDefaultAsyncRuntimeInstance() {
+  static auto runtime = std::make_unique<AsyncRuntime>();
+  return runtime;
+}
+
+static void resetDefaultAsyncRuntime() {
+  return getDefaultAsyncRuntimeInstance().reset();
+}
+
+static AsyncRuntime *getDefaultAsyncRuntime() {
+  return getDefaultAsyncRuntimeInstance().get();
+}
+
+// Async token provides a mechanism to signal asynchronous operation completion.
+struct AsyncToken : public RefCounted {
+  // AsyncToken created with a reference count of 2 because it will be returned
+  // to the `async.execute` caller and also will be later on emplaced by the
+  // asynchronously executed task. If the caller immediately will drop its
+  // reference we must ensure that the token will be alive until the
+  // asynchronous operation is completed.
+  AsyncToken(AsyncRuntime *runtime)
+      : RefCounted(runtime, /*refCount=*/2), state(State::kUnavailable) {}
+
+  std::atomic<State::StateEnum> state;
+
+  // Pending awaiters are guarded by a mutex.
+  std::mutex mu;
+  std::condition_variable cv;
+  std::vector<std::function<void()>> awaiters;
+};
+
+// Async value provides a mechanism to access the result of asynchronous
+// operations. It owns the storage that is used to store/load the value of the
+// underlying type, and a flag to signal if the value is ready or not.
+struct AsyncValue : public RefCounted {
+  // AsyncValue similar to an AsyncToken created with a reference count of 2.
+  AsyncValue(AsyncRuntime *runtime, int64_t size)
+      : RefCounted(runtime, /*refCount=*/2), state(State::kUnavailable),
+        storage(size) {}
+
+  std::atomic<State::StateEnum> state;
+
+  // Use vector of bytes to store async value payload.
+  std::vector<int8_t> storage;
+
+  // Pending awaiters are guarded by a mutex.
+  std::mutex mu;
+  std::condition_variable cv;
+  std::vector<std::function<void()>> awaiters;
+};
+
+// Async group provides a mechanism to group together multiple async tokens or
+// values to await on all of them together (wait for the completion of all
+// tokens or values added to the group).
+struct AsyncGroup : public RefCounted {
+  AsyncGroup(AsyncRuntime *runtime, int64_t size)
+      : RefCounted(runtime), pendingTokens(size), numErrors(0), rank(0) {}
+
+  std::atomic<int> pendingTokens;
+  std::atomic<int> numErrors;
+  std::atomic<int> rank;
+
+  // Pending awaiters are guarded by a mutex.
+  std::mutex mu;
+  std::condition_variable cv;
+  std::vector<std::function<void()>> awaiters;
+};
+
+// Adds references to reference counted runtime object.
+extern "C" void mlirAsyncRuntimeAddRef(RefCountedObjPtr ptr, int64_t count) {
+  RefCounted *refCounted = static_cast<RefCounted *>(ptr);
+  refCounted->addRef(count);
+}
+
+// Drops references from reference counted runtime object.
+extern "C" void mlirAsyncRuntimeDropRef(RefCountedObjPtr ptr, int64_t count) {
+  RefCounted *refCounted = static_cast<RefCounted *>(ptr);
+  refCounted->dropRef(count);
+}
+
+// Creates a new `async.token` in not-ready state.
+extern "C" AsyncToken *mlirAsyncRuntimeCreateToken() {
+  AsyncToken *token = new AsyncToken(getDefaultAsyncRuntime());
+  return token;
+}
+
+// Creates a new `async.value` in not-ready state.
+extern "C" AsyncValue *mlirAsyncRuntimeCreateValue(int64_t size) {
+  AsyncValue *value = new AsyncValue(getDefaultAsyncRuntime(), size);
+  return value;
+}
+
+// Create a new `async.group` in empty state.
+extern "C" AsyncGroup *mlirAsyncRuntimeCreateGroup(int64_t size) {
+  AsyncGroup *group = new AsyncGroup(getDefaultAsyncRuntime(), size);
+  return group;
+}
+
+extern "C" int64_t mlirAsyncRuntimeAddTokenToGroup(AsyncToken *token,
+                                                   AsyncGroup *group) {
+  std::unique_lock<std::mutex> lockToken(token->mu);
+  std::unique_lock<std::mutex> lockGroup(group->mu);
+
+  // Get the rank of the token inside the group before we drop the reference.
+  int rank = group->rank.fetch_add(1);
+
+  auto onTokenReady = [group, token]() {
+    // Increment the number of errors in the group.
+    if (State(token->state).isError())
+      group->numErrors.fetch_add(1);
+
+    // If pending tokens go below zero it means that more tokens than the group
+    // size were added to this group.
+    assert(group->pendingTokens > 0 && "wrong group size");
+
+    // Run all group awaiters if it was the last token in the group.
+    if (group->pendingTokens.fetch_sub(1) == 1) {
+      group->cv.notify_all();
+      for (auto &awaiter : group->awaiters)
+        awaiter();
+    }
+  };
+
+  if (State(token->state).isAvailableOrError()) {
+    // Update group pending tokens immediately and maybe run awaiters.
+    onTokenReady();
+
+  } else {
+    // Update group pending tokens when token will become ready. Because this
+    // will happen asynchronously we must ensure that `group` is alive until
+    // then, and re-ackquire the lock.
+    group->addRef();
+
+    token->awaiters.emplace_back([group, onTokenReady]() {
+      // Make sure that `dropRef` does not destroy the mutex owned by the lock.
+      {
+        std::unique_lock<std::mutex> lockGroup(group->mu);
+        onTokenReady();
+      }
+      group->dropRef();
+    });
+  }
+
+  return rank;
+}
+
+// Switches `async.token` to available or error state (terminatl state) and runs
+// all awaiters.
+static void setTokenState(AsyncToken *token, State state) {
+  assert(state.isAvailableOrError() && "must be terminal state");
+  assert(State(token->state).isUnavailable() && "token must be unavailable");
+
+  // Make sure that `dropRef` does not destroy the mutex owned by the lock.
+  {
+    std::unique_lock<std::mutex> lock(token->mu);
+    token->state = state;
+    token->cv.notify_all();
+    for (auto &awaiter : token->awaiters)
+      awaiter();
+  }
+
+  // Async tokens created with a ref count `2` to keep token alive until the
+  // async task completes. Drop this reference explicitly when token emplaced.
+  token->dropRef();
+}
+
+static void setValueState(AsyncValue *value, State state) {
+  assert(state.isAvailableOrError() && "must be terminal state");
+  assert(State(value->state).isUnavailable() && "value must be unavailable");
+
+  // Make sure that `dropRef` does not destroy the mutex owned by the lock.
+  {
+    std::unique_lock<std::mutex> lock(value->mu);
+    value->state = state;
+    value->cv.notify_all();
+    for (auto &awaiter : value->awaiters)
+      awaiter();
+  }
+
+  // Async values created with a ref count `2` to keep value alive until the
+  // async task completes. Drop this reference explicitly when value emplaced.
+  value->dropRef();
+}
+
+extern "C" void mlirAsyncRuntimeEmplaceToken(AsyncToken *token) {
+  setTokenState(token, State::kAvailable);
+}
+
+extern "C" void mlirAsyncRuntimeEmplaceValue(AsyncValue *value) {
+  setValueState(value, State::kAvailable);
+}
+
+extern "C" void mlirAsyncRuntimeSetTokenError(AsyncToken *token) {
+  setTokenState(token, State::kError);
+}
+
+extern "C" void mlirAsyncRuntimeSetValueError(AsyncValue *value) {
+  setValueState(value, State::kError);
+}
+
+extern "C" bool mlirAsyncRuntimeIsTokenError(AsyncToken *token) {
+  return State(token->state).isError();
+}
+
+extern "C" bool mlirAsyncRuntimeIsValueError(AsyncValue *value) {
+  return State(value->state).isError();
+}
+
+extern "C" bool mlirAsyncRuntimeIsGroupError(AsyncGroup *group) {
+  return group->numErrors.load() > 0;
+}
+
+extern "C" void mlirAsyncRuntimeAwaitToken(AsyncToken *token) {
+  std::unique_lock<std::mutex> lock(token->mu);
+  if (!State(token->state).isAvailableOrError())
+    token->cv.wait(
+        lock, [token] { return State(token->state).isAvailableOrError(); });
+}
+
+extern "C" void mlirAsyncRuntimeAwaitValue(AsyncValue *value) {
+  std::unique_lock<std::mutex> lock(value->mu);
+  if (!State(value->state).isAvailableOrError())
+    value->cv.wait(
+        lock, [value] { return State(value->state).isAvailableOrError(); });
+}
+
+extern "C" void mlirAsyncRuntimeAwaitAllInGroup(AsyncGroup *group) {
+  std::unique_lock<std::mutex> lock(group->mu);
+  if (group->pendingTokens != 0)
+    group->cv.wait(lock, [group] { return group->pendingTokens == 0; });
+}
+
+// Returns a pointer to the storage owned by the async value.
+extern "C" ValueStorage mlirAsyncRuntimeGetValueStorage(AsyncValue *value) {
+  assert(!State(value->state).isError() && "unexpected error state");
+  return value->storage.data();
+}
+
+extern "C" void mlirAsyncRuntimeExecute(CoroHandle handle, CoroResume resume) {
+  auto *runtime = getDefaultAsyncRuntime();
+  runtime->getThreadPool().async([handle, resume]() { (*resume)(handle); });
+}
+
+extern "C" void mlirAsyncRuntimeAwaitTokenAndExecute(AsyncToken *token,
+                                                     CoroHandle handle,
+                                                     CoroResume resume) {
+  auto execute = [handle, resume]() { (*resume)(handle); };
+  std::unique_lock<std::mutex> lock(token->mu);
+  if (State(token->state).isAvailableOrError()) {
+    lock.unlock();
+    execute();
+  } else {
+    token->awaiters.emplace_back([execute]() { execute(); });
+  }
+}
+
+extern "C" void mlirAsyncRuntimeAwaitValueAndExecute(AsyncValue *value,
+                                                     CoroHandle handle,
+                                                     CoroResume resume) {
+  auto execute = [handle, resume]() { (*resume)(handle); };
+  std::unique_lock<std::mutex> lock(value->mu);
+  if (State(value->state).isAvailableOrError()) {
+    lock.unlock();
+    execute();
+  } else {
+    value->awaiters.emplace_back([execute]() { execute(); });
+  }
+}
+
+extern "C" void mlirAsyncRuntimeAwaitAllInGroupAndExecute(AsyncGroup *group,
+                                                          CoroHandle handle,
+                                                          CoroResume resume) {
+  auto execute = [handle, resume]() { (*resume)(handle); };
+  std::unique_lock<std::mutex> lock(group->mu);
+  if (group->pendingTokens == 0) {
+    lock.unlock();
+    execute();
+  } else {
+    group->awaiters.emplace_back([execute]() { execute(); });
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Small async runtime support library for testing.
+//===----------------------------------------------------------------------===//
+
+extern "C" void mlirAsyncRuntimePrintCurrentThreadId() {
+  static thread_local std::thread::id thisId = std::this_thread::get_id();
+  std::cout << "Current thread id: " << thisId << std::endl;
+}
+
+//===----------------------------------------------------------------------===//
+// MLIR Runner (JitRunner) dynamic library integration.
+//===----------------------------------------------------------------------===//
+
+// Export symbols for the MLIR runner integration. All other symbols are hidden.
+#ifdef _WIN32
+#define API __declspec(dllexport)
+#else
+#define API __attribute__((visibility("default")))
+#endif
+
+// Visual Studio had a bug that fails to compile nested generic lambdas
+// inside an `extern "C"` function.
+//   https://developercommunity.visualstudio.com/content/problem/475494/clexe-error-with-lambda-inside-function-templates.html
+// The bug is fixed in VS2019 16.1. Separating the declaration and definition is
+// a work around for older versions of Visual Studio.
+// NOLINTNEXTLINE(*-identifier-naming): externally called.
+extern "C" API void __mlir_runner_init(llvm::StringMap<void *> &exportSymbols);
+
+// NOLINTNEXTLINE(*-identifier-naming): externally called.
+void __mlir_runner_init(llvm::StringMap<void *> &exportSymbols) {
+  auto exportSymbol = [&](llvm::StringRef name, auto ptr) {
+    assert(exportSymbols.count(name) == 0 && "symbol already exists");
+    exportSymbols[name] = reinterpret_cast<void *>(ptr);
+  };
+
+  exportSymbol("mlirAsyncRuntimeAddRef",
+               &mlir::runtime::mlirAsyncRuntimeAddRef);
+  exportSymbol("mlirAsyncRuntimeDropRef",
+               &mlir::runtime::mlirAsyncRuntimeDropRef);
+  exportSymbol("mlirAsyncRuntimeExecute",
+               &mlir::runtime::mlirAsyncRuntimeExecute);
+  exportSymbol("mlirAsyncRuntimeGetValueStorage",
+               &mlir::runtime::mlirAsyncRuntimeGetValueStorage);
+  exportSymbol("mlirAsyncRuntimeCreateToken",
+               &mlir::runtime::mlirAsyncRuntimeCreateToken);
+  exportSymbol("mlirAsyncRuntimeCreateValue",
+               &mlir::runtime::mlirAsyncRuntimeCreateValue);
+  exportSymbol("mlirAsyncRuntimeEmplaceToken",
+               &mlir::runtime::mlirAsyncRuntimeEmplaceToken);
+  exportSymbol("mlirAsyncRuntimeEmplaceValue",
+               &mlir::runtime::mlirAsyncRuntimeEmplaceValue);
+  exportSymbol("mlirAsyncRuntimeSetTokenError",
+               &mlir::runtime::mlirAsyncRuntimeSetTokenError);
+  exportSymbol("mlirAsyncRuntimeSetValueError",
+               &mlir::runtime::mlirAsyncRuntimeSetValueError);
+  exportSymbol("mlirAsyncRuntimeIsTokenError",
+               &mlir::runtime::mlirAsyncRuntimeIsTokenError);
+  exportSymbol("mlirAsyncRuntimeIsValueError",
+               &mlir::runtime::mlirAsyncRuntimeIsValueError);
+  exportSymbol("mlirAsyncRuntimeIsGroupError",
+               &mlir::runtime::mlirAsyncRuntimeIsGroupError);
+  exportSymbol("mlirAsyncRuntimeAwaitToken",
+               &mlir::runtime::mlirAsyncRuntimeAwaitToken);
+  exportSymbol("mlirAsyncRuntimeAwaitValue",
+               &mlir::runtime::mlirAsyncRuntimeAwaitValue);
+  exportSymbol("mlirAsyncRuntimeAwaitTokenAndExecute",
+               &mlir::runtime::mlirAsyncRuntimeAwaitTokenAndExecute);
+  exportSymbol("mlirAsyncRuntimeAwaitValueAndExecute",
+               &mlir::runtime::mlirAsyncRuntimeAwaitValueAndExecute);
+  exportSymbol("mlirAsyncRuntimeCreateGroup",
+               &mlir::runtime::mlirAsyncRuntimeCreateGroup);
+  exportSymbol("mlirAsyncRuntimeAddTokenToGroup",
+               &mlir::runtime::mlirAsyncRuntimeAddTokenToGroup);
+  exportSymbol("mlirAsyncRuntimeAwaitAllInGroup",
+               &mlir::runtime::mlirAsyncRuntimeAwaitAllInGroup);
+  exportSymbol("mlirAsyncRuntimeAwaitAllInGroupAndExecute",
+               &mlir::runtime::mlirAsyncRuntimeAwaitAllInGroupAndExecute);
+  exportSymbol("mlirAsyncRuntimePrintCurrentThreadId",
+               &mlir::runtime::mlirAsyncRuntimePrintCurrentThreadId);
+}
+
+// NOLINTNEXTLINE(*-identifier-naming): externally called.
+extern "C" API void __mlir_runner_destroy() { resetDefaultAsyncRuntime(); }
+
+} // namespace runtime
+} // namespace mlir
+
+#endif // MLIR_ASYNCRUNTIME_DEFINE_FUNCTIONS

--- a/lib/ExecutionEngine/CMakeLists.txt
+++ b/lib/ExecutionEngine/CMakeLists.txt
@@ -1,0 +1,18 @@
+# This is a copy of the core MLIR AsyncRuntime.cpp which is built with
+# hidden symbols that make it hard to use woth python.
+# Ideally this should disappear but it is related to deeper destruction of 
+# static ojects, dlopen/dlclose/atexit in a multi-threaded environment.
+# For now, copy to get off the ground.
+add_mlir_library(mlir_async_runtime_copy
+SHARED
+AsyncRuntime.cpp
+
+EXCLUDE_FROM_LIBMLIR
+
+LINK_LIBS PUBLIC
+${LLVM_PTHREAD_LIB}
+)
+# The following line hides the functions we need in order to load/unload shared
+# libraries properly. Comment it to get off the ground.
+# set_property(TARGET mlir_async_runtime PROPERTY CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(mlir_async_runtime_copy PRIVATE mlir_async_runtime_EXPORTS)

--- a/lib/LinalgTensorCodegenDriver.cpp
+++ b/lib/LinalgTensorCodegenDriver.cpp
@@ -12,6 +12,7 @@
 #include "Transforms/Passes.h"
 #include "Transforms/Transforms.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Conversion/AsyncToLLVM/AsyncToLLVM.h"
 #include "mlir/Conversion/LinalgToLLVM/LinalgToLLVM.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
@@ -20,6 +21,7 @@
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Arithmetic/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Async/Passes.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -151,6 +153,9 @@ void LLVMLoweringPass::runOnOperation() {
   // have been missed previously.
   dynamicPM.addNestedPass<FuncOp>(createConvertVectorToSCFPass());
   dynamicPM.addNestedPass<FuncOp>(createConvertLinalgToLoopsPass());
+  dynamicPM.addPass(createAsyncToAsyncRuntimePass());
+  dynamicPM.addPass(createAsyncRuntimeRefCountingPass());
+  dynamicPM.addPass(createAsyncRuntimeRefCountingOptPass());
   dynamicPM.addPass(createCanonicalizerPass());
   dynamicPM.addPass(createLowerAffinePass());
   dynamicPM.addPass(createLowerToCFGPass());
@@ -167,6 +172,7 @@ void LLVMLoweringPass::runOnOperation() {
   // clang-format on
   dynamicPM.addNestedPass<FuncOp>(createConvertMathToLLVMPass());
   dynamicPM.addPass(createMemRefToLLVMPass());
+  dynamicPM.addPass(createConvertAsyncToLLVMPass());
   dynamicPM.addPass(createLowerToLLVMPass());
   dynamicPM.addPass(createCanonicalizerPass());
   dynamicPM.addPass(createCSEPass());

--- a/python/examples/core/compilation.py
+++ b/python/examples/core/compilation.py
@@ -31,6 +31,7 @@ _MLIR_RUNNER_UTILS_LIB_ENV = "MLIR_RUNNER_UTILS_LIB"
 _MLIR_RUNNER_UTILS_LIB_DEFAULT = "libmlir_runner_utils.so"
 _MLIR_C_RUNNER_UTILS_LIB_ENV = "MLIR_C_RUNNER_UTILS_LIB"
 _MLIR_C_RUNNER_UTILS_LIB_DEFAULT = "libmlir_c_runner_utils.so"
+_MLIR_RUNNER_EXTRA_LIBS_ENV = "MLIR_RUNNER_EXTRA_LIBS"
 
 
 def numpy_type(scalar_type):
@@ -153,12 +154,14 @@ def compile_to_execution_engine(module,
                                 transform: Callable,
                                 opt_level: int = 3):
   transformed_module = transform(module)
-  execution_engine = ExecutionEngine(
-      transformed_module,
-      opt_level,
-      shared_libs=[
-          os.getenv(_MLIR_RUNNER_UTILS_LIB_ENV, _MLIR_RUNNER_UTILS_LIB_DEFAULT),
-          os.getenv(_MLIR_C_RUNNER_UTILS_LIB_ENV,
-                    _MLIR_C_RUNNER_UTILS_LIB_DEFAULT)
-      ])
+  shared_libs = [
+      os.getenv(_MLIR_RUNNER_UTILS_LIB_ENV, _MLIR_RUNNER_UTILS_LIB_DEFAULT),
+      os.getenv(_MLIR_C_RUNNER_UTILS_LIB_ENV, _MLIR_C_RUNNER_UTILS_LIB_DEFAULT)
+  ]
+  extra_libs = os.getenv(_MLIR_RUNNER_EXTRA_LIBS_ENV)
+  if extra_libs is not None:
+    shared_libs.append(*(str(extra_libs).split(',')))
+  execution_engine = ExecutionEngine(transformed_module,
+                                     opt_level,
+                                     shared_libs=shared_libs)
   return transformed_module, execution_engine

--- a/python/examples/core/transforms.py
+++ b/python/examples/core/transforms.py
@@ -243,12 +243,39 @@ class LinalgExtTileToInParallel(Transform):
   def __init__(self, fun_name: str, op_name: str, **kwargs):
     self._parse_variables_in_kwargs(kwargs)
 
-    pipeline = (
-        f'linalg-tile-to-in-parallel,'
-        # TODO: when bufferization works, no more need to go through sequential for
-        # f'linalg-in-parallel-to-sequential-for,'
-        f'canonicalize,'
-        f'cse')
+    pipeline = (f'linalg-tile-to-in-parallel,'
+                f'canonicalize,'
+                f'cse')
+    self.pipeline = (f'builtin.func({pipeline})')
+
+
+class LinalgExtInParallelToSequentialFor(Transform):
+  """Rewrite linalg_ext.in_parallel op to scf.for.
+  """
+
+  variables = {}
+
+  def __init__(self, fun_name: str, op_name: str, **kwargs):
+    self._parse_variables_in_kwargs(kwargs)
+
+    pipeline = (f'linalg-in-parallel-to-sequential-for,'
+                f'canonicalize,'
+                f'cse')
+    self.pipeline = (f'builtin.func({pipeline})')
+
+
+class LinalgExtInParallelToAsync(Transform):
+  """Rewrite linalg_ext.in_parallel op to async.
+  """
+
+  variables = {}
+
+  def __init__(self, fun_name: str, op_name: str, **kwargs):
+    self._parse_variables_in_kwargs(kwargs)
+
+    pipeline = (f'linalg-in-parallel-to-async,'
+                f'canonicalize,'
+                f'cse')
     self.pipeline = (f'builtin.func({pipeline})')
 
 

--- a/python/examples/linalg_ext/test_seq.py
+++ b/python/examples/linalg_ext/test_seq.py
@@ -14,17 +14,12 @@ import typing as tp
 # Compilation strategies.
 ################################################################################
 
-
-def TestExpert(transforms: tp.Sequence[tp.Union[Transform,
-                                                TransformationList]]):
-  return (TransformationList(transforms=transforms) + Bufferize() +
-          LoweringOnlyExpert('matmul', 'linalg.generic'))
-
-
-expert_linalg_ext_tile = TestExpert([
-    LinalgExtTile('matmul', 'linalg.generic', tile_sizes=[2]),
-    LinalgExtTileToSequentialFor('matmul', 'linalg.generic'),
-    Vectorize('matmul', 'linalg.generic'),
+expert_linalg_ext_tile = TransformationList(transforms=[
+    LinalgExtTile('matmul_on_tensors', 'linalg.generic', tile_sizes=[2]),
+    LinalgExtTileToSequentialFor('matmul_on_tensors', 'linalg.generic'),
+    Vectorize('matmul_on_tensors', 'linalg.generic'),
+    Bufferize(),
+    LowerToLLVM(),
 ])
 
 all_experts = [

--- a/run_tests.py
+++ b/run_tests.py
@@ -5,7 +5,8 @@ import os
 import subprocess
 import sys
 
-def _convert_path_to_module(test_script : str) -> str:
+
+def _convert_path_to_module(test_script: str) -> str:
   """Convert the path of the test script to its module name."""
   test_script = test_script.replace(os.sep, ".")
   test_script = test_script.strip(".")
@@ -24,6 +25,8 @@ def _configure_env():
                                               "lib/libmlir_runner_utils.so")
   env["MLIR_C_RUNNER_UTILS_LIB"] = os.path.join(
       build_dir, "lib/libmlir_c_runner_utils.so")
+  env["MLIR_RUNNER_EXTRA_LIBS"] = os.path.join(
+      build_dir, "lib/libmlir_async_runtime_copy.so")
   return env
 
 


### PR DESCRIPTION
This revision plugs the remaining transformations with the async dialect now that buferization is functional.
This now successfully generates parallel code and executes in parallel from tensor-level abstractions.
    
To make this happen, make a temporary copy of the AsyncRuntime library function and pipe it through the configure.
This is temporarily needed to circumvent symbol visibility issues related to dlopen/dlclose/atexit and std::thread
(see [here](https://llvm.discourse.group/t/aync-runtime-method-not-being-properly-exported/3708)).
    
Repro:
```
export MLIR_RUNNER_EXTRA_LIBS="${IREE_LLVM_SANDBOX_BUILD_DIR}/lib/libmlir_async_runtime_copy.so" && \
${HOME}/.venv/mlirdev/bin/python -m python.examples.linalg_ext.test_in_par
```