### PR TITLE
Check mutual exclusivity of scalarize_dyn_dims and tile sizes

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -100,6 +100,7 @@ def TileOp : Linalg_Transform_Operation<"tile", [TargetableOpTrait]> {
                    OptionalAttr<SymbolRefAttr>:$targetMatcher,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$sizes,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$interchange,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$peel,
                    DefaultValuedAttr<BoolAttr, "false">:$pad,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$pack_paddings,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$hoist_paddings,

--- a/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -56,6 +56,12 @@ static LogicalResult verifySequenceOp(transform::SequenceOp op) {
 }
 
 LogicalResult transform::TileOp::verify() {
+  if (!sizes().empty() && scalarize_dyn_dims()) {
+    return emitOpError() << sizesAttrName() << " and "
+                         << scalarize_dyn_dimsAttrName()
+                         << " attributes are mutually exclusive";
+  }
+
   ArrayAttr transposes = transpose_paddings();
   for (Attribute attr : transposes) {
     SmallVector<int64_t> transpose = extractFromI64ArrayAttr(attr);

--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -181,6 +181,7 @@ static FailureOr<LinalgOp> executeTileOp(LinalgOp target,
   LinalgTilingOptions tilingOptions;
   tilingOptions.setTileSizes(extractI64Array(tileOp.sizes()));
   tilingOptions.setInterchange(extractUIntArray(tileOp.interchange()));
+  tilingOptions.setPeeledLoops(extractI64Array(tileOp.peel()));
   if (tileOp.scalarize_dyn_dims())
     tilingOptions.scalarizeDynamicDims();
 

--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -179,7 +179,11 @@ buildGeneralizeFromTileOpPattern(linalg::transform::TileOp tileOp) {
 static FailureOr<LinalgOp> executeTileOp(LinalgOp target,
                                          linalg::transform::TileOp tileOp) {
   LinalgTilingOptions tilingOptions;
-  tilingOptions.setTileSizes(extractI64Array(tileOp.sizes()));
+  SmallVector<int64_t> tileSizes = extractI64Array(tileOp.sizes());
+  // "scalarize_dyn_dims" actually sets the same lambda as the tile sizes and
+  // asserts that it is not already set.
+  if (!tileSizes.empty() || !tileOp.scalarize_dyn_dims())
+    tilingOptions.setTileSizes(tileSizes);
   tilingOptions.setInterchange(extractUIntArray(tileOp.interchange()));
   tilingOptions.setPeeledLoops(extractI64Array(tileOp.peel()));
   if (tileOp.scalarize_dyn_dims())

--- a/test/LinalgTransform/invalid.mlir
+++ b/test/LinalgTransform/invalid.mlir
@@ -15,3 +15,10 @@ linalg_transform.sequence {
   // expected-error@below {{expects transpose paddings to be a permutation, found [2, 0]}}
   tile when @match {pad = true, transpose_paddings = [[0, 1], [2, 0]]}
 }
+
+// -----
+
+linalg_transform.sequence {
+  // expected-error@below {{"sizes" and "scalarize_dyn_dims" attributes are mutually exclusive}}
+  tile when @match {sizes = [1,2,3], scalarize_dyn_dims = true}
+}


### PR DESCRIPTION
Upstream transformations assert on this. Thanks to having a dialect, we
can detect this as an incorrect schedule and emit a diagnostic instead.