### PR TITLE
Fix issues that might surface while building sandbox in other environments

### DIFF
--- a/include/Dialects/VectorExt/VectorExtWarpUtils.h
+++ b/include/Dialects/VectorExt/VectorExtWarpUtils.h
@@ -10,6 +10,7 @@
 #define DIALECT_VECTOREXT_VECTORWARPUTILS_H_
 
 #include "llvm/ADT/STLExtras.h"
+#include "Dialects/VectorExt/VectorExtOps.h"
 
 namespace mlir {
 class RewritePatternSet;

--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -692,7 +692,7 @@ executePipelineLoopOp(scf::ForOp loop,
   return scf::ForOp();
 }
 
-scf::ExecuteRegionOp outlineInExecuteRegion(RewriterBase &b, Operation *op) {
+static scf::ExecuteRegionOp outlineInExecuteRegion(RewriterBase &b, Operation *op) {
   op->dump();
   if (op->getNumRegions() != 1)
     return nullptr;

--- a/lib/LinalgTensorCodegenDriver.cpp
+++ b/lib/LinalgTensorCodegenDriver.cpp
@@ -490,7 +490,7 @@ void UnrollOneParentLoopPass::runOnOperation() {
   });
 }
 
-scf::ExecuteRegionOp outlineInExecuteRegion(RewriterBase &b, Operation *op) {
+static scf::ExecuteRegionOp outlineInExecuteRegion(RewriterBase &b, Operation *op) {
   if (op->getNumRegions() != 1)
     return nullptr;
   OpBuilder::InsertionGuard g(b);


### PR DESCRIPTION
* Avoid symbol collision by marking a common private function `outlineInExecuteRegion` as `static`
* Add missing header in `VectorExtWarpUtils.h`