### PR TITLE
Support the `peel` option in TileOp

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -100,6 +100,7 @@ def TileOp : Linalg_Transform_Operation<"tile", [TargetableOpTrait]> {
                    OptionalAttr<SymbolRefAttr>:$targetMatcher,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$sizes,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$interchange,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$peel,
                    DefaultValuedAttr<BoolAttr, "false">:$pad,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$pack_paddings,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$hoist_paddings,

--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -181,6 +181,7 @@ static FailureOr<LinalgOp> executeTileOp(LinalgOp target,
   LinalgTilingOptions tilingOptions;
   tilingOptions.setTileSizes(extractI64Array(tileOp.sizes()));
   tilingOptions.setInterchange(extractUIntArray(tileOp.interchange()));
+  tilingOptions.setPeeledLoops(extractI64Array(tileOp.peel()));
   if (tileOp.scalarize_dyn_dims())
     tilingOptions.scalarizeDynamicDims();
 

--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -90,6 +90,7 @@ class TileOp:
                *,
                sizes: IntListArg = None,
                interchange: IntListArg = None,
+               peel: IntListArg = None,
                pad: BoolArg = None,
                pack_paddings: IntListArg = None,
                hoist_paddings: IntListArg = None,
@@ -100,6 +101,7 @@ class TileOp:
                ip=None):
     sizes = _ensure_array_attr(sizes, [])
     interchange = _ensure_array_attr(interchange, [])
+    peel = _ensure_array_attr(peel, [])
     pad = _ensure_bool_attr(pad, False)
     pack_paddings = _ensure_array_attr(pack_paddings, [])
     hoist_paddings = _ensure_array_attr(hoist_paddings, [])
@@ -117,6 +119,7 @@ class TileOp:
         target if isinstance(target, ir.FlatSymbolRefAttr) else None,
         sizes,
         interchange,
+        peel,
         pad,
         pack_paddings,
         hoist_paddings,


### PR DESCRIPTION
It was orginially omitted for simplicity.