### PR TITLE
Add pattern to forward warpSingleLaneOp operands

### DIFF
--- a/include/Dialects/VectorExt/VectorExtOps.td
+++ b/include/Dialects/VectorExt/VectorExtOps.td
@@ -148,8 +148,9 @@ def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_execute_on_lane_0",
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "Value":$laneid)>,
-    // TODO: Add arguments support in the builder.
-    OpBuilder<(ins "TypeRange":$resultTypes, "Value":$laneid)>
+    OpBuilder<(ins "TypeRange":$resultTypes, "Value":$laneid)>,
+    OpBuilder<(ins "TypeRange":$resultTypes, "Value":$laneid,
+                  "ValueRange":$operands, "TypeRange":$argTypes)>
   ];
 
   let extraClassDeclaration = [{

--- a/include/Dialects/VectorExt/VectorExtOps.td
+++ b/include/Dialects/VectorExt/VectorExtOps.td
@@ -149,8 +149,11 @@ def VectorExt_WarpSingleLaneOp : VectorExt_Op<"warp_execute_on_lane_0",
   let builders = [
     OpBuilder<(ins "Value":$laneid)>,
     OpBuilder<(ins "TypeRange":$resultTypes, "Value":$laneid)>,
+    // `blockArgTypes` are different than `args` types as they are they
+    // represent all the `args` instances visibile to lane 0. Therefore we need
+    // to explicit pass the type.
     OpBuilder<(ins "TypeRange":$resultTypes, "Value":$laneid,
-                  "ValueRange":$operands, "TypeRange":$argTypes)>
+                   "ValueRange":$args, "TypeRange":$blockArgTypes)>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/Dialects/VectorExt/IR/VectorExtOps.cpp
+++ b/lib/Dialects/VectorExt/IR/VectorExtOps.cpp
@@ -220,15 +220,15 @@ void WarpSingleLaneOp::build(OpBuilder &builder, OperationState &result,
 
 void WarpSingleLaneOp::build(OpBuilder &builder, OperationState &result,
                              TypeRange resultTypes, Value laneId,
-                             ValueRange operands, TypeRange argTypes) {
+                             ValueRange args, TypeRange blockArgTypes) {
   result.addOperands(laneId);
   result.addTypes(resultTypes);
-  result.addOperands(operands);
-  assert(operands.size() == argTypes.size());
+  result.addOperands(args);
+  assert(args.size() == blockArgTypes.size());
   OpBuilder::InsertionGuard guard(builder);
   Region *warpRegion = result.addRegion();
   Block *block = builder.createBlock(warpRegion);
-  for (auto it : llvm::zip(argTypes, operands))
+  for (auto it : llvm::zip(blockArgTypes, args))
     block->addArgument(std::get<0>(it), std::get<1>(it).getLoc());
 }
 

--- a/lib/Dialects/VectorExt/IR/VectorExtOps.cpp
+++ b/lib/Dialects/VectorExt/IR/VectorExtOps.cpp
@@ -213,18 +213,23 @@ void WarpSingleLaneOp::getSuccessorRegions(
 }
 
 void WarpSingleLaneOp::build(OpBuilder &builder, OperationState &result,
-                             Value laneId) {
-  build(builder, result, /*resultTypes=*/llvm::None, laneId);
+                             TypeRange resultTypes, Value laneId) {
+  build(builder, result, resultTypes, laneId,
+        /*operands=*/llvm::None, /*argTypes=*/llvm::None);
 }
 
 void WarpSingleLaneOp::build(OpBuilder &builder, OperationState &result,
-                             TypeRange resultTypes, Value laneId) {
+                             TypeRange resultTypes, Value laneId,
+                             ValueRange operands, TypeRange argTypes) {
   result.addOperands(laneId);
   result.addTypes(resultTypes);
-
+  result.addOperands(operands);
+  assert(operands.size() == argTypes.size());
   OpBuilder::InsertionGuard guard(builder);
   Region *warpRegion = result.addRegion();
-  builder.createBlock(warpRegion);
+  Block *block = builder.createBlock(warpRegion);
+  for (auto it : llvm::zip(argTypes, operands))
+    block->addArgument(std::get<0>(it), std::get<1>(it).getLoc());
 }
 
 #define GET_OP_CLASSES

--- a/test/VectorExt/warp.mlir
+++ b/test/VectorExt/warp.mlir
@@ -18,6 +18,21 @@ func @warp_dead_result(%laneid: index) -> (vector<1xf32>) {
 
 // -----
 
+// CHECK-LABEL:   func @warp_propagate_operand(
+//  CHECK-SAME:   %[[ID:.*]]: index, %[[V:.*]]: vector<4xf32>)
+func @warp_propagate_operand(%laneid: index, %v0: vector<4xf32>)
+  -> (vector<4xf32>) {
+  %r = vector_ext.warp_execute_on_lane_0(%laneid)
+     args(%v0 : vector<4xf32>) -> (vector<4xf32>) {
+     ^bb0(%arg0 : vector<128xf32>) :
+    vector_ext.yield %arg0 : vector<128xf32>
+  }
+  // CHECK: return %[[V]] : vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// -----
+
 #map0 = affine_map<()[s0] -> (s0 * 2)>
 
 // CHECK-LABEL:   func @warp_propagate_elementwise(


### PR DESCRIPTION
Add builder to create warpOp with operands and add a pattern to
propagate the operands when they are directly returned out of the region