### PR TITLE
Update TileOp to allow a `dim` attribute to specify the dimension alo…

### DIFF
--- a/include/Dialects/LinalgExt/LinalgExtOps.td
+++ b/include/Dialects/LinalgExt/LinalgExtOps.td
@@ -115,7 +115,7 @@ def LinalgExt_TileOp : LinalgExt_PureOp<"tile",
   let description = [{
     `linalg_ext.tile` is a 1-D loop construct that operates on tensors and
     evaluates its body once for each tile. The number and size of tiles is
-    specified by the `tile_sizes` operand.
+    specified by the `tile_size` operand.
 
     The `tile` op takes a list of destination-passing style tensors and returns
     a matching list of tensors of the same size.
@@ -124,23 +124,22 @@ def LinalgExt_TileOp : LinalgExt_PureOp<"tile",
     dimension matching the corresponding tile size.
 
     The default terminator behavior is such that tiles yielded by individual
-    iterations are concatenated along the first dimension. This is the canonical
-    way to perform "subset insertions".
+    iterations are concatenated along the `tiled_dim` dimension.
+    This is the canonical way to perform "subset insertions".
+    Note, if `tiled_dim` has the value `0`, it may be elided from pretty
+    pinting and parsing.
 
     All return tiles are concatenated into forming the matching full result
     tensor according to the terminator.
 
-    In the future, a "dim" permutation attribute is expected to be added to the
-    terminator to modify the behavior of tile concatenation into the result.
+    When the `tile_size` operand is a `tensor<..index>`, the `tile` op
+    evaluates its body `dim(tile_size, 0)` times. Each iteration `i` produces a
+    tile of leading size `tile_size[i]`.
 
-    When the `tile_sizes` operand is a `tensor<..index>`, the `tile` op
-    evaluates its body `dim(tile_sizes, 0)` times. Each iteration `i` produces a
-    tile of leading size `tile_sizes[i]`.
-
-    The induced `offset` block argument captures the running sum of `tile_sizes`
+    The induced `offset` block argument captures the running sum of `tile_size`
     for all the previous iterations.
 
-    When the `tile_sizes` operand is a single index, it is interpreted as a
+    When the `tile_size` operand is a single index, it is interpreted as a
     sequence of tile sizes given by the following formula:
     ```
       N = tensor.dim(...)
@@ -152,18 +151,25 @@ def LinalgExt_TileOp : LinalgExt_PureOp<"tile",
     All tiles except the last are of the same size.
   }];
   let arguments = (ins AnyTypeOf<[// TODO: allow TensorOf<[Index]>,
-                                  Index]>:$tile_sizes,
-                       Variadic<AnyRankedTensor>:$outs);
+                                  Index]>:$tile_size,
+                       Variadic<AnyRankedTensor>:$outs,
+                       I64Attr:$tiled_dim);
   let results = (outs Variadic<AnyType>:$results);
   let regions = (region SizedRegion<1>:$region);
   let skipDefaultBuilders = 1;
   let builders = [
+    // Builder that builds a tile on the implicit first dimension (i.e. `0`).
     OpBuilder<(ins "Value":$tileSizes, "ValueRange":$outs,
       CArg<"function_ref<void(OpBuilder &, Location, Value, Value, ValueRange)>",
-           "nullptr">)>
+           "nullptr">)>,
+    // Builder that builds a tile with a specified integral dimension.
+    OpBuilder<(ins "Value":$tileSizes, "ValueRange":$outs, "int64_t":$tiledDims,
+      CArg<"function_ref<void(OpBuilder &, Location, Value, Value, ValueRange)>",
+           "nullptr">)>,
   ];
 
   let extraClassDeclaration = [{
+    static StringRef getTiledDimAttrName() { return "tiled_dim";}
     using TileOpBodyBuilderFn =
       function_ref<void(OpBuilder &, Location, Value /*offset*/, Value /*size*/,
                         ValueRange /*outs*/)>;

--- a/include/Dialects/LinalgExt/Passes.h
+++ b/include/Dialects/LinalgExt/Passes.h
@@ -22,7 +22,7 @@ createLinalgExtTilingPass(ArrayRef<int64_t> tileSizes = {});
 /// Creates a pass to drive tiling of LinalgExt operations to
 /// linalg_ext::TileOp.
 std::unique_ptr<OperationPass<FuncOp>>
-createLinalgExtTilingToTileOpPass(int64_t tileSize = 0);
+createLinalgExtTilingToTileOpPass(ArrayRef<int64_t> tileSizes = {});
 
 std::unique_ptr<OperationPass<FuncOp>> createInParallelToAsyncPass();
 std::unique_ptr<OperationPass<FuncOp>> createInParallelToSequentialForPass();

--- a/include/Dialects/LinalgExt/Passes.td
+++ b/include/Dialects/LinalgExt/Passes.td
@@ -53,8 +53,9 @@ def LinalgExtTilingToTileOp : Pass<"linalg-ext-tiling-to-tile-op", "FuncOp"> {
     "scf::SCFDialect"
   ];
   let options = [
-    // TODO: some permutation flag to know which dim to tile with TileOp.
-    Option<"tileSize", "tile-size", "unsigned", /*default=*/"0", "Tile Size">
+    ListOption<"tileSizes", "tile-sizes", "int64_t",
+    "Tile Sizes, all must be 0 except one of the sizes",
+    "llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated">
   ];
 }
 

--- a/lib/Dialects/LinalgExt/Transforms/TileToSequentialFor.cpp
+++ b/lib/Dialects/LinalgExt/Transforms/TileToSequentialFor.cpp
@@ -47,7 +47,7 @@ struct TileOpToSCFRewriter : public OpRewritePattern<linalg_ext::TileOp> {
     Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     Value totalSize =
         rewriter.create<tensor::DimOp>(loc, tileOp.outs().front(), zero);
-    Value step = tileOp.tile_sizes();
+    Value step = tileOp.tile_size();
     assert(step.getType().isa<IndexType>() && "NYI: not an index type");
 
     // Construct the op without a body builder: we need to clone the ops in the

--- a/python/examples/core/transforms.py
+++ b/python/examples/core/transforms.py
@@ -204,14 +204,17 @@ class LinalgExtTile(Transform):
 
   def __init__(self, fun_name: str, op_name: str, **kwargs):
     self._parse_variables_in_kwargs(kwargs)
-    assert len(self.tile_sizes) == 1, "expected single tile size, got: " + \
-      str(self.tile_sizes)
-
+    count_non_zero = 0
+    for ts in self.tile_sizes:
+      if ts != 0:
+        count_non_zero = count_non_zero + 1
+    assert count_non_zero, 'only a single element may have count non zero'
+    tile_str = _get_size_list_as_str(name="tile-sizes", sizes=self.tile_sizes)
     pipeline = (
         f'linalg-ext-tiling-to-tile-op{{'
         #f'     anchor-func={fun_name} '
         #f'     anchor-op={op_name} '
-        f'     tile-size={self.tile_sizes[0]}}}'
+        f'     {tile_str}}}'
         #f'canonicalize,'
         #f'cse'
     )

--- a/python/examples/linalg_ext/test_in_par.py
+++ b/python/examples/linalg_ext/test_in_par.py
@@ -40,6 +40,16 @@ all_experts = [
                          hoist_paddings=[2, 3, 0]))
               .then(Vectorize(fun_name, ''))
               .then(LoweringOnlyExpert(fun_name, op_name)),
+            LinalgExtTile(fun_name, op_name, tile_sizes=[0, 16])
+              .then(LinalgExtTileToInParallel(fun_name, op_name))
+              .then(Tile(fun_name,
+                         op_name,
+                         tile_sizes=[12, 32, 16],
+                         pad=True,
+                         pack_paddings=[1, 1, 0],
+                         hoist_paddings=[2, 3, 0]))
+              .then(Vectorize(fun_name, ''))
+              .then(LoweringOnlyExpert(fun_name, op_name)),
         ]
     ]
 ]

--- a/test/LinalgExt/tiling-to-tile-op.mlir
+++ b/test/LinalgExt/tiling-to-tile-op.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-proto-opt %s -linalg-ext-tiling-to-tile-op="tile-size=10" | FileCheck %s
+// RUN: mlir-proto-opt %s -linalg-ext-tiling-to-tile-op="tile-sizes=10" | FileCheck %s
 
 // CHECK-LABEL: reverse_1d_tensor(
 //  CHECK-SAME:   %[[T:[0-9a-z]+]]: tensor<?x?xf32>
@@ -51,9 +51,10 @@ func @matmul_static(%A: tensor<100x200xf32>, %B: tensor<200x300xf32>, %C: tensor
   //      CHECK: %[[C10:.*]] = arith.constant 10 : index
   //      CHECK: linalg_ext.tile %[[C10]] outs(%[[C]]: tensor<100x300xf32>) -> (tensor<100x300xf32>) {
   //      CHECK: ^bb0(%[[OFF:.*]]: index, %[[SZ:.*]]: index, %[[C_ITER:.*]]: tensor<?x?xf32>):
-  //      CHECK:   %[[tA:.*]] = tensor.extract_slice %[[A]]{{.*}} : tensor<100x200xf32> to tensor<?x200xf32>
+  //      CHECK:   %[[tA:.*]] = tensor.extract_slice %[[A]]{{.*}} : tensor<100x200xf32> to tensor<?x?xf32>
+  //      CHECK:   %[[tB:.*]] = tensor.extract_slice %[[B]]{{.*}} : tensor<200x300xf32> to tensor<?x?xf32>
   //      CHECK:   %[[RES:.*]] = linalg.matmul
-  // CHECK-SAME:      ins(%[[tA]], %[[B]] : tensor<?x200xf32>, tensor<200x300xf32>)
+  // CHECK-SAME:      ins(%[[tA]], %[[tB]] : tensor<?x?xf32>, tensor<?x?xf32>)
   // CHECK-SAME:     outs(%[[C_ITER]] : tensor<?x?xf32>) -> tensor<?x?xf32>
   //      CHECK:   linalg_ext.tile_yield %[[RES]] : tensor<?x?xf32>
   %D = linalg.matmul ins(%A, %B: tensor<100x200xf32>, tensor<200x300xf32>) outs(%C: tensor<100x300xf32>) -> tensor<100x300xf32>


### PR DESCRIPTION
…ng which to distribute the result tensor.

Also update the implementations of TilingToTileOp, TileToX and TilingExternalModel to allow more general
tiling than single outermost dimension.
This allows distributing other dimensions than just the firs