### PR TITLE
Introduce an extension mechanism for TransformState

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.h
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.h
@@ -9,7 +9,9 @@
 #ifndef MLIR_DIALECT_LINALG_IR_LINALGTRANSFORMOPS_H
 #define MLIR_DIALECT_LINALG_IR_LINALGTRANSFORMOPS_H
 
+#include "Dialects/LinalgTransform/TrackingListener.h"
 #include "Dialects/LinalgTransform/TransformOpInterface.h"
+#include "TrackingListener.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -25,5 +27,17 @@ class ForOp;
 
 #define GET_OP_CLASSES
 #include "Dialects/LinalgTransform/LinalgTransformOps.h.inc"
+
+namespace mlir {
+namespace linalg {
+
+class TrackingState : public transform::TransformState::Extension,
+                      public TrackingListener {
+public:
+  explicit TrackingState(transform::TransformState &state)
+      : TrackingListener(getMapping(state)) {}
+};
+} // namespace linalg
+} // namespace mlir
 
 #endif // MLIR_DIALECT_LINALG_IR_LINALGTRANSFORMOPS_H

--- a/include/Dialects/LinalgTransform/TrackingCSE.h
+++ b/include/Dialects/LinalgTransform/TrackingCSE.h
@@ -9,14 +9,15 @@
 #ifndef MLIR_DIALECT_LINALG_TRANSFORMS_TRACKINGCSE_H
 #define MLIR_DIALECT_LINALG_TRANSFORMS_TRACKINGCSE_H
 
-#include "Dialects/LinalgTransform/TransformOpMapping.h"
-
 namespace mlir {
 class DominanceInfo;
+struct LogicalResult;
+class Operation;
+struct RewriteListener;
 
 LogicalResult
 eliminateCommonSubexpressionsWithTrackedOps(Operation *root,
-                                            TransformOpMapping &trackedOps,
+                                            RewriteListener &listener,
                                             DominanceInfo *domInfo = nullptr);
 } // namespace mlir
 

--- a/include/Dialects/LinalgTransform/TrackingListener.h
+++ b/include/Dialects/LinalgTransform/TrackingListener.h
@@ -20,6 +20,15 @@ namespace linalg {
 class TrackingListener : public RewriteListener {
 public:
   TrackingListener(TransformOpMapping &trackedOperations);
+  TrackingListener(TrackingListener &&other)
+      : trackedOperations(other.trackedOperations),
+        trackedOperationKeys(std::move(other.trackedOperationKeys)),
+        hadErrors(other.hadErrors) {
+#ifndef NDEBUG
+    errorStateChecked = other.errorStateChecked;
+    other.errorStateChecked = true;
+#endif
+  }
   ~TrackingListener() {
 #ifndef NDEBUG
     assert(errorStateChecked && "must check listener error state");

--- a/include/Dialects/LinalgTransform/TrackingRewriteDriver.h
+++ b/include/Dialects/LinalgTransform/TrackingRewriteDriver.h
@@ -13,6 +13,8 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
+struct RewriteListener;
+
 /// Apply the given list of transformations to the regions of the
 /// isolated-from-above operation `root` greedily until convergence. Update
 /// Linalg operations in values of `trackedOperations` if they are replaced by
@@ -20,7 +22,7 @@ namespace mlir {
 /// must be replaced with Linalg operations and must not be erased in the
 /// patterns.
 LogicalResult applyPatternsTrackAndFoldGreedily(
-    Operation *root, TransformOpMapping &trackedOperations,
+    Operation *root, RewriteListener &listener,
     const FrozenRewritePatternSet &patterns,
     GreedyRewriteConfig config = GreedyRewriteConfig());
 } // namespace mlir

--- a/lib/Dialects/LinalgTransform/IR/TrackingRewriteDriver.cpp
+++ b/lib/Dialects/LinalgTransform/IR/TrackingRewriteDriver.cpp
@@ -7,16 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "Dialects/LinalgTransform/TrackingRewriteDriver.h"
-#include "Dialects/LinalgTransform/TrackingListener.h"
 #include "Transforms/ListenerGreedyPatternRewriteDriver.h"
 
 using namespace mlir;
 
 LogicalResult mlir::applyPatternsTrackAndFoldGreedily(
-    Operation *root, TransformOpMapping &trackedOperations,
+    Operation *root, RewriteListener &listener,
     const FrozenRewritePatternSet &patterns, GreedyRewriteConfig config) {
-  linalg::TrackingListener listener(trackedOperations);
-  if (failed(applyPatternsAndFoldGreedily(root, patterns, config, &listener)))
-    return failure();
-  return listener.checkErrorState();
+  return applyPatternsAndFoldGreedily(root, patterns, config, &listener);
 }

--- a/lib/Dialects/LinalgTransform/IR/TransformOpInterface.cpp
+++ b/lib/Dialects/LinalgTransform/IR/TransformOpInterface.cpp
@@ -89,6 +89,10 @@ transform::TransformState::applyTransform(TransformOpInterface transform) {
   return success();
 }
 
+// Out-of-line definition to ensure vtable and metadata are emitted to a single
+// .o file.
+transform::TransformState::Extension::~Extension() {}
+
 //===----------------------------------------------------------------------===//
 // TransformResults
 //===----------------------------------------------------------------------===//

--- a/lib/Dialects/LinalgTransform/Transforms/TrackingCSE.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TrackingCSE.cpp
@@ -7,16 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "Dialects/LinalgTransform/TrackingCSE.h"
-#include "Dialects/LinalgTransform/TrackingListener.h"
-#include "Transforms/Listener.h"
 #include "Transforms/ListenerCSE.h"
 
 using namespace mlir;
 
 LogicalResult mlir::eliminateCommonSubexpressionsWithTrackedOps(
-    Operation *root, TransformOpMapping &trackedOps, DominanceInfo *domInfo) {
-  linalg::TrackingListener listener(trackedOps);
-  if (failed(eliminateCommonSubexpressions(root, domInfo, &listener)))
-    return failure();
-  return listener.checkErrorState();
+    Operation *root, RewriteListener &listener, DominanceInfo *domInfo) {
+  return eliminateCommonSubexpressions(root, domInfo, &listener);
 }


### PR DESCRIPTION
This mechanism allows one to attach arbitrary typed extension objects to
the TransformState object, shared by ops implementing the
TransformOpInterface. Thus transform ops may communicate more
information than available in the state.

Use this mechanism instead of manually creating tracking listeners in
the Linalg Transform dialect interpreter. The current use is slightly
awkward as it requires to add and remove an extension in order to ensure
it reflects the most recent state of the payload IR, but it already
avoids reconstructing the internal structure of the tracking listener
for every canonicalization/CSE/enabler transformation that run
consecutively. Further work should remove the need to remove the
extension by notifying it about changes to the state.