### PR TITLE
Fix running bench targets.

### DIFF
--- a/python/examples/core/harness.py
+++ b/python/examples/core/harness.py
@@ -510,10 +510,14 @@ def test_argparser(benchmark_name: str, \
   default_spec_list: Default specification list.
   """
   parser = argparse.ArgumentParser(description=benchmark_name)
-  add_argparser_arguments(parser, benchmark_name, default_n_iters,
-                          default_problem_sizes_list, default_expert_list,
-                          default_dynamic_at_compile_time_list,
-                          default_spec_list)
+  add_argparser_arguments(
+      parser=parser,
+      benchmark_name=benchmark_name,
+      default_n_iters=default_n_iters,
+      default_problem_sizes_list=default_problem_sizes_list,
+      default_expert_list=default_expert_list,
+      default_dynamic_at_compile_time_list=default_dynamic_at_compile_time_list,
+      default_spec_list=default_spec_list)
   return parser.parse_args(sys.argv[1:])
 
 


### PR DESCRIPTION
The order was broken because of https://github.com/google/iree-llvm-sandbox/commit/72730fc5b8f41b6faf50ae1fb733838802c9cd1c
The PR passes arguments using keyword arguments to fix and prevent this
issue in the future.