### PR TITLE
Stop exposing mutable state to transform extensions

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.h
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.h
@@ -20,24 +20,12 @@
 namespace mlir {
 namespace scf {
 class ForOp;
-}
+} // namespace scf
 } // namespace mlir
 
 #include "Dialects/LinalgTransform/LinalgTransformOpsDialect.h.inc"
 
 #define GET_OP_CLASSES
 #include "Dialects/LinalgTransform/LinalgTransformOps.h.inc"
-
-namespace mlir {
-namespace linalg {
-
-class TrackingState : public transform::TransformState::Extension,
-                      public TrackingListener {
-public:
-  explicit TrackingState(transform::TransformState &state)
-      : TrackingListener(getMapping(state)) {}
-};
-} // namespace linalg
-} // namespace mlir
 
 #endif // MLIR_DIALECT_LINALG_IR_LINALGTRANSFORMOPS_H

--- a/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -359,9 +359,7 @@ transform::VectorizeOp::apply(transform::TransformResults &results,
   RewritePatternSet patterns(ctx);
   patterns.add<LinalgVectorizationPattern>(ctx);
   configureVectorizationPatterns(*this, patterns);
-  TrackingListener &listener = state.addExtension<TrackingState>(state);
-  auto raii =
-      llvm::make_scope_exit([&]() { state.removeExtension<TrackingState>(); });
+  auto &listener = state.getExtension<TrackingListener>();
   LogicalResult applicationResult = applyPatternsTrackAndFoldGreedily(
       state.getTopLevel(), listener, std::move(patterns));
   LogicalResult listenerResult = listener.checkErrorState();
@@ -700,7 +698,7 @@ static scf::ExecuteRegionOp outlineInExecuteRegion(RewriterBase &b,
 static FailureOr<FuncOp> outlineLoop(scf::ForOp loop, StringRef funcName,
                                      transform::TransformState &state) {
   PatternRewriterListener rewriter(loop->getContext());
-  TrackingListener &listener = state.addExtension<TrackingState>(state);
+  auto &listener = state.getExtension<TrackingListener>();
   rewriter.addListener(&listener);
   Location loc = loop.getLoc();
   scf::ExecuteRegionOp exec = outlineInExecuteRegion(rewriter, loop);


### PR DESCRIPTION
Instead of exposing mutable state to extensions, provide more more
scoped mutation functions that ensure internal consistensy of the state.
Also provide hooks for extensions to get notified about modifications to
the state made by other notifications or external actions.