### PR TITLE
Fix python bindings for tiling in transform dialect

### DIFF
--- a/python/examples/dialects/linalg_transform_test.py
+++ b/python/examples/dialects/linalg_transform_test.py
@@ -19,9 +19,9 @@ def run(f):
     print(module)
 
 
-# CHECK-LABEL: TEST: create_sequence
+# CHECK-LABEL: TEST: tile_once
 @run
-def create_sequence():
+def tile_once():
   sequence = transform.SequenceOp()
   with ir.InsertionPoint(sequence.body.blocks[0]):
     tiled = transform.TileOp("foo", sizes=[32, 16], pad=True)
@@ -32,6 +32,26 @@ def create_sequence():
 
   code = str(sequence)
   assert "tile when @foo" in code
+  assert "sizes = [32, 16]" in code
+  assert "pad = true" in code
+  assert "vectorize" in code
+
+
+# CHECK-LABEL: TEST: tile_twice
+@run
+def tile_twice():
+  sequence = transform.SequenceOp()
+  with ir.InsertionPoint(sequence.body.blocks[0]):
+    tiled1 = transform.TileOp("foo", sizes=[128, 32], pad=True)
+    tiled2 = transform.TileOp(tiled1, sizes=[32, 16], pad=True)
+    transform.VectorizeOp(tiled2, vectorize_padding=True)
+    transform.BufferizeOp()
+    transform.LowerVectorsOp(multireduction_lowering="innerreduce")
+    transform.LowerToLLVMOp()
+
+  code = str(sequence)
+  assert "tile when @foo" in code
+  assert "sizes = [128, 32]" in code
   assert "sizes = [32, 16]" in code
   assert "pad = true" in code
   assert "vectorize" in code

--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -4,6 +4,7 @@
 
 try:
   import mlir.ir as ir
+  import mlir.dialects.pdl as pdl
   from typing import Optional, Sequence, Union
 except ImportError as e:
   raise RuntimeError("Error loading imports from extension module") from e
@@ -96,27 +97,24 @@ class TileOp:
     hoist_paddings = _ensure_array_attr(hoist_paddings, [])
     scalarize_dyn_dims = _ensure_bool_attr(scalarize_dyn_dims, False)
     generalize = _ensure_bool_attr(generalize, False)
-
-    # FIXME: don't rely on parsing when the PDL dialect is available in Python
-    operation_type = ir.Type.parse("!pdl.operation")
+    operation_type = pdl.OperationType.get()
 
     if isinstance(target, str):
       target = ir.FlatSymbolRefAttr.get(target)
 
-      super().__init__(
-          operation_type,
-          target if not isinstance(target, ir.FlatSymbolRefAttr) else None,
-          target if isinstance(target, ir.FlatSymbolRefAttr) else None,
-          sizes,
-          interchange,
-          pad,
-          pack_paddings,
-          hoist_paddings,
-          scalarize_dyn_dims,
-          generalize,
-          loc=loc,
-          ip=ip)
-      return
+    super().__init__(
+        operation_type,
+        target if not isinstance(target, ir.FlatSymbolRefAttr) else None,
+        target if isinstance(target, ir.FlatSymbolRefAttr) else None,
+        sizes,
+        interchange,
+        pad,
+        pack_paddings,
+        hoist_paddings,
+        scalarize_dyn_dims,
+        generalize,
+        loc=loc,
+        ip=ip)
 
 
 class VectorizeOp:
@@ -131,8 +129,7 @@ class VectorizeOp:
     if isinstance(target, str):
       target = ir.FlatSymbolRefAttr(target)
 
-    # FIXME: don't rely on parsing when the PDL dialect is available in Python
-    operation_type = ir.Type.parse("!pdl.operation")
+    operation_type = pdl.OperationType.get()
 
     super().__init__(
         operation_type,


### PR DESCRIPTION
Previously, due to an oversight, it was impossible to express two-level tiling using python bindings for the transform dialect. This change addresses the issue, and cleans up some minor FIXMEs in the same module.