### PR TITLE
Add generalize and interchange ops.

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -136,6 +136,40 @@ def TileOp : Linalg_Transform_Operation<"tile",
   }];
 }
 
+def GeneralizeOp : Linalg_Transform_Operation<"generalize",
+    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+  let description = [{Indicates that ops of a specific kind in the given
+  function should be transformed to generic operations.}];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::linalg::LinalgOp> applyToOne(
+        ::mlir::linalg::LinalgOp target);
+  }];
+}
+
+def InterchangeOp : Linalg_Transform_Operation<"interchange",
+    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+  let description = [{Indicates that ops of a specific kind in the given
+  function should be interchanged with the options provided as attributes.}];
+
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$iterator_interchange);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::linalg::LinalgOp> applyToOne(
+        ::mlir::linalg::LinalgOp target);
+  }];
+}
+
 def BufferizeOp : Transform_Op<"bufferize"> {
   let description = [{Indicates that the entire module should be bufferized.}];
   let assemblyFormat = "attr-dict";
@@ -210,7 +244,7 @@ def UnrollLoopOp : Linalg_Transform_Operation<"unroll_loop", [
 
   let arguments = (ins PDL_Operation:$target,
                    Confined<I64Attr, [IntPositive]>:$factor);
-  
+
   let assemblyFormat = "$target attr-dict";
 
   let extraClassDeclaration = [{

--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -138,8 +138,7 @@ def TileOp : Linalg_Transform_Operation<"tile",
 
 def GeneralizeOp : Linalg_Transform_Operation<"generalize",
     [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
-  let description = [{Indicates that ops of a specific kind in the given
-  function should be transformed to generic operations.}];
+  let description = [{Generalizes the op pointed to by the target handle.}];
 
   let arguments = (ins PDL_Operation:$target);
   let results = (outs PDL_Operation:$transformed);
@@ -154,8 +153,8 @@ def GeneralizeOp : Linalg_Transform_Operation<"generalize",
 
 def InterchangeOp : Linalg_Transform_Operation<"interchange",
     [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
-  let description = [{Indicates that ops of a specific kind in the given
-  function should be interchanged with the options provided as attributes.}];
+  let description = [{Interchanges the iterators of the op pointed to by the
+  target handle using the iterator interchange attribute.}];
 
   let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$iterator_interchange);

--- a/python/examples/core/transforms.py
+++ b/python/examples/core/transforms.py
@@ -390,6 +390,8 @@ class Generalize(Transform):
   }
 
   def __init__(self, fun_name: str, op_name: str, **kwargs):
+    self.fun_name = fun_name
+    self.op_name = op_name
     self._parse_variables_in_kwargs(kwargs)
     interchange_str = _get_size_list_as_str(name='iterator-interchange',
                                             sizes=self.iterator_interchange)
@@ -399,6 +401,11 @@ class Generalize(Transform):
                 f'     anchor-op={op_name} '
                 f'     generalize}}')
     self.pipeline = (f'builtin.func({pipeline})')
+
+  def build_transform_ir(self):
+    target = tx.MatchOp(emit_pattern_if_not_present(self.fun_name,
+                                                    self.op_name))
+    tx.GeneralizeOp(target)
 
 
 class Interchange(Transform):
@@ -415,6 +422,7 @@ class Interchange(Transform):
   }
 
   def __init__(self, fun_name: str, **kwargs):
+    self.fun_name = fun_name
     self._parse_variables_in_kwargs(kwargs)
     interchange_str = _get_size_list_as_str(name='iterator-interchange',
                                             sizes=self.iterator_interchange)
@@ -424,6 +432,10 @@ class Interchange(Transform):
                 f'     anchor-op="linalg.generic" '
                 f'     {interchange_str}}}')
     self.pipeline = (f'builtin.func({pipeline})')
+
+  def build_transform_ir(self):
+    target = tx.MatchOp(emit_pattern_if_not_present(self.fun_name, 'generic'))
+    tx.InterchangeOp(target, iterator_interchange=self.iterator_interchange)
 
 
 class DecomposeToLowerDimensionalNamedOp(Transform):

--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -151,6 +151,43 @@ class TileOp:
         ip=ip)
 
 
+class GeneralizeOp:
+  """Specialization for the GeneralizeOp class."""
+
+  def __init__(self,
+               target: Union[ir.Value, ir.Operation, ir.OpView],
+               *,
+               loc=None,
+               ip=None):
+    operation_type = pdl.OperationType.get()
+
+    super().__init__(
+        operation_type,
+        target,
+        loc=loc,
+        ip=ip)
+
+
+class InterchangeOp:
+  """Specialization for the InterchangeOp class."""
+
+  def __init__(self,
+               target: Union[ir.Value, ir.Operation, ir.OpView],
+               *,
+               iterator_interchange: IntListArg = None,
+               loc=None,
+               ip=None):
+    iterator_interchange = _ensure_array_attr(iterator_interchange, [])
+    operation_type = pdl.OperationType.get()
+
+    super().__init__(
+        operation_type,
+        target,
+        iterator_interchange,
+        loc=loc,
+        ip=ip)
+
+
 class VectorizeOp:
 
   def __init__(self,

--- a/test/LinalgTransform/generalize.mlir
+++ b/test/LinalgTransform/generalize.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-proto-opt -linalg-interp-transforms %s | FileCheck %s
+
+
+// CHECK-LABEL: func @generalize_unary
+func @generalize_unary(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+
+  // CHECK-NOT:   linalg.elemwise_unary
+  //     CHECK:   linalg.generic
+  %0 = linalg.elemwise_unary ins(%arg0 : tensor<?x?xf32>)
+                             outs(%arg1: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+
+pdl.pattern @pdl_target : benefit(1) {
+  %args = operands
+  %results = types
+  %0 = pdl.operation "linalg.elemwise_unary"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  apply_native_constraint "nestedInFunc"[@generalize_unary](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  rewrite %0 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  %0 = match @pdl_target
+  generalize %0
+}

--- a/test/LinalgTransform/interchange.mlir
+++ b/test/LinalgTransform/interchange.mlir
@@ -1,0 +1,34 @@
+// RUN: mlir-proto-opt -linalg-interp-transforms %s | FileCheck %s
+
+//       CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d1, d0)>
+
+// CHECK-LABEL: func @interchange_generic
+func @interchange_generic(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+
+  //      CHECK:   linalg.generic
+  // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP]]
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%arg0 : tensor<?x?xf32>) outs(%arg1 : tensor<?x?xf32>) {
+  ^bb0(%arg2: f32, %arg3: f32):
+    %1 = math.exp %arg2 : f32
+    linalg.yield %1 : f32
+  } -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+
+pdl.pattern @pdl_target : benefit(1) {
+  %args = operands
+  %results = types
+  %0 = pdl.operation "linalg.generic"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  apply_native_constraint "nestedInFunc"[@interchange_generic](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  rewrite %0 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  %0 = match @pdl_target
+  interchange %0 {iterator_interchange = [1, 0]}
+}

--- a/test/LinalgTransform/invalid.mlir
+++ b/test/LinalgTransform/invalid.mlir
@@ -25,3 +25,11 @@ linalg_transform.sequence {
   // expected-error@below {{"sizes" and "scalarize_dyn_dims" attributes are mutually exclusive}}
   tile %0 {sizes = [1,2,3], scalarize_dyn_dims = true}
 }
+
+// -----
+
+linalg_transform.sequence {
+  %0 = match @match
+  // expected-error@below {{expects iterator_interchange to be a permutation, found [1, 1]}}
+  interchange %0 {iterator_interchange = [1, 1]}
+}


### PR DESCRIPTION
The revision adds:
- an generalization and an interchange op to the transform dialect
- adds tests for the two operations
- adds the transform IR builders

I added two operations to match the existing experts. Long term we may want to have a generalize op only that takes an optional interchange parameter. I am happy to update the revision if you also think this is preferable.