### PR TITLE
Disallow more than one value use in the transform dialect

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -64,7 +64,17 @@ def ForwardOp : Linalg_Transform_Operation<"util.forward",
 
 def SequenceOp : Linalg_Transform_Operation<"sequence",
                                             [NoTerminator, OpAsmOpInterface]> {
-  let description = [{Contains a sequence of transformation ops to apply.}];
+  let description = [{Contains a sequence of transformation ops to apply.
+
+  The transformations indicated by the sequence are applied in order of their
+  appearance. Each value produced by a transformation within the sequence
+  corresponds to an operation or a group of operations in the IR being
+  transformed. Therefore, each value may be used at most once by another
+  transformation operation as the transformation is likely to replace the
+  transformed operation with another operation or a group thereof. In such
+  cases, the tranfsormation operation is expected to produce a new value to
+  denote the newly produced operations that can be transformed further.
+  }];
 
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = "attr-dict-with-keyword regions";
@@ -72,6 +82,8 @@ def SequenceOp : Linalg_Transform_Operation<"sequence",
   let extraClassDeclaration = [{
     static StringRef getDefaultDialect() { return "linalg_transform"; }
   }];
+
+  let verifier = [{ return verifySequenceOp(*this); }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/LinalgTransform/invalid.mlir
+++ b/test/LinalgTransform/invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-proto-opt %s -split-input-file -verify-diagnostics
+
+linalg_transform.sequence {
+  // expected-error@below {{result #0 has more than one use}}
+  %0 = tile when @match
+  // expected-note@below {{used here as operand #0}}
+  tile %0
+  // expected-note@below {{used here as operand #0}}
+  vectorize %0
+}


### PR DESCRIPTION
In the transform dialect, values correspond to an operation or a group
of operations in the IR being transformed. Applying a transformation
most likely changes the operation, so it becomes conceptually tricky to
relate the value to some operation. Instead, we can consider that the
value is "consumed" by the transformation operation, which may define
new values that map to the operations obtained as the result of
transformation for chaining purposes.