### PR TITLE
Fix unused variable warning in release build

### DIFF
--- a/lib/Transforms/StagedPatternRewriteDriver.cpp
+++ b/lib/Transforms/StagedPatternRewriteDriver.cpp
@@ -33,8 +33,10 @@ using namespace mlir;
 
 namespace {
 
+#ifndef NDEBUG
 const char *logLineComment =
     "//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//\n";
+#endif
 
 struct WorkList {
   void addToWorklist(Operation *op) {


### PR DESCRIPTION
While seemingly minor it still breaks build in environments where warnings are errors.