### PR TITLE
Add a minimal skeleton for a library callable from MLIR

### DIFF
--- a/experimental/iterators/CMakeLists.txt
+++ b/experimental/iterators/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(iterators VERSION 0.1.0)
 
+# TODO: Atm LLVM is still in C++14 land.
 set(CMAKE_CXX_STANDARD 17)
+
+include_directories(include)
+add_subdirectory(lib)
+
+
+
 
 add_subdirectory(docs)
 
@@ -23,6 +30,8 @@ target_include_directories(iterators PUBLIC include)
 include(CTest)
 enable_testing()
 
+# TODO: move these to the tests director.
+# TODO: split tests into C++ and MLIR
 add_executable(iterator_tests
         tests/column_scan_operator_test.cc
         tests/reduce_operator_test.cc

--- a/experimental/iterators/include/iterators/Utils/RuntimeUtils.h
+++ b/experimental/iterators/include/iterators/Utils/RuntimeUtils.h
@@ -1,0 +1,29 @@
+//===- RuntimeUtils.h - Utils for MLIR / C++ interop ---------------------===//
+
+#ifndef ITERATORS_UTILS_RUNTIMEUTILS_H
+#define ITERATORS_UTILS_RUNTIMEUTILS_H
+
+#ifdef _WIN32
+#ifndef RUNTIME_UTILS_EXPORT
+#ifdef runtime_utils_EXPORTS
+// We are building this library
+#define RUNTIME_UTILS_EXPORT __declspec(dllexport)
+#else
+// We are using this library
+#define RUNTIME_UTILS_EXPORT __declspec(dllimport)
+#endif // runtime_utils_EXPORTS
+#endif // RUNTIME_UTILS_EXPORT
+#else
+// Non-windows: use visibility attributes.
+#define RUNTIME_UTILS_EXPORT __attribute__((visibility("default")))
+#endif // _WIN32
+
+#include <cstdint>
+
+//===---------------------------------------------------------------------===//
+// Exposed C API.
+//===---------------------------------------------------------------------===//
+extern "C" RUNTIME_UTILS_EXPORT int64_t oneWay();
+extern "C" RUNTIME_UTILS_EXPORT void otherWay(int64_t);
+
+#endif // ITERATORS_UTILS_RUNTIMEUTILS_H

--- a/experimental/iterators/lib/CMakeLists.txt
+++ b/experimental/iterators/lib/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Utils)

--- a/experimental/iterators/lib/Utils/CMakeLists.txt
+++ b/experimental/iterators/lib/Utils/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(runtime_utils
+  SHARED
+  RuntimeUtils.cpp
+)
+set_property(TARGET runtime_utils PROPERTY CXX_STANDARD 11)
+target_compile_definitions(runtime_utils PRIVATE runtime_utils_EXPORTS)

--- a/experimental/iterators/lib/Utils/RuntimeUtils.cpp
+++ b/experimental/iterators/lib/Utils/RuntimeUtils.cpp
@@ -1,0 +1,18 @@
+//===- RuntimeUtils.cpp - Utils for MLIR / C++ interop -------------------===//
+
+#include "iterators/Utils/RuntimeUtils.h"
+
+#include <cstdio>
+
+//===---------------------------------------------------------------------===//
+// Exposed C API.
+//===---------------------------------------------------------------------===//
+extern "C" int64_t oneWay() {
+  void *p = reinterpret_cast<void *>(0xDEADBEEF);
+  fprintf(stdout, "Create a dummy pointer %p\n", p);
+  return reinterpret_cast<int64_t>(p);
+}
+
+extern "C" void otherWay(int64_t p) {
+  fprintf(stdout, "Use a dummy pointer %p\n", p);
+}

--- a/experimental/iterators/test/simple.mlir
+++ b/experimental/iterators/test/simple.mlir
@@ -1,0 +1,17 @@
+// TODO: this currently does not propertly connect to an actual execution
+
+// R-UN: mlir-opt %s -convert-std-to-llvm -reconcile-unrealized-casts | \
+// R-UN: mlir-cpu-runner -e main -entry-point-result=void \
+// R-UN:   -shared-libs=$(pwd)/lib/Utils/libruntime_utils.so \
+// R-UN: | FileCheck %s
+
+func private @oneWay() -> (i64)
+func private @otherWay(i64)
+
+func @main() {
+  // CHECK: Create a dummy pointer 0xdeadbee
+  %p = call @oneWay() : () -> (i64)
+  // CHECK: Use a dummy pointer 0xdeadbee
+  call @otherWay(%p) : (i64) -> ()
+  return
+}


### PR DESCRIPTION
Assuming mlir-opt and mlir-cpu-runner are built and in the path.

```
~/github/iree-llvm-sandbox/iterators_build$ >

mlir-opt ../experimental/iterators/test/simple.mlir -convert-std-to-llvm | mlir-cpu-runner -e main -entry-point-result=void -shared-libs=$(pwd)/lib/Utils/libruntime_utils.so
```

Prints:
```
Create a dummy pointer 0xdeadbeef
Use a dummy pointer 0xdeadbeef
```