### PR TITLE
Report errors from TrackingListener

### DIFF
--- a/include/Dialects/LinalgTransform/TrackingCSE.h
+++ b/include/Dialects/LinalgTransform/TrackingCSE.h
@@ -14,9 +14,10 @@
 namespace mlir {
 class DominanceInfo;
 
-void eliminateCommonSubexpressionsWithTrackedOps(
-    Operation *root, TransformOpMapping &trackedOps,
-    DominanceInfo *domInfo = nullptr);
+LogicalResult
+eliminateCommonSubexpressionsWithTrackedOps(Operation *root,
+                                            TransformOpMapping &trackedOps,
+                                            DominanceInfo *domInfo = nullptr);
 } // namespace mlir
 
 #endif // MLIR_DIALECT_LINALG_TRANSFORMS_TRACKINGCSE_H

--- a/lib/Dialects/LinalgTransform/Transforms/TrackingCSE.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TrackingCSE.cpp
@@ -13,9 +13,10 @@
 
 using namespace mlir;
 
-void mlir::eliminateCommonSubexpressionsWithTrackedOps(
-    Operation *root, TransformOpMapping &trackedOps,
-    DominanceInfo *domInfo) {
+LogicalResult mlir::eliminateCommonSubexpressionsWithTrackedOps(
+    Operation *root, TransformOpMapping &trackedOps, DominanceInfo *domInfo) {
   linalg::TrackingListener listener(trackedOps);
-  (void)eliminateCommonSubexpressions(root, domInfo, &listener);
+  if (failed(eliminateCommonSubexpressions(root, domInfo, &listener)))
+    return failure();
+  return listener.checkErrorState();
 }

--- a/lib/Dialects/LinalgTransform/Transforms/TrackingRewriteDriver.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TrackingRewriteDriver.cpp
@@ -16,5 +16,7 @@ LogicalResult mlir::applyPatternsTrackAndFoldGreedily(
     Operation *root, TransformOpMapping &trackedOperations,
     const FrozenRewritePatternSet &patterns, GreedyRewriteConfig config) {
   linalg::TrackingListener listener(trackedOperations);
-  return applyPatternsAndFoldGreedily(root, patterns, config, &listener);
+  if (failed(applyPatternsAndFoldGreedily(root, patterns, config, &listener)))
+    return failure();
+  return listener.checkErrorState();
 }


### PR DESCRIPTION
Add an error reporting capability to TrackingListener to handle the
situations where tracking is no longer possible because of the schedule
shape. Such situations may happen with schedules that pass the IR
verifier because their conditions are dynamic (some ops being or not
being matched).