### PR TITLE
Add loop transformations to the transform dialect

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -174,6 +174,44 @@ def LowerToLLVMOp : Linalg_Transform_Operation<"lower_to_llvm"> {
   let assemblyFormat = "attr-dict";
 }
 
+def GetParentLoopOp : Linalg_Transform_Operation<"get_parent_loop"> {
+  let description = [{Obtains a handle to a parent loop of the given
+  operation.}];
+
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<Confined<I64Attr, [IntPositive]>,
+                                     "1">:$num_loops);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+}
+
+def UnrollLoopOp : Linalg_Transform_Operation<"unroll_loop"> {
+  let description = [{Unrolls the given loop with the given unroll factor.}];
+
+  let arguments = (ins PDL_Operation:$target,
+                   Confined<I64Attr, [IntPositive]>:$factor);
+  
+  let assemblyFormat = "$target attr-dict";
+}
+
+def PipelineLoopOp : Linalg_Transform_Operation<"pipeline_loop"> {
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<I64Attr, "1">:$iteration_interval,
+                   DefaultValuedAttr<I64Attr, "10">:$read_latency);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+}
+
+def OutlineLoopOp : Linalg_Transform_Operation<"outline_loop"> {
+  let arguments = (ins PDL_Operation:$target,
+                   StrAttr:$func_name);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 
 def ExpertOp : Linalg_Transform_Operation<"expert"> {

--- a/include/Dialects/LinalgTransform/TransformOpMapping.h
+++ b/include/Dialects/LinalgTransform/TransformOpMapping.h
@@ -17,7 +17,7 @@ namespace mlir {
 class Operation;
 class Value;
 
-using TransformOpMapping = DenseMap<Value, SmallVector<linalg::LinalgOp>>;
+using TransformOpMapping = DenseMap<Value, SmallVector<Operation *>>;
 } // namespace mlir
 
 #endif // MLIR_DIALECT_LINALG_RANSFORMS_TRANSFORMOPMAPPING_H

--- a/include/Transforms/Functional.h
+++ b/include/Transforms/Functional.h
@@ -165,6 +165,7 @@ template <typename OpT>
 struct IsaOr {
   static bool apply(Operation *op) { return isa<OpT>(op); }
   static OpT cast(Operation *op) { return ::mlir::cast<OpT>(op); }
+  static OpT dyn_cast(Operation *op) { return ::mlir::dyn_cast<OpT>(op); }
 };
 /// In the special case, nothing needs to be done. Just pass the generic op
 /// directly into the pattern.
@@ -172,6 +173,7 @@ template <>
 struct IsaOr<Operation *> {
   static bool apply(Operation *op) { return true; }
   static Operation *cast(Operation *op) { return op; }
+  static Operation *dyn_cast(Operation *op) { return op; }
 };
 
 /// A sequence here is a tuple of unique functions. However, when constructing

--- a/lib/Dialects/LinalgTransform/Transforms/PDL.h
+++ b/lib/Dialects/LinalgTransform/Transforms/PDL.h
@@ -21,11 +21,10 @@ namespace linalg {
 
 /// Find all operations in `module` that are matched by the specified PDL
 /// pattern, which is also located in `module`.
-FailureOr<SmallVector<LinalgOp>> findMatchingOps(Operation *op,
-                                                 SymbolRefAttr pattern,
-                                                 ModuleOp module);
-inline FailureOr<SmallVector<LinalgOp>> findMatchingOps(transform::MatchOp op,
-                                                        ModuleOp module) {
+FailureOr<SmallVector<Operation *>>
+findMatchingOps(Operation *op, SymbolRefAttr pattern, ModuleOp module);
+inline FailureOr<SmallVector<Operation *>>
+findMatchingOps(transform::MatchOp op, ModuleOp module) {
   return findMatchingOps(op, op.targetMatcher(), module);
 }
 

--- a/test/LinalgTransform/failure.mlir
+++ b/test/LinalgTransform/failure.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-proto-opt -linalg-interp-transforms -split-input-file -verify-diagnostics
+// RUN: mlir-proto-opt -linalg-interp-transforms -split-input-file -verify-diagnostics -allow-unregistered-dialect
 
 // This cannot be vectorized because of dynamic tensor shapes. We expect the
 // pass fail and report an error at the vectorization operation below.
@@ -22,7 +22,80 @@ pdl.pattern @target_pattern : benefit(1) {
 }
 
 linalg_transform.sequence {
+  %0 = match @target_pattern
   // expected-error@below {{failed to apply}}
-  vectorize when @target_pattern
+  vectorize %0
 }
 
+// -----
+
+func public @no_loop(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %0 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+    ins(%arg0: tensor<?xf32>) outs(%arg1: tensor<?xf32>) {
+  ^bb0(%arg2: f32, %arg3: f32):
+    %1 = arith.mulf %arg2, %arg2 : f32
+    linalg.yield %1 : f32
+  } -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+pdl.pattern @target_pattern : benefit(1) {
+  %0 = operands
+  %1 = types
+  %2 = operation "linalg.generic"(%0 : !pdl.range<value>)  -> (%1 : !pdl.range<type>)
+  rewrite %2 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  %0 = match @target_pattern
+  // expected-error@below {{the transformed op is enclosed by 0 loops, but 1 expected}}
+  // expected-error@below {{failed to apply}}
+  get_parent_loop %0
+}
+
+// -----
+
+func private @prevent_dce()
+
+pdl.pattern @something : benefit(1) {
+  %0 = operands
+  %2 = operation "scf.for"(%0 : !pdl.range<value>)
+  rewrite %2 with "linalg_transform.apply"
+}
+
+func public @loop(%lb: index, %ub: index, %step: index) {
+  scf.for %i = %lb to %ub step %step {
+    call @prevent_dce() : () -> ()
+  }
+  return
+}
+
+linalg_transform.sequence {
+  %0 = match @something
+  // expected-error@below {{NYI: cannot target the result of pipelining}}
+  // expected-error@below {{failed to apply}}
+  %1 = pipeline_loop %0
+  // expected-note@below {{use here}}
+  get_parent_loop %1
+}
+
+// -----
+
+func public @no_outlining() {
+  "some.operation"() ({}, {}) : () -> ()
+  return
+}
+
+pdl.pattern @some_operation : benefit(1) {
+  %0 = operation "some.operation"
+  rewrite %0 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  %0 = match @some_operation
+  // Make sure we don't crash on wrong operation type.
+  // expected-error@below {{failed to apply}}
+  outline_loop %0 {func_name = "outlined"}
+}


### PR DESCRIPTION
Introduce transform dialect operations for loop transformations
currently supported by the transformation strategy. To target
transformation on loops, also introduce an auxiliary operation that
takes a handle to a Linalg operation and produces a handle to
one of its surrounding loops.