### PR TITLE
Only run LinalgExtInParallelToAsync in relevant benchmarks

### DIFF
--- a/python/examples/core/experts.py
+++ b/python/examples/core/experts.py
@@ -10,8 +10,7 @@ from .transform import TransformListFactory, TransformationList
 # not possible to deactivate bufferization, vectorization or lowering or make
 # them apply partially.
 ###############################################################################
-LoweringOnlyExpert = Bufferize.then(LinalgExtInParallelToAsync).then(
-    LowerVectors).then(LowerToLLVM)
+LoweringOnlyExpert = Bufferize.then(LowerVectors).then(LowerToLLVM)
 SingleTilingExpert = Tile.then(DecomposeToLowerDimensionalNamedOp).then(
     Vectorize).then(LoweringOnlyExpert)
 DoubleTilingExpert = Tile.then(SingleTilingExpert)

--- a/python/examples/linalg_ext/in_par_bench.py
+++ b/python/examples/linalg_ext/in_par_bench.py
@@ -59,7 +59,10 @@ def all_experts(fun_name: str):
                            transpose_paddings2=[[1, 0], [0, 1], [0, 1]],
                            ))
           .then(Vectorize(fun_name, ''))
-          .then(LoweringOnlyExpert(fun_name, op_name)),
+          .then(Bufferize)
+          .then(LinalgExtInParallelToAsync)
+          .then(LowerVectors)
+          .then(LowerToLLVM)
         ]
     ]
   ]


### PR DESCRIPTION
Running `LinalgExtInParallelToAsync` as part of `LoweringOnlyExpert` is
useless for most benchmaks and interferes with the switch to the
transform dialect. Use it in the benchmark that actually cares about it
instead.