### PR TITLE
Band-aid for pad transpose in transform interpreter

### DIFF
--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -137,10 +137,15 @@ buildPadFromTileOpPattern(linalg::transform::TileOp tileOp) {
                      .getSExtValue()
                : 0;
   };
+  // TODO: support `tranpose_paddings` in TileOp.
+  auto transposeFunc = [tileOp](OpOperand &opOperand) mutable {
+    return SmallVector<int64_t>();
+  };
   LinalgPaddingOptions paddingOptions;
   paddingOptions.setPaddingValueComputationFunction(getNeutralOfLinalgOp);
   paddingOptions.setPaddingNoFoldComputationFunction(packFunc);
   paddingOptions.setPaddingHoistComputationFunction(hoistingFunc);
+  paddingOptions.setPaddingTransposeComputationFunction(transposeFunc);
 
   return callLinalgPattern<LinalgPaddingPattern>(tileOp.getContext(),
                                                  paddingOptions);


### PR DESCRIPTION
Add a band-aid that requests no padding transposes in the transform dialect interpreter. This function was added to the padding options and is called by the padding pattern without any verification of being set.