### PR TITLE
Report errors when transform dialect interpretation fails

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -64,7 +64,17 @@ def ForwardOp : Linalg_Transform_Operation<"util.forward",
 
 def SequenceOp : Linalg_Transform_Operation<"sequence",
                                             [NoTerminator, OpAsmOpInterface]> {
-  let description = [{Contains a sequence of transformation ops to apply.}];
+  let description = [{Contains a sequence of transformation ops to apply.
+
+  The transformations indicated by the sequence are applied in order of their
+  appearance. Each value produced by a transformation within the sequence
+  corresponds to an operation or a group of operations in the IR being
+  transformed. Therefore, each value may be used at most once by another
+  transformation operation as the transformation is likely to replace the
+  transformed operation with another operation or a group thereof. In such
+  cases, the tranfsormation operation is expected to produce a new value to
+  denote the newly produced operations that can be transformed further.
+  }];
 
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = "attr-dict-with-keyword regions";
@@ -72,6 +82,8 @@ def SequenceOp : Linalg_Transform_Operation<"sequence",
   let extraClassDeclaration = [{
     static StringRef getDefaultDialect() { return "linalg_transform"; }
   }];
+
+  let verifier = [{ return verifySequenceOp(*this); }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -574,11 +574,9 @@ static LogicalResult executeSequence(linalg::transform::SequenceOp sequence,
   }
 
   for (Operation &transform : sequence.body().front()) {
-    if (failed(executeTransform(&transform, module, operations))) {
-      // TODO: should this be a user-visible error?
-      LLVM_DEBUG(DBGS() << "failed to apply transform: " << transform << "\n");
-      return failure();
-    }
+    if (failed(executeTransform(&transform, module, operations)))
+      return transform.emitError() << "failed to apply";
+
     LLVM_DEBUG(DBGS() << "successfully applied transform: " << transform
                       << "\n");
 

--- a/test/LinalgTransform/failure.mlir
+++ b/test/LinalgTransform/failure.mlir
@@ -1,0 +1,28 @@
+// RUN: mlir-proto-opt -linalg-interp-transforms -split-input-file -verify-diagnostics
+
+// This cannot be vectorized because of dynamic tensor shapes. We expect the
+// pass fail and report an error at the vectorization operation below.
+func public @non_vectorizable(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %0 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+    ins(%arg0: tensor<?xf32>) outs(%arg1: tensor<?xf32>) {
+  ^bb0(%arg2: f32, %arg3: f32):
+    %1 = arith.mulf %arg2, %arg2 : f32
+    linalg.yield %1 : f32
+  } -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+pdl.pattern @target_pattern : benefit(1) {
+  %0 = operands
+  %1 = types
+  %2 = operation "linalg.generic"(%0 : !pdl.range<value>)  -> (%1 : !pdl.range<type>)
+  rewrite %2 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  // expected-error@below {{failed to apply}}
+  vectorize when @target_pattern
+}
+

--- a/test/LinalgTransform/invalid.mlir
+++ b/test/LinalgTransform/invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-proto-opt %s -split-input-file -verify-diagnostics
+
+linalg_transform.sequence {
+  // expected-error@below {{result #0 has more than one use}}
+  %0 = tile when @match
+  // expected-note@below {{used here as operand #0}}
+  tile %0
+  // expected-note@below {{used here as operand #0}}
+  vectorize %0
+}


### PR DESCRIPTION
The transform dialect interpretation consists in applying individual
transformations, specified as operations, in a chain. Each of these
transformations may fail and lead to the entire pass failing. Report to
the user which of the transformation failed using a diagnostic.