### PR TITLE
Add default attribute values to fix conv benchmarks.

### DIFF
--- a/python/examples/conv/ops.py
+++ b/python/examples/conv/ops.py
@@ -9,8 +9,8 @@ def conv_1d_ncw_cfw(
     I=TensorDef(TV.T1, S.N, S.C, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.F, S.KW),
     O=TensorDef(U, S.N, S.F, S.OW, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.ow, D.c, D.kw)
   O[D.n, D.f, D.ow] += (
@@ -23,8 +23,8 @@ def conv_1d_ncw_cwf(
     I=TensorDef(TV.T1, S.N, S.C, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.KW, S.F),
     O=TensorDef(U, S.N, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.ow, D.f, D.c, D.kw)
   O[D.n, D.ow, D.f] += (
@@ -37,8 +37,8 @@ def conv_1d_ncw_fcw(
     I=TensorDef(TV.T1, S.N, S.C, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.C, S.KW),
     O=TensorDef(U, S.N, S.F, S.OW, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.ow, D.c, D.kw)
   O[D.n, D.f, D.ow] += (
@@ -51,8 +51,8 @@ def conv_1d_ncw_fwc(
     I=TensorDef(TV.T1, S.N, S.C, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.KW, S.C),
     O=TensorDef(U, S.N, S.F, S.OW, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.ow, D.kw, D.c)
   O[D.n, D.f, D.ow] += (
@@ -65,8 +65,8 @@ def conv_1d_ncw_wcf(
     I=TensorDef(TV.T1, S.N, S.C, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KW, S.C, S.F),
     O=TensorDef(U, S.N, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.ow, D.f, D.kw, D.c)
   O[D.n, D.ow, D.f] += (
@@ -79,8 +79,8 @@ def conv_1d_ncw_wfc(
     I=TensorDef(TV.T1, S.N, S.C, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KW, S.F, S.C),
     O=TensorDef(U, S.N, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.ow, D.f, D.kw, D.c)
   O[D.n, D.ow, D.f] += (
@@ -93,8 +93,8 @@ def conv_1d_nwc_cfw(
     I=TensorDef(TV.T1, S.N, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.C, S.F, S.KW),
     O=TensorDef(U, S.N, S.F, S.OW, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.ow, D.c, D.kw)
   O[D.n, D.f, D.ow] += (
@@ -107,8 +107,8 @@ def conv_1d_nwc_cwf(
     I=TensorDef(TV.T1, S.N, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.C, S.KW, S.F),
     O=TensorDef(U, S.N, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.ow, D.f, D.c, D.kw)
   O[D.n, D.ow, D.f] += (
@@ -121,8 +121,8 @@ def conv_1d_nwc_fcw(
     I=TensorDef(TV.T1, S.N, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.F, S.C, S.KW),
     O=TensorDef(U, S.N, S.F, S.OW, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.ow, D.c, D.kw)
   O[D.n, D.f, D.ow] += (
@@ -135,8 +135,8 @@ def conv_1d_nwc_fwc(
     I=TensorDef(TV.T1, S.N, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.F, S.KW, S.C),
     O=TensorDef(U, S.N, S.F, S.OW, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.ow, D.kw, D.c)
   O[D.n, D.f, D.ow] += (
@@ -149,8 +149,8 @@ def conv_1d_nwc_wcf(
     I=TensorDef(TV.T1, S.N, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.KW, S.C, S.F),
     O=TensorDef(U, S.N, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.ow, D.f, D.kw, D.c)
   O[D.n, D.ow, D.f] += (
@@ -163,8 +163,8 @@ def conv_1d_nwc_wfc(
     I=TensorDef(TV.T1, S.N, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.KW, S.F, S.C),
     O=TensorDef(U, S.N, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.ow, D.f, D.kw, D.c)
   O[D.n, D.ow, D.f] += (
@@ -177,8 +177,8 @@ def conv_1d_cnw_cfw(
     I=TensorDef(TV.T1, S.C, S.N, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.F, S.KW),
     O=TensorDef(U, S.N, S.F, S.OW, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.ow, D.c, D.kw)
   O[D.n, D.f, D.ow] += (
@@ -191,8 +191,8 @@ def conv_1d_cnw_cwf(
     I=TensorDef(TV.T1, S.C, S.N, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.KW, S.F),
     O=TensorDef(U, S.N, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.ow, D.f, D.c, D.kw)
   O[D.n, D.ow, D.f] += (
@@ -205,8 +205,8 @@ def conv_1d_cnw_fcw(
     I=TensorDef(TV.T1, S.C, S.N, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.C, S.KW),
     O=TensorDef(U, S.N, S.F, S.OW, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.ow, D.c, D.kw)
   O[D.n, D.f, D.ow] += (
@@ -219,8 +219,8 @@ def conv_1d_cnw_fwc(
     I=TensorDef(TV.T1, S.C, S.N, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.KW, S.C),
     O=TensorDef(U, S.N, S.F, S.OW, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.ow, D.kw, D.c)
   O[D.n, D.f, D.ow] += (
@@ -233,8 +233,8 @@ def conv_1d_cnw_wcf(
     I=TensorDef(TV.T1, S.C, S.N, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KW, S.C, S.F),
     O=TensorDef(U, S.N, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.ow, D.f, D.kw, D.c)
   O[D.n, D.ow, D.f] += (
@@ -247,8 +247,8 @@ def conv_1d_cnw_wfc(
     I=TensorDef(TV.T1, S.C, S.N, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KW, S.F, S.C),
     O=TensorDef(U, S.N, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.ow, D.f, D.kw, D.c)
   O[D.n, D.ow, D.f] += (
@@ -261,8 +261,8 @@ def conv_1d_cwn_cfw(
     I=TensorDef(TV.T1, S.C, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.C, S.F, S.KW),
     O=TensorDef(U, S.F, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.ow, D.n, D.c, D.kw)
   O[D.f, D.ow, D.n] += (
@@ -275,8 +275,8 @@ def conv_1d_cwn_cwf(
     I=TensorDef(TV.T1, S.C, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.C, S.KW, S.F),
     O=TensorDef(U, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.ow, D.n, D.f, D.c, D.kw)
   O[D.ow, D.n, D.f] += (
@@ -289,8 +289,8 @@ def conv_1d_cwn_fcw(
     I=TensorDef(TV.T1, S.C, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.F, S.C, S.KW),
     O=TensorDef(U, S.F, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.ow, D.n, D.c, D.kw)
   O[D.f, D.ow, D.n] += (
@@ -303,8 +303,8 @@ def conv_1d_cwn_fwc(
     I=TensorDef(TV.T1, S.C, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.F, S.KW, S.C),
     O=TensorDef(U, S.F, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.ow, D.n, D.kw, D.c)
   O[D.f, D.ow, D.n] += (
@@ -317,8 +317,8 @@ def conv_1d_cwn_wcf(
     I=TensorDef(TV.T1, S.C, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.KW, S.C, S.F),
     O=TensorDef(U, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.ow, D.n, D.f, D.kw, D.c)
   O[D.ow, D.n, D.f] += (
@@ -331,8 +331,8 @@ def conv_1d_cwn_wfc(
     I=TensorDef(TV.T1, S.C, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.KW, S.F, S.C),
     O=TensorDef(U, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.ow, D.n, D.f, D.kw, D.c)
   O[D.ow, D.n, D.f] += (
@@ -345,8 +345,8 @@ def conv_1d_wnc_cfw(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.C, S.F, S.KW),
     O=TensorDef(U, S.F, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.ow, D.n, D.c, D.kw)
   O[D.f, D.ow, D.n] += (
@@ -359,8 +359,8 @@ def conv_1d_wnc_cwf(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.C, S.KW, S.F),
     O=TensorDef(U, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.ow, D.n, D.f, D.c, D.kw)
   O[D.ow, D.n, D.f] += (
@@ -373,8 +373,8 @@ def conv_1d_wnc_fcw(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.F, S.C, S.KW),
     O=TensorDef(U, S.F, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.ow, D.n, D.c, D.kw)
   O[D.f, D.ow, D.n] += (
@@ -387,8 +387,8 @@ def conv_1d_wnc_fwc(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.F, S.KW, S.C),
     O=TensorDef(U, S.F, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.ow, D.n, D.kw, D.c)
   O[D.f, D.ow, D.n] += (
@@ -401,8 +401,8 @@ def conv_1d_wnc_wcf(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.KW, S.C, S.F),
     O=TensorDef(U, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.ow, D.n, D.f, D.kw, D.c)
   O[D.ow, D.n, D.f] += (
@@ -415,8 +415,8 @@ def conv_1d_wnc_wfc(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.KW, S.F, S.C),
     O=TensorDef(U, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.ow, D.n, D.f, D.kw, D.c)
   O[D.ow, D.n, D.f] += (
@@ -429,8 +429,8 @@ def conv_1d_wcn_cfw(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.C, S.F, S.KW),
     O=TensorDef(U, S.F, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.ow, D.n, D.c, D.kw)
   O[D.f, D.ow, D.n] += (
@@ -443,8 +443,8 @@ def conv_1d_wcn_cwf(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.C, S.KW, S.F),
     O=TensorDef(U, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.ow, D.n, D.f, D.c, D.kw)
   O[D.ow, D.n, D.f] += (
@@ -457,8 +457,8 @@ def conv_1d_wcn_fcw(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.F, S.C, S.KW),
     O=TensorDef(U, S.F, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.ow, D.n, D.c, D.kw)
   O[D.f, D.ow, D.n] += (
@@ -471,8 +471,8 @@ def conv_1d_wcn_fwc(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.F, S.KW, S.C),
     O=TensorDef(U, S.F, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.ow, D.n, D.kw, D.c)
   O[D.f, D.ow, D.n] += (
@@ -485,8 +485,8 @@ def conv_1d_wcn_wcf(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.KW, S.C, S.F),
     O=TensorDef(U, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.ow, D.n, D.f, D.kw, D.c)
   O[D.ow, D.n, D.f] += (
@@ -499,8 +499,8 @@ def conv_1d_wcn_wfc(
     I=TensorDef(TV.T1, S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.KW, S.F, S.C),
     O=TensorDef(U, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SW),
-    dilations=IndexAttrDef(S.DW)):
+    strides=IndexAttrDef(S.SW, default=[1]),
+    dilations=IndexAttrDef(S.DW, default=[1])):
   implements(ConvolutionOpInterface)
   domain(D.ow, D.n, D.f, D.kw, D.c)
   O[D.ow, D.n, D.f] += (
@@ -514,8 +514,8 @@ def conv_2d_nchw_cfhw(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.F, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.c, D.kh, D.kw)
   O[D.n, D.f, D.oh, D.ow] += (
@@ -529,8 +529,8 @@ def conv_2d_nchw_chwf(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.KH, S.KW, S.F),
     O=TensorDef(U, S.N, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.oh, D.ow, D.f, D.c, D.kh, D.kw)
   O[D.n, D.oh, D.ow, D.f] += (
@@ -544,8 +544,8 @@ def conv_2d_nchw_fchw(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.C, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.c, D.kh, D.kw)
   O[D.n, D.f, D.oh, D.ow] += (
@@ -559,8 +559,8 @@ def conv_2d_nchw_fhwc(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.KH, S.KW, S.C),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.kh, D.kw, D.c)
   O[D.n, D.f, D.oh, D.ow] += (
@@ -574,8 +574,8 @@ def conv_2d_nchw_hwcf(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.N, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.oh, D.ow, D.f, D.kh, D.kw, D.c)
   O[D.n, D.oh, D.ow, D.f] += (
@@ -589,8 +589,8 @@ def conv_2d_nchw_hwfc(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.N, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.oh, D.ow, D.f, D.kh, D.kw, D.c)
   O[D.n, D.oh, D.ow, D.f] += (
@@ -604,8 +604,8 @@ def conv_2d_nhwc_cfhw(
                 S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.C, S.F, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.c, D.kh, D.kw)
   O[D.n, D.f, D.oh, D.ow] += (
@@ -619,8 +619,8 @@ def conv_2d_nhwc_chwf(
                 S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.C, S.KH, S.KW, S.F),
     O=TensorDef(U, S.N, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.oh, D.ow, D.f, D.c, D.kh, D.kw)
   O[D.n, D.oh, D.ow, D.f] += (
@@ -634,8 +634,8 @@ def conv_2d_nhwc_fchw(
                 S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.F, S.C, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.c, D.kh, D.kw)
   O[D.n, D.f, D.oh, D.ow] += (
@@ -649,8 +649,8 @@ def conv_2d_nhwc_fhwc(
                 S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.F, S.KH, S.KW, S.C),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.kh, D.kw, D.c)
   O[D.n, D.f, D.oh, D.ow] += (
@@ -664,8 +664,8 @@ def conv_2d_nhwc_hwcf(
                 S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.N, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.oh, D.ow, D.f, D.kh, D.kw, D.c)
   O[D.n, D.oh, D.ow, D.f] += (
@@ -679,8 +679,8 @@ def conv_2d_nhwc_hwfc(
                 S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.N, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.oh, D.ow, D.f, D.kh, D.kw, D.c)
   O[D.n, D.oh, D.ow, D.f] += (
@@ -694,8 +694,8 @@ def conv_2d_cnhw_cfhw(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.F, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.c, D.kh, D.kw)
   O[D.n, D.f, D.oh, D.ow] += (
@@ -709,8 +709,8 @@ def conv_2d_cnhw_chwf(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.KH, S.KW, S.F),
     O=TensorDef(U, S.N, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.oh, D.ow, D.f, D.c, D.kh, D.kw)
   O[D.n, D.oh, D.ow, D.f] += (
@@ -724,8 +724,8 @@ def conv_2d_cnhw_fchw(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.C, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.c, D.kh, D.kw)
   O[D.n, D.f, D.oh, D.ow] += (
@@ -739,8 +739,8 @@ def conv_2d_cnhw_fhwc(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.KH, S.KW, S.C),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.kh, D.kw, D.c)
   O[D.n, D.f, D.oh, D.ow] += (
@@ -754,8 +754,8 @@ def conv_2d_cnhw_hwcf(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.N, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.oh, D.ow, D.f, D.kh, D.kw, D.c)
   O[D.n, D.oh, D.ow, D.f] += (
@@ -769,8 +769,8 @@ def conv_2d_cnhw_hwfc(
                 S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.N, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.oh, D.ow, D.f, D.kh, D.kw, D.c)
   O[D.n, D.oh, D.ow, D.f] += (
@@ -784,8 +784,8 @@ def conv_2d_chwn_cfhw(
                 S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.C, S.F, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.oh, D.ow, D.n, D.c, D.kh, D.kw)
   O[D.f, D.oh, D.ow, D.n] += (
@@ -799,8 +799,8 @@ def conv_2d_chwn_chwf(
                 S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.C, S.KH, S.KW, S.F),
     O=TensorDef(U, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.oh, D.ow, D.n, D.f, D.c, D.kh, D.kw)
   O[D.oh, D.ow, D.n, D.f] += (
@@ -814,8 +814,8 @@ def conv_2d_chwn_fchw(
                 S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.F, S.C, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.oh, D.ow, D.n, D.c, D.kh, D.kw)
   O[D.f, D.oh, D.ow, D.n] += (
@@ -829,8 +829,8 @@ def conv_2d_chwn_fhwc(
                 S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.F, S.KH, S.KW, S.C),
     O=TensorDef(U, S.F, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.oh, D.ow, D.n, D.kh, D.kw, D.c)
   O[D.f, D.oh, D.ow, D.n] += (
@@ -844,8 +844,8 @@ def conv_2d_chwn_hwcf(
                 S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.oh, D.ow, D.n, D.f, D.kh, D.kw, D.c)
   O[D.oh, D.ow, D.n, D.f] += (
@@ -859,8 +859,8 @@ def conv_2d_chwn_hwfc(
                 S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.oh, D.ow, D.n, D.f, D.kh, D.kw, D.c)
   O[D.oh, D.ow, D.n, D.f] += (
@@ -874,8 +874,8 @@ def conv_2d_hwnc_cfhw(
                 S.N, S.C),
     K=TensorDef(TV.T2, S.C, S.F, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.oh, D.ow, D.n, D.c, D.kh, D.kw)
   O[D.f, D.oh, D.ow, D.n] += (
@@ -889,8 +889,8 @@ def conv_2d_hwnc_chwf(
                 S.N, S.C),
     K=TensorDef(TV.T2, S.C, S.KH, S.KW, S.F),
     O=TensorDef(U, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.oh, D.ow, D.n, D.f, D.c, D.kh, D.kw)
   O[D.oh, D.ow, D.n, D.f] += (
@@ -904,8 +904,8 @@ def conv_2d_hwnc_fchw(
                 S.N, S.C),
     K=TensorDef(TV.T2, S.F, S.C, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.oh, D.ow, D.n, D.c, D.kh, D.kw)
   O[D.f, D.oh, D.ow, D.n] += (
@@ -919,8 +919,8 @@ def conv_2d_hwnc_fhwc(
                 S.N, S.C),
     K=TensorDef(TV.T2, S.F, S.KH, S.KW, S.C),
     O=TensorDef(U, S.F, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.oh, D.ow, D.n, D.kh, D.kw, D.c)
   O[D.f, D.oh, D.ow, D.n] += (
@@ -934,8 +934,8 @@ def conv_2d_hwnc_hwcf(
                 S.N, S.C),
     K=TensorDef(TV.T2, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.oh, D.ow, D.n, D.f, D.kh, D.kw, D.c)
   O[D.oh, D.ow, D.n, D.f] += (
@@ -949,8 +949,8 @@ def conv_2d_hwnc_hwfc(
                 S.N, S.C),
     K=TensorDef(TV.T2, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.oh, D.ow, D.n, D.f, D.kh, D.kw, D.c)
   O[D.oh, D.ow, D.n, D.f] += (
@@ -964,8 +964,8 @@ def conv_2d_hwcn_cfhw(
                 S.C, S.N),
     K=TensorDef(TV.T2, S.C, S.F, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.oh, D.ow, D.n, D.c, D.kh, D.kw)
   O[D.f, D.oh, D.ow, D.n] += (
@@ -979,8 +979,8 @@ def conv_2d_hwcn_chwf(
                 S.C, S.N),
     K=TensorDef(TV.T2, S.C, S.KH, S.KW, S.F),
     O=TensorDef(U, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.oh, D.ow, D.n, D.f, D.c, D.kh, D.kw)
   O[D.oh, D.ow, D.n, D.f] += (
@@ -994,8 +994,8 @@ def conv_2d_hwcn_fchw(
                 S.C, S.N),
     K=TensorDef(TV.T2, S.F, S.C, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.oh, D.ow, D.n, D.c, D.kh, D.kw)
   O[D.f, D.oh, D.ow, D.n] += (
@@ -1009,8 +1009,8 @@ def conv_2d_hwcn_fhwc(
                 S.C, S.N),
     K=TensorDef(TV.T2, S.F, S.KH, S.KW, S.C),
     O=TensorDef(U, S.F, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.oh, D.ow, D.n, D.kh, D.kw, D.c)
   O[D.f, D.oh, D.ow, D.n] += (
@@ -1024,8 +1024,8 @@ def conv_2d_hwcn_hwcf(
                 S.C, S.N),
     K=TensorDef(TV.T2, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.oh, D.ow, D.n, D.f, D.kh, D.kw, D.c)
   O[D.oh, D.ow, D.n, D.f] += (
@@ -1039,8 +1039,8 @@ def conv_2d_hwcn_hwfc(
                 S.C, S.N),
     K=TensorDef(TV.T2, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SH, S.SW),
-    dilations=IndexAttrDef(S.DH, S.DW)):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.oh, D.ow, D.n, D.f, D.kh, D.kw, D.c)
   O[D.oh, D.ow, D.n, D.f] += (
@@ -1054,8 +1054,8 @@ def conv_3d_ncdhw_cfdhw(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.F, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OD, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.od, D.oh, D.ow, D.c, D.kd, D.kh, D.kw)
   O[D.n, D.f, D.od, D.oh, D.ow] += (
@@ -1071,8 +1071,8 @@ def conv_3d_ncdhw_cdhwf(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.KD, S.KH, S.KW, S.F),
     O=TensorDef(U, S.N, S.OD, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.od, D.oh, D.ow, D.f, D.c, D.kd, D.kh, D.kw)
   O[D.n, D.od, D.oh, D.ow, D.f] += (
@@ -1088,8 +1088,8 @@ def conv_3d_ncdhw_fcdhw(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.C, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OD, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.od, D.oh, D.ow, D.c, D.kd, D.kh, D.kw)
   O[D.n, D.f, D.od, D.oh, D.ow] += (
@@ -1105,8 +1105,8 @@ def conv_3d_ncdhw_fdhwc(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.KD, S.KH, S.KW, S.C),
     O=TensorDef(U, S.N, S.F, S.OD, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.od, D.oh, D.ow, D.kd, D.kh, D.kw, D.c)
   O[D.n, D.f, D.od, D.oh, D.ow] += (
@@ -1122,8 +1122,8 @@ def conv_3d_ncdhw_dhwcf(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.N, S.OD, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.od, D.oh, D.ow, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.n, D.od, D.oh, D.ow, D.f] += (
@@ -1139,8 +1139,8 @@ def conv_3d_ncdhw_dhwfc(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.N, S.OD, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.od, D.oh, D.ow, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.n, D.od, D.oh, D.ow, D.f] += (
@@ -1156,8 +1156,8 @@ def conv_3d_ndhwc_cfdhw(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.C, S.F, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OD, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.od, D.oh, D.ow, D.c, D.kd, D.kh, D.kw)
   O[D.n, D.f, D.od, D.oh, D.ow] += (
@@ -1173,8 +1173,8 @@ def conv_3d_ndhwc_cdhwf(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.C, S.KD, S.KH, S.KW, S.F),
     O=TensorDef(U, S.N, S.OD, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.od, D.oh, D.ow, D.f, D.c, D.kd, D.kh, D.kw)
   O[D.n, D.od, D.oh, D.ow, D.f] += (
@@ -1190,8 +1190,8 @@ def conv_3d_ndhwc_fcdhw(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.F, S.C, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OD, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.od, D.oh, D.ow, D.c, D.kd, D.kh, D.kw)
   O[D.n, D.f, D.od, D.oh, D.ow] += (
@@ -1207,8 +1207,8 @@ def conv_3d_ndhwc_fdhwc(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.F, S.KD, S.KH, S.KW, S.C),
     O=TensorDef(U, S.N, S.F, S.OD, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.od, D.oh, D.ow, D.kd, D.kh, D.kw, D.c)
   O[D.n, D.f, D.od, D.oh, D.ow] += (
@@ -1224,8 +1224,8 @@ def conv_3d_ndhwc_dhwcf(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.N, S.OD, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.od, D.oh, D.ow, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.n, D.od, D.oh, D.ow, D.f] += (
@@ -1241,8 +1241,8 @@ def conv_3d_ndhwc_dhwfc(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.C),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.N, S.OD, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.od, D.oh, D.ow, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.n, D.od, D.oh, D.ow, D.f] += (
@@ -1258,8 +1258,8 @@ def conv_3d_cndhw_cfdhw(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.F, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OD, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.od, D.oh, D.ow, D.c, D.kd, D.kh, D.kw)
   O[D.n, D.f, D.od, D.oh, D.ow] += (
@@ -1275,8 +1275,8 @@ def conv_3d_cndhw_cdhwf(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.C, S.KD, S.KH, S.KW, S.F),
     O=TensorDef(U, S.N, S.OD, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.od, D.oh, D.ow, D.f, D.c, D.kd, D.kh, D.kw)
   O[D.n, D.od, D.oh, D.ow, D.f] += (
@@ -1292,8 +1292,8 @@ def conv_3d_cndhw_fcdhw(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.C, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.N, S.F, S.OD, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.od, D.oh, D.ow, D.c, D.kd, D.kh, D.kw)
   O[D.n, D.f, D.od, D.oh, D.ow] += (
@@ -1309,8 +1309,8 @@ def conv_3d_cndhw_fdhwc(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.F, S.KD, S.KH, S.KW, S.C),
     O=TensorDef(U, S.N, S.F, S.OD, S.OH, S.OW, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.od, D.oh, D.ow, D.kd, D.kh, D.kw, D.c)
   O[D.n, D.f, D.od, D.oh, D.ow] += (
@@ -1326,8 +1326,8 @@ def conv_3d_cndhw_dhwcf(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.N, S.OD, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.od, D.oh, D.ow, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.n, D.od, D.oh, D.ow, D.f] += (
@@ -1343,8 +1343,8 @@ def conv_3d_cndhw_dhwfc(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.N, S.OD, S.OH, S.OW, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.n, D.od, D.oh, D.ow, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.n, D.od, D.oh, D.ow, D.f] += (
@@ -1360,8 +1360,8 @@ def conv_3d_cdhwn_cfdhw(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.C, S.F, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OD, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.od, D.oh, D.ow, D.n, D.c, D.kd, D.kh, D.kw)
   O[D.f, D.od, D.oh, D.ow, D.n] += (
@@ -1377,8 +1377,8 @@ def conv_3d_cdhwn_cdhwf(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.C, S.KD, S.KH, S.KW, S.F),
     O=TensorDef(U, S.OD, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.od, D.oh, D.ow, D.n, D.f, D.c, D.kd, D.kh, D.kw)
   O[D.od, D.oh, D.ow, D.n, D.f] += (
@@ -1394,8 +1394,8 @@ def conv_3d_cdhwn_fcdhw(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.F, S.C, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OD, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.od, D.oh, D.ow, D.n, D.c, D.kd, D.kh, D.kw)
   O[D.f, D.od, D.oh, D.ow, D.n] += (
@@ -1411,8 +1411,8 @@ def conv_3d_cdhwn_fdhwc(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.F, S.KD, S.KH, S.KW, S.C),
     O=TensorDef(U, S.F, S.OD, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.od, D.oh, D.ow, D.n, D.kd, D.kh, D.kw, D.c)
   O[D.f, D.od, D.oh, D.ow, D.n] += (
@@ -1428,8 +1428,8 @@ def conv_3d_cdhwn_dhwcf(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.OD, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.od, D.oh, D.ow, D.n, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.od, D.oh, D.ow, D.n, D.f] += (
@@ -1445,8 +1445,8 @@ def conv_3d_cdhwn_dhwfc(
                 S.OH * S.SH + S.KH * S.DH, S.OW * S.SW + S.KW * S.DW, S.N),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.OD, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.od, D.oh, D.ow, D.n, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.od, D.oh, D.ow, D.n, D.f] += (
@@ -1462,8 +1462,8 @@ def conv_3d_dhwnc_cfdhw(
                 S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.C, S.F, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OD, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.od, D.oh, D.ow, D.n, D.c, D.kd, D.kh, D.kw)
   O[D.f, D.od, D.oh, D.ow, D.n] += (
@@ -1479,8 +1479,8 @@ def conv_3d_dhwnc_cdhwf(
                 S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.C, S.KD, S.KH, S.KW, S.F),
     O=TensorDef(U, S.OD, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.od, D.oh, D.ow, D.n, D.f, D.c, D.kd, D.kh, D.kw)
   O[D.od, D.oh, D.ow, D.n, D.f] += (
@@ -1496,8 +1496,8 @@ def conv_3d_dhwnc_fcdhw(
                 S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.F, S.C, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OD, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.od, D.oh, D.ow, D.n, D.c, D.kd, D.kh, D.kw)
   O[D.f, D.od, D.oh, D.ow, D.n] += (
@@ -1513,8 +1513,8 @@ def conv_3d_dhwnc_fdhwc(
                 S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.F, S.KD, S.KH, S.KW, S.C),
     O=TensorDef(U, S.F, S.OD, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.od, D.oh, D.ow, D.n, D.kd, D.kh, D.kw, D.c)
   O[D.f, D.od, D.oh, D.ow, D.n] += (
@@ -1530,8 +1530,8 @@ def conv_3d_dhwnc_dhwcf(
                 S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.OD, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.od, D.oh, D.ow, D.n, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.od, D.oh, D.ow, D.n, D.f] += (
@@ -1547,8 +1547,8 @@ def conv_3d_dhwnc_dhwfc(
                 S.OW * S.SW + S.KW * S.DW, S.N, S.C),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.OD, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.od, D.oh, D.ow, D.n, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.od, D.oh, D.ow, D.n, D.f] += (
@@ -1564,8 +1564,8 @@ def conv_3d_dhwcn_cfdhw(
                 S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.C, S.F, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OD, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.od, D.oh, D.ow, D.n, D.c, D.kd, D.kh, D.kw)
   O[D.f, D.od, D.oh, D.ow, D.n] += (
@@ -1581,8 +1581,8 @@ def conv_3d_dhwcn_cdhwf(
                 S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.C, S.KD, S.KH, S.KW, S.F),
     O=TensorDef(U, S.OD, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.od, D.oh, D.ow, D.n, D.f, D.c, D.kd, D.kh, D.kw)
   O[D.od, D.oh, D.ow, D.n, D.f] += (
@@ -1598,8 +1598,8 @@ def conv_3d_dhwcn_fcdhw(
                 S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.F, S.C, S.KD, S.KH, S.KW),
     O=TensorDef(U, S.F, S.OD, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.od, D.oh, D.ow, D.n, D.c, D.kd, D.kh, D.kw)
   O[D.f, D.od, D.oh, D.ow, D.n] += (
@@ -1615,8 +1615,8 @@ def conv_3d_dhwcn_fdhwc(
                 S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.F, S.KD, S.KH, S.KW, S.C),
     O=TensorDef(U, S.F, S.OD, S.OH, S.OW, S.N, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.f, D.od, D.oh, D.ow, D.n, D.kd, D.kh, D.kw, D.c)
   O[D.f, D.od, D.oh, D.ow, D.n] += (
@@ -1632,8 +1632,8 @@ def conv_3d_dhwcn_dhwcf(
                 S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.C, S.F),
     O=TensorDef(U, S.OD, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.od, D.oh, D.ow, D.n, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.od, D.oh, D.ow, D.n, D.f] += (
@@ -1649,8 +1649,8 @@ def conv_3d_dhwcn_dhwfc(
                 S.OW * S.SW + S.KW * S.DW, S.C, S.N),
     K=TensorDef(TV.T2, S.KD, S.KH, S.KW, S.F, S.C),
     O=TensorDef(U, S.OD, S.OH, S.OW, S.N, S.F, output=True),
-    strides=IndexAttrDef(S.SD, S.SH, S.SW),
-    dilations=IndexAttrDef(S.DD, S.DH, S.DW)):
+    strides=IndexAttrDef(S.SD, S.SH, S.SW, default=[1, 1, 1]),
+    dilations=IndexAttrDef(S.DD, S.DH, S.DW, default=[1, 1, 1])):
   implements(ConvolutionOpInterface)
   domain(D.od, D.oh, D.ow, D.n, D.f, D.kd, D.kh, D.kw, D.c)
   O[D.od, D.oh, D.ow, D.n, D.f] += (


### PR DESCRIPTION
We're not able to run benchmarks if the default values are not added.
It's one of opdsl requrements.