### PR TITLE
Add RW lock support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Run the following as root.
 numactl --hardware
 
 ################################################################
-# Prepare to run on CPU 4 only
+# Prepare to run on a subset of CPUs only
 ################################################################
 # Disable address space randomization.
 echo 0 > /proc/sys/kernel/randomize_va_space
@@ -153,8 +153,8 @@ cat /sys/devices/system/cpu/cpu4/topology/thread_siblings_list
 # E.g. on a 36 core system, this should return 4,40, use a shift of 36 for rest.
 echo 0 > /sys/devices/system/cpu/cpu$((4 + 36))/online
 
-# Disable the siblings of CPU 8-15, we'll use those for parallel runs.
-for i in $(seq 0 16); do \
+# Disable the siblings of CPU 0-31, we'll use those for parallel runs.
+for i in $(seq 0 31); do \
   echo 0 /sys/devices/system/cpu/cpu$(( ${i} + 36))/online; \
 done
 
@@ -166,13 +166,13 @@ done
 # Instead, reproduce the following finer-grained instructions:
 #   https://documentation.suse.com/sle-rt/15-SP2/html/SLE-RT-all/cha-shielding-cpuset.html
 
-cset set -s system -c 16-35 -m 1
+cset set -s system -c 32-35 -m 1
 
-#for i in $(seq 0 15); do \
+#for i in $(seq 0 32); do \
 #  cset set -s sandbox_${i} -c ${i} -m 0 --cpu_exclusive
 #done
 
-cset set -s sandbox_parallel -c 0-15 -m 0 --cpu_exclusive
+cset set -s sandbox_parallel -c 0-31 -m 0 --cpu_exclusive
 
 cset proc -m -f root -t system
 
@@ -182,7 +182,7 @@ cset proc -m -f root -t system
 
 echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
 echo performance > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
-for i in $(seq 0 16); do \
+for i in $(seq 0 31); do \
   echo performance > /sys/devices/system/cpu/cpu$(( ${i} ))/cpufreq/scaling_governor;\
 done
 

--- a/python/examples/core/nevergrad_tuner_utils.py
+++ b/python/examples/core/nevergrad_tuner_utils.py
@@ -161,7 +161,8 @@ def add_argparser_tuning_arguments(parser: ArgumentParser):
       type=str,
       nargs='?',
   )
-  parser.add_argument('--num-compilation-processes',
+  parser.add_argument('--num-parallel-tasks', type=int, nargs='?', default=1)
+  parser.add_argument('--num-cpus-per-benchmark',
                       type=int,
                       nargs='?',
                       default=1)
@@ -174,11 +175,11 @@ def add_argparser_tuning_arguments(parser: ArgumentParser):
       default='RandomSearch',
   )
   parser.add_argument('--timeout-per-compilation',
-                      type=int,
+                      type=float,
                       nargs='?',
                       default=5)
   # Until ExecutionEngine pickles, we are both compiling and evaluating.
-  parser.add_argument('--timeout-per-evaluation',
-                      type=int,
+  parser.add_argument('--timeout-per-benchmark',
+                      type=float,
                       nargs='?',
-                      default=5)
+                      default=1)

--- a/python/examples/tuning/test_nevergrad_small_matmul_noisy.py
+++ b/python/examples/tuning/test_nevergrad_small_matmul_noisy.py
@@ -79,14 +79,6 @@ class NGScheduler(NGSchedulerInterface):
   def extract_tile_partial_by_one_from_proposal(self, proposal):
     return [x for x in proposal.kwargs[self.tile_partial_by_one_search_keyword]]
 
-  # Optimizer may want to override our constraints set.
-  def validate_proposal(self, proposal):
-    if not size_constraints_conjunction_satisfied(
-        self.problem_sizes,
-        self.extract_register_tile_sizes_from_proposal(proposal)):
-      return False
-    return True
-
   # TODO: Evolve to python-metaprogrammed PDLL constraints.
   def create_matchers(self, module, benefit: int = 1):
     #                  M=A.0   N=B.1   K=A.1
@@ -169,12 +161,13 @@ class NGScheduler(NGSchedulerInterface):
 
         transform.LowerToLLVMOp()
 
-def make_optimizer(scheduler: NGSchedulerInterface,
-                   search_strategy: str,
+
+def make_optimizer(scheduler: NGSchedulerInterface, search_strategy: str,
                    budget: int):
   optimizer = ng.optimizers.registry[search_strategy](
       parametrization=scheduler.instrumentation, budget=budget)
   return optimizer
+
 
 def main():
   argparser = ArgumentParser()


### PR DESCRIPTION
This allows decoupling the taskset for compilation (even supporting multiple compilation processes per cpu),
from the evaluation process which is now better isolated.
This allows setting up tasksets that let us run on multiple cores in each evaluation.
This is a prerequisite for running in parallel without prohibitive interferences.