### PR TITLE
Ignore unused transform matches

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -18,6 +18,7 @@ include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def Linalg_Transform_Dialect : Dialect {
   let name = "linalg_transform";

--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -248,6 +248,9 @@ static LogicalResult executeMatchOp(transform::MatchOp op, ModuleOp module,
   if (failed(ops))
     return failure();
   LLVM_DEBUG(DBGS() << "matched " << ops->size() << " ops\n");
+  if (op.target().use_empty())
+    return success();
+
   operations.try_emplace(op.target(), std::move(*ops));
   return checkSingleHandle(op.target(), operations);
 }

--- a/test/LinalgTransform/failure.mlir
+++ b/test/LinalgTransform/failure.mlir
@@ -169,4 +169,8 @@ linalg_transform.sequence {
   // expected-error @below {{failed to apply}}
   // expected-note @below {{handle}}
   %1 = match @pdl_target2
+  
+  // Add references to handles produced by match so that they are not DCE'd.
+  tile %0
+  tile %1
 }


### PR DESCRIPTION
Sometimes, match operations may be generated by clients of the transform
dialect but their results remain unused. This may generate spurious
interpretation errors, for example, if match operations produce
overlapping operation sets even though one of the sets is never
transformed. Do not track the results of match operations that will not
be used later, similarly to other transformations. Mark match operations
as not having side effects so that it can be removed by DCE if its
results are unused.