### PR TITLE
Add an untargeted version of the vectorization op

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -137,15 +137,17 @@ def DecomposeOp : Linalg_Transform_Operation<"decompose"> {
 }
 
 def VectorizeOp : Linalg_Transform_Operation<"vectorize"> {
-  let description = [{Indiactes that ops of a specific kind in the given
-  function should be vectorized with the options provided as attributes.}];
+  let description = [{Indiactes that vectorization should be performed. If a
+  target handle is provided, only vectorizes the operations pointed to by the
+  handle. Otherwise vectorizes the entire module. Vectorization options are
+  provided as operation attributes.}];
 
-  let arguments = (ins PDL_Operation:$target,
+  let arguments = (ins Optional<PDL_Operation>:$target,
                    DefaultValuedAttr<BoolAttr, "false">:$vectorize_padding
                   );
-  let results = (outs PDL_Operation:$transformed);
+  let results = (outs Optional<PDL_Operation>:$transformed);
 
-  let assemblyFormat = "$target attr-dict";
+  let hasCustomAssemblyFormat = 1;
 }
 
 def LowerVectorsOp : Linalg_Transform_Operation<"lower_vectors"> {

--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -156,15 +156,15 @@ class TileOp:
 class VectorizeOp:
 
   def __init__(self,
-               target: Union[ir.Value, ir.Operation, ir.OpView],
+               target: Optional[Union[ir.Value, ir.Operation, ir.OpView]] = None,
                *,
-               vectorize_padding: BoolArg,
+               vectorize_padding: BoolArg = None,
                loc=None,
                ip=None):
     operation_type = pdl.OperationType.get()
 
     super().__init__(
-        operation_type,
+        operation_type if target is not None else None,
         target,
         _ensure_bool_attr(vectorize_padding, False),
         loc=loc,

--- a/test/LinalgTransform/roundtrip.mlir
+++ b/test/LinalgTransform/roundtrip.mlir
@@ -19,6 +19,10 @@ linalg_transform.sequence {
   %4 = match @match2
   // CHECK: %{{.*}} = vectorize %[[OPS2]]
   vectorize %4
+  // CHECK-NOT: %
+  // CHECK: vectorize
+  // CHECK-NOT: %
+  vectorize
   // CHECK: bufferize
   bufferize
   // CHECK: lower_vectors {multireduction_lowering = "innerreduce"}


### PR DESCRIPTION
In some cases, a global vectorization is desirable to ensure a proper
composition of vectorization and canonicalization patterns in the
process that is not achievable with the scoped targeted vectorization.
Introduce an untargeted version of the vectorization op in addition to
the targeted one to support such cases.