### PR TITLE
Avoid keeping pointers to deleted ops in transform interpreter

### DIFF
--- a/test/LinalgTransform/failure.mlir
+++ b/test/LinalgTransform/failure.mlir
@@ -26,3 +26,65 @@ linalg_transform.sequence {
   vectorize when @target_pattern
 }
 
+// -----
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func public @benchmark(%arg0: tensor<39x154xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = false}, %arg1: tensor<154x5xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = false}, %arg2: tensor<39x5xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = true}) -> tensor<39x5xf32> attributes {passthrough = ["noinline", ["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]} {
+  %0 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<39x154xf32>, tensor<154x5xf32>) outs(%arg2 : tensor<39x5xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+    %1 = arith.mulf %arg3, %arg4 : f32
+    %2 = arith.addf %arg5, %1 : f32
+    linalg.yield %2 : f32
+  } -> tensor<39x5xf32>
+  return %0 : tensor<39x5xf32>
+}
+
+pdl.pattern @target_pattern : benefit(1) {
+  %0 = operands
+  %1 = types
+  %2 = operation "linalg.generic"(%0 : !pdl.range<value>)  -> (%1 : !pdl.range<type>)
+  apply_native_constraint "nestedInFunc" [@benchmark](%2 : !pdl.operation)
+  rewrite %2 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  %0 = tile when @target_pattern {interchange = [0, 2, 1],  sizes = [3, 5, 14]}
+  %1 = tile %0 { sizes = [3, 5, 2]}
+  // expected-error@below {{failed to apply}}
+  %2 = vectorize %1 {vectorize_padding = true}
+}
+
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func public @benchmark(%arg0: tensor<39x154xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = false}, %arg1: tensor<154x5xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = false}, %arg2: tensor<39x5xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = true}) -> tensor<39x5xf32> attributes {passthrough = ["noinline", ["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]} {
+  %0 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<39x154xf32>, tensor<154x5xf32>) outs(%arg2 : tensor<39x5xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+    %1 = arith.mulf %arg3, %arg4 : f32
+    %2 = arith.addf %arg5, %1 : f32
+    linalg.yield %2 : f32
+  } -> tensor<39x5xf32>
+  return %0 : tensor<39x5xf32>
+}
+
+pdl.pattern @target_pattern : benefit(1) {
+  %0 = operands
+  %1 = types
+  %2 = operation "linalg.generic"(%0 : !pdl.range<value>)  -> (%1 : !pdl.range<type>)
+  apply_native_constraint "nestedInFunc" [@benchmark](%2 : !pdl.operation)
+  rewrite %2 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  %0 = tile when @target_pattern {interchange = [2, 1, 0],  sizes = [3, 5, 14]}
+  %1 = tile %0 { sizes = [3, 5, 2]}
+  // expected-error@below {{failed to apply}}
+  %2 = vectorize %1 {vectorize_padding = true}
+}


### PR DESCRIPTION
The transform interpreter maintains a mapping between the values
produced by the transform dialect operations and (sets of) operations in
the main IR to transform. Each transformation is likely to change the
tracked operation so the transform dialect diallows more than one use.
However, the pointer to the operation may still be kept in the mapping,
leading to use-after-free (or, in the case where the pointer address is
reused for a different operation, to the transform interpreter accessing
unexpected operations). Leverage the single-use restriction and clean up
the mapping immediately after the corresponding value is "consumed" by
the transform dialect operation.