### PR TITLE
Add more options to lower vectors in transform dialect

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -151,6 +151,8 @@ def LowerVectorsOp : Linalg_Transform_Operation<"lower_vectors"> {
     (ins DefaultValuedAttr<I64ArrayAttr, "{0, 1, 2, 3, 4, 5, 6}">:$stages,
      DefaultValuedAttr<StrAttr, "\"outerproduct\"">:$contraction_lowering,
      DefaultValuedAttr<StrAttr, "\"innerparallel\"">:$multireduction_lowering,
+     DefaultValuedAttr<StrAttr, "\"linalg-copy\"">:$split_transfers,
+     DefaultValuedAttr<BoolAttr, "true">:$unroll_vector_transfers,
      DefaultValuedAttr<StrAttr, "\"eltwise\"">:$transpose_lowering,
      DefaultValuedAttr<BoolAttr, "false">:$transpose_avx2_lowering
     );

--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -60,6 +60,8 @@ class LowerVectorsOp:
                stages: IntListArg = None,
                contraction_lowering: StringArg = None,
                multireduction_lowering: StringArg = None,
+               split_transfers: StringArg = None,
+               unroll_vector_transfers: BoolArg = None,
                transpose_lowering: StringArg = None,
                transpose_avx2_lowering: BoolArg = None,
                loc=None,
@@ -69,12 +71,16 @@ class LowerVectorsOp:
                                                "outerproduct")
     multireduction_lowering = _ensure_string_attr(multireduction_lowering,
                                                   "innerparallel")
+    split_transfers = _ensure_string_attr(split_transfers, "linalg-copy")
+    unroll_vector_transfers = _ensure_bool_attr(unroll_vector_transfers, True)
     transpose_lowering = _ensure_string_attr(transpose_lowering, "eltwise")
     transpose_avx2_lowering = _ensure_bool_attr(transpose_avx2_lowering, False)
 
     super().__init__(stages,
                      contraction_lowering,
                      multireduction_lowering,
+                     split_transfers,
+                     unroll_vector_transfers,
                      transpose_lowering,
                      transpose_avx2_lowering,
                      loc=loc,


### PR DESCRIPTION
These options were either not implemented initially for simplicity or
added after the initial implementation.