### PR TITLE
[linalg_transform] Replace Targetable Ops with a Match Op

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.h
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.h
@@ -16,27 +16,6 @@
 #include "Dialects/LinalgTransform/LinalgTransformOpsDialect.h.inc"
 #include "mlir/IR/BuiltinAttributes.h"
 
-namespace mlir {
-/// A trait for transform ops that can be targeted at either the result of a
-/// matcher (identified by its symbol name) or at the result of another
-/// transformation (identified by the value it produced).
-template <typename ConcreteOp>
-class TargetableTransformOpTrait
-    : public OpTrait::TraitBase<ConcreteOp, TargetableTransformOpTrait> {
-public:
-  static LogicalResult verifyTrait(Operation *op) {
-    Optional<SymbolRefAttr> matcher = cast<ConcreteOp>(op).targetMatcher();
-    Value input = cast<ConcreteOp>(op).target();
-    if (!((matcher.hasValue() && matcher.getValue() != nullptr) ^
-          (input != nullptr)))
-      return op->emitOpError()
-             << "expects either an `op` operand or a `matcher` attribute";
-
-    return success();
-  }
-};
-} // namespace mlir
-
 #define GET_OP_CLASSES
 #include "Dialects/LinalgTransform/LinalgTransformOps.h.inc"
 

--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -46,7 +46,8 @@ def ScopeOp : Linalg_Transform_Operation<"util.scope",
   let regions = (region AnyRegion:$body);
   let arguments = (ins Variadic<AnyType>:$ins);
   let results = (outs Variadic<AnyType>:$outs);
-  let assemblyFormat = "`(` operands `)` attr-dict-with-keyword $body `:` functional-type(operands, results)";
+  let assemblyFormat = [{ `(` operands `)` attr-dict-with-keyword $body
+                          `:` functional-type(operands, results) }];
 
   let verifier = [{ return RegionBranchOpInterface::verifyTypes(*this); }];
 }
@@ -88,16 +89,23 @@ def SequenceOp : Linalg_Transform_Operation<"sequence",
 
 //===----------------------------------------------------------------------===//
 
-def TargetableOpTrait : NativeOpTrait<"TargetableTransformOpTrait"> {
-  let cppNamespace = "::mlir";
+def MatchOp : Linalg_Transform_Operation<"match"> {
+  let description = [{ Find and return an op that matches the specific PDL
+  pattern. When executed inside a sequence, it returns all matching ops. }];
+
+  let arguments = (ins SymbolRefAttr:$targetMatcher);
+  let results = (outs PDL_Operation:$target);
+
+  let assemblyFormat = "$targetMatcher attr-dict";
 }
 
-def TileOp : Linalg_Transform_Operation<"tile", [TargetableOpTrait]> {
+//===----------------------------------------------------------------------===//
+
+def TileOp : Linalg_Transform_Operation<"tile"> {
   let description = [{Indicates that ops of a specific kind in the given
   function should be tiled with the options provided as attributes.}];
 
-  let arguments = (ins Optional<PDL_Operation>:$target,
-                   OptionalAttr<SymbolRefAttr>:$targetMatcher,
+  let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$sizes,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$interchange,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$peel,
@@ -113,8 +121,7 @@ def TileOp : Linalg_Transform_Operation<"tile", [TargetableOpTrait]> {
                   );
   let results = (outs PDL_Operation:$transformed);
 
-  let assemblyFormat = "($target^)? (`when` $targetMatcher^)? attr-dict";
-
+  let assemblyFormat = "$target attr-dict";
   let hasVerifier = 1;
 }
 
@@ -129,17 +136,16 @@ def DecomposeOp : Linalg_Transform_Operation<"decompose"> {
   let assemblyFormat = "attr-dict";
 }
 
-def VectorizeOp : Linalg_Transform_Operation<"vectorize", [TargetableOpTrait]> {
+def VectorizeOp : Linalg_Transform_Operation<"vectorize"> {
   let description = [{Indiactes that ops of a specific kind in the given
   function should be vectorized with the options provided as attributes.}];
 
-  let arguments = (ins Optional<PDL_Operation>:$target,
-                   OptionalAttr<SymbolRefAttr>:$targetMatcher,
+  let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<BoolAttr, "false">:$vectorize_padding
                   );
   let results = (outs PDL_Operation:$transformed);
 
-  let assemblyFormat = "($target^)? (`when` $targetMatcher^)? attr-dict";
+  let assemblyFormat = "$target attr-dict";
 }
 
 def LowerVectorsOp : Linalg_Transform_Operation<"lower_vectors"> {
@@ -170,18 +176,16 @@ def LowerToLLVMOp : Linalg_Transform_Operation<"lower_to_llvm"> {
 
 //===----------------------------------------------------------------------===//
 
-def ExpertOp : Linalg_Transform_Operation<"expert", [TargetableOpTrait]> {
+def ExpertOp : Linalg_Transform_Operation<"expert"> {
   let description = [{A "transformation expert" that can be lowered to a
   sequence of transformations. The details of the lowering depend on the name
   and are expressed declaratively.}];
 
-  let arguments = (ins Optional<PDL_Operation>:$target,
-                   OptionalAttr<SymbolRefAttr>:$targetMatcher,
+  let arguments = (ins PDL_Operation:$target,
                    StrAttr:$expertName);
   let results = (outs PDL_Operation:$transformed);
 
-  let assemblyFormat = "`apply` $expertName (`to` $target^)? "
-                       "(`when` $targetMatcher^)? attr-dict";
+  let assemblyFormat = "`apply` $expertName `to` $target attr-dict";
 }
 
 #endif // LINALG_TRANSFORM_OPS

--- a/lib/Dialects/LinalgTransform/Transforms/CMakeLists.txt
+++ b/lib/Dialects/LinalgTransform/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(MLIRLinalgTransformTransforms
   ExpertExpansion.cpp
+  PDL.cpp
   ScopedTransform.cpp
   TrackingCSE.cpp
   TrackingRewriteDriver.cpp

--- a/lib/Dialects/LinalgTransform/Transforms/PDL.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/PDL.cpp
@@ -1,0 +1,84 @@
+//===-- PDL.cpp - Interoperability with PDL -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PDL.h"
+
+#include "Transforms/Functional.h"
+#include "mlir/Dialect/PDL/IR/PDLOps.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Rewrite/PatternApplicator.h"
+
+namespace mlir {
+namespace linalg {
+
+/// Return ops that match any of the patterns.
+static SmallVector<LinalgOp> getMatchingOps(
+    Operation *parent, const FrozenRewritePatternSet &patterns) {
+  PatternApplicator applicator(patterns);
+  applicator.applyDefaultCostModel();
+
+  // TODO: The C++ functional API needs better interoperability with PDL.
+  return functional::applyForEachIn(
+      parent,
+      [&](Operation *op, PatternRewriter &rewriter) -> FailureOr<LinalgOp> {
+        if (succeeded(applicator.matchAndRewrite(op, rewriter)))
+          if (auto linalgOp = dyn_cast<LinalgOp>(op)) return linalgOp;
+        return failure();
+      });
+}
+
+/// Hook for PDL driver to check if an operation (`value`) is directly nested in
+/// a function with the name provided as constant parameter.
+/// TODO: PDL needs user-defined "questions".
+static LogicalResult nestedInFunc(PDLValue value, ArrayAttr constantParams,
+                                  PatternRewriter &rewriter) {
+  auto *operation = value.cast<Operation *>();
+  auto func = operation->getParentOfType<FuncOp>();
+  assert(constantParams.size() == 1 &&
+         "expected a constant param with function name");
+  auto functionSymbol = constantParams[0].dyn_cast<SymbolRefAttr>();
+  assert(functionSymbol && "expected a function name");
+
+  if (!func)
+    return rewriter.notifyMatchFailure(operation, "not nested in a function");
+  return success(functionSymbol.getLeafReference() == func.getName());
+}
+
+/// PDL rewrite hook that does nothing.
+static void noOpRewriter(ArrayRef<PDLValue> args, ArrayAttr constantParams,
+                         PatternRewriter &rewriter, PDLResultList &results) {
+  assert(args.size() == 1 && "expected one argument");
+#ifndef NDEBUG
+  args.front().cast<Operation *>()->setAttr("linalg_transform.matched",
+                                            rewriter.getUnitAttr());
+#endif
+}
+
+FailureOr<SmallVector<LinalgOp>> findMatchingOps(Operation *op,
+                                                 SymbolRefAttr pattern,
+                                                 ModuleOp module) {
+  auto patternOp = module.lookupSymbol<pdl::PatternOp>(pattern);
+  if (!patternOp)
+    return {op->emitError("could not find a pattern named: ") << pattern};
+
+  // Clone the pattern operation into the temporary module used by the driver
+  // as it might be referenced multiple times.
+  OwningOpRef<ModuleOp> pdlModuleOp = ModuleOp::create(patternOp.getLoc());
+  OpBuilder::atBlockBegin(&pdlModuleOp->body().front()).clone(*patternOp);
+
+  // Build the PDL module.
+  PDLPatternModule pdlModule(std::move(pdlModuleOp));
+  pdlModule.registerConstraintFunction("nestedInFunc", nestedInFunc);
+  pdlModule.registerRewriteFunction("linalg_transform.apply", noOpRewriter);
+
+  RewritePatternSet patterns(std::move(pdlModule));
+  return getMatchingOps(module, std::move(patterns));
+}
+
+}  // namespace linalg
+}  // namespace mlir

--- a/lib/Dialects/LinalgTransform/Transforms/PDL.h
+++ b/lib/Dialects/LinalgTransform/Transforms/PDL.h
@@ -1,0 +1,35 @@
+//===-- PDL.h - Interoperability with PDL ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef IREE_LLVM_SANDBOX_DIALECTS_LINALGTRANSFORM_TRANSFORMS_PDL_H
+#define IREE_LLVM_SANDBOX_DIALECTS_LINALGTRANSFORM_TRANSFORMS_PDL_H
+
+#include "Dialects/LinalgTransform/LinalgTransformOps.h"
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LLVM.h"
+
+namespace mlir {
+namespace linalg {
+
+/// Find all operations in `module` that are matched by the specified PDL
+/// pattern, which is also located in `module`.
+FailureOr<SmallVector<LinalgOp>> findMatchingOps(Operation *op,
+                                                 SymbolRefAttr pattern,
+                                                 ModuleOp module);
+inline FailureOr<SmallVector<LinalgOp>> findMatchingOps(transform::MatchOp op,
+                                                        ModuleOp module) {
+  return findMatchingOps(op, op.targetMatcher(), module);
+}
+
+}  // namespace linalg
+}  // namespace mlir
+
+#endif  // IREE_LLVM_SANDBOX_DIALECTS_LINALGTRANSFORM_TRANSFORMS_PDL_H

--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -52,6 +52,19 @@ def _ensure_string_attr(value: StringArg):
   return value
 
 
+class MatchOp:
+  """Specialization for the MatchOp class."""
+
+  def __init__(self, target):
+    if isinstance(target, str):
+      target = ir.FlatSymbolRefAttr.get(target)
+
+    # FIXME: don't rely on parsing when the PDL dialect is available in Python
+    operation_type = ir.Type.parse("!pdl.operation")
+
+    super().__init__(operation_type, target)
+
+
 class LowerVectorsOp:
   """Specialization for the LowerVectorsOp class."""
 
@@ -91,8 +104,7 @@ class TileOp:
   """Specialization for the TileOp class."""
 
   def __init__(self,
-               target: Union[ir.Value, ir.Operation, ir.OpView, str,
-                             ir.FlatSymbolRefAttr],
+               target: Union[ir.Value, ir.Operation, ir.OpView],
                *,
                sizes: IntListArg = None,
                interchange: IntListArg = None,
@@ -116,13 +128,9 @@ class TileOp:
     generalize = _ensure_bool_attr(generalize, False)
     operation_type = pdl.OperationType.get()
 
-    if isinstance(target, str):
-      target = ir.FlatSymbolRefAttr.get(target)
-
     super().__init__(
         operation_type,
-        target if not isinstance(target, ir.FlatSymbolRefAttr) else None,
-        target if isinstance(target, ir.FlatSymbolRefAttr) else None,
+        target,
         sizes,
         interchange,
         peel,
@@ -139,21 +147,16 @@ class TileOp:
 class VectorizeOp:
 
   def __init__(self,
-               target: Union[ir.Value, ir.Operation, ir.OpView, str,
-                             ir.FlatSymbolRefAttr],
+               target: Union[ir.Value, ir.Operation, ir.OpView],
                *,
                vectorize_padding: BoolArg,
                loc=None,
                ip=None):
-    if isinstance(target, str):
-      target = ir.FlatSymbolRefAttr.get(target)
-
     operation_type = pdl.OperationType.get()
 
     super().__init__(
         operation_type,
-        target if not isinstance(target, ir.FlatSymbolRefAttr) else None,
-        target if isinstance(target, ir.FlatSymbolRefAttr) else None,
+        target,
         _ensure_bool_attr(vectorize_padding, False),
         loc=loc,
         ip=ip)

--- a/test/LinalgTransform/invalid.mlir
+++ b/test/LinalgTransform/invalid.mlir
@@ -1,24 +1,27 @@
 // RUN: mlir-proto-opt %s -split-input-file -verify-diagnostics
 
 linalg_transform.sequence {
+  %0 = match @match
   // expected-error@below {{result #0 has more than one use}}
-  %0 = tile when @match
+  %1 = tile %0
   // expected-note@below {{used here as operand #0}}
-  tile %0
+  tile %1
   // expected-note@below {{used here as operand #0}}
-  vectorize %0
+  vectorize %1
 }
 
 // -----
 
 linalg_transform.sequence {
+  %0 = match @match
   // expected-error@below {{expects transpose paddings to be a permutation, found [2, 0]}}
-  tile when @match {pad = true, transpose_paddings = [[0, 1], [2, 0]]}
+  tile %0 {pad = true, transpose_paddings = [[0, 1], [2, 0]]}
 }
 
 // -----
 
 linalg_transform.sequence {
+  %0 = match @match
   // expected-error@below {{"sizes" and "scalarize_dyn_dims" attributes are mutually exclusive}}
-  tile when @match {sizes = [1,2,3], scalarize_dyn_dims = true}
+  tile %0 {sizes = [1,2,3], scalarize_dyn_dims = true}
 }

--- a/test/LinalgTransform/roundtrip.mlir
+++ b/test/LinalgTransform/roundtrip.mlir
@@ -2,19 +2,23 @@
 
 // CHECK: linalg_transform.sequence
 linalg_transform.sequence {
-  // CHECK: %[[TILED:.*]] = tile when @match1 {
-  // CHECK_DAG: pad = false
+  // CHECK: %[[OPS:.*]] = match @{{.*}}
+  %0 = match @match1
+  // CHECK: %[[TILED:.*]] = tile %[[OPS]] {
+  // CHECK-DAG: pad = false
   // CHECK-DAG: sizes = [4, 4, 4]
   // CHECK: }
-  %1 = tile when @match1 {sizes = [4, 4, 4], pad = false}
+  %1 = tile %0 {sizes = [4, 4, 4], pad = false}
   // CHECK: %[[TILED2:.*]] = tile %[[TILED]]
   %2 = tile %1 {sizes = [2, 2, 2], pad = true}
   // CHECK: decompose
   decompose
   // CHECK: %{{.*}} = vectorize %[[TILED2]] {vectorize_padding = true}
   %3 = vectorize %2 {vectorize_padding = true}
-  // CHECK: %{{.*}} = vectorize when @match2
-  vectorize when @match2
+  // CHECK: %[[OPS2:.*]] = match @{{.*}}
+  %4 = match @match2
+  // CHECK: %{{.*}} = vectorize %[[OPS2]]
+  vectorize %4
   // CHECK: bufferize
   bufferize
   // CHECK: lower_vectors {multireduction_lowering = "innerreduce"}

--- a/test/LinalgTransform/selective-targeting.mlir
+++ b/test/LinalgTransform/selective-targeting.mlir
@@ -69,6 +69,8 @@ pdl.pattern @pdl_target_attrC : benefit(1) {
 }
 
 linalg_transform.sequence {
-  tile when @pdl_target_attrA {sizes = [4, 4, 4], pad = false}
-  vectorize when @pdl_target_attrC
+  %0 = match @pdl_target_attrA
+  tile %0 {sizes = [4, 4, 4], pad = false}
+  %1 = match @pdl_target_attrC
+  vectorize %1
 }

--- a/test/LinalgTransform/single-tiling-full-script.mlir
+++ b/test/LinalgTransform/single-tiling-full-script.mlir
@@ -24,8 +24,9 @@ pdl.pattern @pdl_target : benefit(1) {
 }
 
 linalg_transform.sequence {
-  %0 = tile when @pdl_target {sizes = [4, 4, 4]}
-  %1 = vectorize %0 {vectorize_padding = true}
+  %0 = match @pdl_target
+  %1 = tile %0 {sizes = [4, 4, 4]}
+  %2 = vectorize %1 {vectorize_padding = true}
   bufferize
   lower_vectors { multireduction_lowering = "innerreduce"}
   lower_to_llvm

--- a/test/LinalgTransform/tile-interchange.mlir
+++ b/test/LinalgTransform/tile-interchange.mlir
@@ -28,9 +28,10 @@ pdl.pattern @target_pattern : benefit(1) {
 }
 
 linalg_transform.sequence {
-  %0 = tile when @target_pattern {interchange = [0, 2, 1],  sizes = [3, 5, 14]}
-  %1 = tile %0 { sizes = [3, 5, 2]}
-  %2 = vectorize %1 {vectorize_padding = true}
+  %0 = match @target_pattern
+  %1 = tile %0 {interchange = [0, 2, 1],  sizes = [3, 5, 14]}
+  %2 = tile %1 { sizes = [3, 5, 2]}
+  %3 = vectorize %2 {vectorize_padding = true}
 }
 
 
@@ -64,7 +65,8 @@ pdl.pattern @target_pattern : benefit(1) {
 }
 
 linalg_transform.sequence {
-  %0 = tile when @target_pattern {interchange = [2, 1, 0],  sizes = [3, 5, 14]}
-  %1 = tile %0 { sizes = [3, 5, 2]}
-  %2 = vectorize %1 {vectorize_padding = true}
+  %0 = match @target_pattern
+  %1 = tile %0 {interchange = [2, 1, 0],  sizes = [3, 5, 14]}
+  %2 = tile %1 { sizes = [3, 5, 2]}
+  %3 = vectorize %2 {vectorize_padding = true}
 }

--- a/test/LinalgTransform/tile.mlir
+++ b/test/LinalgTransform/tile.mlir
@@ -39,5 +39,6 @@ pdl.pattern @pdl_target : benefit(1) {
 }
 
 linalg_transform.sequence {
-  %0 = tile when @pdl_target {sizes = [4, 4, 4], pad = false}
+  %0 = match @pdl_target
+  tile %0 {sizes = [4, 4, 4], pad = false}
 }

--- a/test/LinalgTransform/vectorize.mlir
+++ b/test/LinalgTransform/vectorize.mlir
@@ -31,5 +31,6 @@ pdl.pattern @pdl_target : benefit(1) {
 }
 
 linalg_transform.sequence {
-  %1 = vectorize when @pdl_target {vectorize_padding = true}
+  %0 = match @pdl_target
+  vectorize %0 {vectorize_padding = true}
 }


### PR DESCRIPTION
Created a `linalg_transform.match` op that returns the ops matched by a PDL
pattern. Removed the dual-use "target or target matcher" of certain transform
ops. Splitting the match makes more sense composability-wise.