### PR TITLE
Fix LinalgTransform Python bindings attribute construction

### DIFF
--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -127,7 +127,7 @@ class VectorizeOp:
                loc=None,
                ip=None):
     if isinstance(target, str):
-      target = ir.FlatSymbolRefAttr(target)
+      target = ir.FlatSymbolRefAttr.get(target)
 
     operation_type = pdl.OperationType.get()
 


### PR DESCRIPTION
The attribute must be created with a static "get" method instead of
just creating the object.