### PR TITLE
Support transpose_padding in transfer dialect TileOp

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -103,12 +103,18 @@ def TileOp : Linalg_Transform_Operation<"tile", [TargetableOpTrait]> {
                    DefaultValuedAttr<BoolAttr, "false">:$pad,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$pack_paddings,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$hoist_paddings,
+                   DefaultValuedAttr<
+                      TypedArrayAttrBase<I64ArrayAttr,
+                                         "array of arrays of i64">,
+                      "{}">:$transpose_paddings,
                    DefaultValuedAttr<BoolAttr, "false">:$scalarize_dyn_dims,
                    DefaultValuedAttr<BoolAttr, "false">:$generalize
                   );
   let results = (outs PDL_Operation:$transformed);
 
   let assemblyFormat = "($target^)? (`when` $targetMatcher^)? attr-dict";
+
+  let hasVerifier = 1;
 }
 
 def BufferizeOp : Linalg_Transform_Operation<"bufferize"> {

--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -140,9 +140,14 @@ buildPadFromTileOpPattern(linalg::transform::TileOp tileOp) {
                      .getSExtValue()
                : 0;
   };
-  // TODO: support `tranpose_paddings` in TileOp.
   auto transposeFunc = [tileOp](OpOperand &opOperand) mutable {
-    return SmallVector<int64_t>();
+    if (opOperand.getOperandNumber() >= tileOp.transpose_paddings().size())
+      return SmallVector<int64_t>();
+
+    auto transposePaddings =
+        tileOp.transpose_paddings()[opOperand.getOperandNumber()]
+            .cast<ArrayAttr>();
+    return extractI64Array(transposePaddings);
   };
   LinalgPaddingOptions paddingOptions;
   paddingOptions.setPaddingValueComputationFunction(getNeutralOfLinalgOp);

--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -11,6 +11,7 @@ except ImportError as e:
 
 BoolArg = Optional[Union[bool, ir.BoolAttr]]
 IntListArg = Optional[Union[Sequence[int], ir.ArrayAttr]]
+IntListListArg = Optional[Union[Sequence[Union[Sequence[int], ir.ArrayAttr]], ir.ArrayAttr]]
 StringArg = Optional[Union[str, ir.StringAttr]]
 
 
@@ -30,6 +31,12 @@ def _ensure_array_attr(value: IntListArg):
     return ir.ArrayAttr.get([ir.IntegerAttr.get(i64, i) for i in value])
   return value
 
+
+@_defaulted_ensure
+def _ensure_array_of_array_attr(value: IntListListArg):
+  if isinstance(value, Sequence):
+    return ir.ArrayAttr.get([_ensure_array_attr(inner) for inner in value])
+  return value
 
 @_defaulted_ensure
 def _ensure_bool_attr(value: BoolArg):
@@ -86,6 +93,7 @@ class TileOp:
                pad: BoolArg = None,
                pack_paddings: IntListArg = None,
                hoist_paddings: IntListArg = None,
+               transpose_paddings: IntListListArg = None,
                scalarize_dyn_dims: BoolArg = None,
                generalize: BoolArg = None,
                loc=None,
@@ -95,6 +103,7 @@ class TileOp:
     pad = _ensure_bool_attr(pad, False)
     pack_paddings = _ensure_array_attr(pack_paddings, [])
     hoist_paddings = _ensure_array_attr(hoist_paddings, [])
+    transpose_paddings = _ensure_array_of_array_attr(transpose_paddings, [])
     scalarize_dyn_dims = _ensure_bool_attr(scalarize_dyn_dims, False)
     generalize = _ensure_bool_attr(generalize, False)
     operation_type = pdl.OperationType.get()
@@ -111,6 +120,7 @@ class TileOp:
         pad,
         pack_paddings,
         hoist_paddings,
+        transpose_paddings,
         scalarize_dyn_dims,
         generalize,
         loc=loc,

--- a/test/LinalgTransform/invalid.mlir
+++ b/test/LinalgTransform/invalid.mlir
@@ -8,3 +8,10 @@ linalg_transform.sequence {
   // expected-note@below {{used here as operand #0}}
   vectorize %0
 }
+
+// -----
+
+linalg_transform.sequence {
+  // expected-error@below {{expects transpose paddings to be a permutation, found [2, 0]}}
+  tile when @match {pad = true, transpose_paddings = [[0, 1], [2, 0]]}
+}


### PR DESCRIPTION
This has been added after the op was introduced and not reflected in the
op before now.