### PR TITLE
Remove unnecessary buffers in fusion tests.

### DIFF
--- a/python/examples/fusion/test.py
+++ b/python/examples/fusion/test.py
@@ -73,7 +73,7 @@ def fill_matmul_bias_add_fusion():
   keys = ['M', 'N', 'K']
   n_iters = 1
   problem_size_list = [[24, 32, 48], [27, 37, 43]]
-  test_harness(lambda s, t: MatmulBiasAddProblem(), [[np.float32] * 5],
+  test_harness(lambda s, t: MatmulBiasAddProblem(), [[np.float32] * 4],
                test_sizes(keys, problem_size_list),
                [expert.print_ir(after_all=False, at_begin=False, llvm=False)],
                n_iters=n_iters,


### PR DESCRIPTION
We used to have an extra argument to store matmul result. Remove the
argument to make sure the expected input pattern is generated. E.g.,

```mlir
  func @matmul_bias_add(%arg0: tensor<27x43xf32>,
                        %arg1: tensor<43x37xf32>,
                        %arg2: tensor<37xf32>,
                        %arg3: tensor<27x37xf32>) -> tensor<27x37xf32> {
    %cst = arith.constant 0.000000e+00 : f32
    %0 = linalg.fill(%cst, %arg3) : f32, tensor<27x37xf32> -> tensor<27x37xf32>
    %1 = linalg.matmul
      ins(%arg0, %arg1 : tensor<27x43xf32>, tensor<43x37xf32>)
      outs(%0 : tensor<27x37xf32>) -> tensor<27x37xf32>
    %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                                          affine_map<(d0, d1) -> (d1)>,
                                          affine_map<(d0, d1) -> (d0, d1)>],
                         iterator_types = ["parallel", "parallel"]}
      ins(%1, %arg2 : tensor<27x37xf32>, tensor<37xf32>)
      outs(%arg3 : tensor<27x37xf32>) {
    ^bb0(%arg4: f32, %arg5: f32, %arg6: f32):
      %3 = arith.addf %arg4, %arg5 : f32
      linalg.yield %3 : f32
    } -> tensor<27x37xf32>
    return %2 : tensor<27x37xf32>
  }
```

This allows us to reproduce the issue seeing in https://github.com/google/iree/issues/8303