### PR TITLE
Add an initial FuseOp to control fusion.

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -136,9 +136,30 @@ def TileOp : Linalg_Transform_Operation<"tile",
   }];
 }
 
+def TileAndFuseOp : Linalg_Transform_Operation<"tile_and_fuse",
+    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+  let description = [{Tiles the operations pointed to by the target handle and
+  fuses their producers greedily using the options provided as attributes.}];
+
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_sizes,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_interchange
+                  );
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::linalg::LinalgOp> applyToOne(
+        ::mlir::linalg::LinalgOp target);
+  }];
+}
+
 def GeneralizeOp : Linalg_Transform_Operation<"generalize",
     [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
-  let description = [{Generalizes the op pointed to by the target handle.}];
+  let description = [{Generalizes the operations pointed to
+  by the target handle.}];
 
   let arguments = (ins PDL_Operation:$target);
   let results = (outs PDL_Operation:$transformed);
@@ -153,8 +174,8 @@ def GeneralizeOp : Linalg_Transform_Operation<"generalize",
 
 def InterchangeOp : Linalg_Transform_Operation<"interchange",
     [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
-  let description = [{Interchanges the iterators of the op pointed to by the
-  target handle using the iterator interchange attribute.}];
+  let description = [{Interchanges the iterators of the operations pointed to
+  by the target handle using the iterator interchange attribute.}];
 
   let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$iterator_interchange);

--- a/test/LinalgTransform/fuse.mlir
+++ b/test/LinalgTransform/fuse.mlir
@@ -1,0 +1,31 @@
+// RUN: mlir-proto-opt -linalg-interp-transforms %s | FileCheck %s
+
+
+// CHECK-LABEL: func @fuse_unary
+func @fuse_unary(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+
+  //     CHECK:   scf.for
+  //     CHECK:     scf.for
+  //     CHECK:       linalg.elemwise_unary
+  //     CHECK:       linalg.elemwise_binary
+  %0 = linalg.elemwise_unary ins(%arg0 : tensor<?x?xf32>)
+                             outs(%arg1: tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = linalg.elemwise_binary ins(%0, %arg0 : tensor<?x?xf32>, tensor<?x?xf32>)
+                             outs(%arg1: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+
+
+pdl.pattern @pdl_target : benefit(1) {
+  %args = operands
+  %results = types
+  %0 = pdl.operation "linalg.elemwise_binary"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  apply_native_constraint "nestedInFunc"[@fuse_unary](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  rewrite %0 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  %0 = match @pdl_target
+  %1 = tile_and_fuse %0 {tile_sizes = [32, 32], tile_interchange = [0, 1]}
+}

--- a/test/LinalgTransform/invalid.mlir
+++ b/test/LinalgTransform/invalid.mlir
@@ -33,3 +33,11 @@ linalg_transform.sequence {
   // expected-error@below {{expects iterator_interchange to be a permutation, found [1, 1]}}
   interchange %0 {iterator_interchange = [1, 1]}
 }
+
+// -----
+
+linalg_transform.sequence {
+  %0 = match @match
+  // expected-error@below {{expects interchange to be a permutation, found [1, 1]}}
+  tile_and_fuse %0 {tile_sizes=[0, 1], tile_interchange = [1, 1]}
+}


### PR DESCRIPTION
Add a fuseOp to control fusion / tiling and fusion. The operation only supports tile and fuse with loop interchange. Padding is currently not supported and planed as a separate operation that works on all operation. In the future, we probably want the fuseOp to return the tiled root operation and all fused producers. This is left for future revisions.