### PR TITLE
Run enabler transformations in the transform dialect interpreter

### DIFF
--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -42,6 +42,7 @@
 #include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
 #include "mlir/Dialect/SCF/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Rewrite/FrozenRewritePatternSet.h"
@@ -215,6 +216,8 @@ executeVectorizeOp(LinalgOp target,
   patterns.add<linalg::LinalgCopyVTRForwardingPattern,
                linalg::LinalgCopyVTWForwardingPattern>(ctx,
                                                        /*benefit=*/2);
+  vector::TransferReadOp::getCanonicalizationPatterns(patterns, ctx);
+  vector::TransferWriteOp::getCanonicalizationPatterns(patterns, ctx);
   if (vectorizeOp.vectorize_padding())
     linalg::populatePadOpVectorizationPatterns(patterns);
   LinalgVectorizationPattern pattern(vectorizeOp.getContext());

--- a/test/LinalgTransform/selective-targeting.mlir
+++ b/test/LinalgTransform/selective-targeting.mlir
@@ -17,11 +17,16 @@ func @matmul_tensors(
     -> tensor<128x128xf32>
 
   // This operation is marked for tiling and vectorization.
-  // CHECK-COUNT-3: scf.for
-  // CHECK-COUNT-3: vector.transfer_read
-  // CHECK: vector.contract
-  // CHECK-NOT: linalg.matmul
-  // CHECK: vector.transfer_write
+  // Note that the loop-invariant read is hoisted out of the innermost loop.
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     vector.transfer_read
+  // CHECK:     scf.for
+  // CHECK:       vector.transfer_read
+  // CHECK:       vector.transfer_read
+  // CHECK:       vector.contract
+  // CHECK-NOT:   linalg.matmul
+  // CHECK:       vector.transfer_write
   %1 = linalg.matmul { test.attrA, test.attrC}
                       ins(%arg3, %arg4: tensor<128x128xf32>, tensor<128x128xf32>)
                      outs(%arg5: tensor<128x128xf32>)


### PR DESCRIPTION
These were initially omitted from the interpreter for simplicity. Add
them back to ensure parity with the code generation strategy. In the
latter, enablers seem optional, but in practice are run always except
for a single test verifying that they can be omitted.

This exposes the redundancy and the likely overhead in the enabler
transformations running between every other pairs of transformations,
while only some of the enablers are necessary for some of the
transformations (e.g. no need to simplify single-iteration loops if no
new loops are introduced, no need to hoist loop-invariant transfers if
no transfers are introduced, etc.) and that CSE effectively runs twice
in a row.