### PR TITLE
Pad and hoist

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -190,6 +190,29 @@ def InterchangeOp : Linalg_Transform_Operation<"interchange",
   }];
 }
 
+def PadOp : Linalg_Transform_Operation<"pad",
+    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+  let description = [{Pads the operations pointed to by the target handle
+  using the options provides as operation attributes.}];
+
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$pack_paddings,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$hoist_paddings,
+                   DefaultValuedAttr<
+                      TypedArrayAttrBase<I64ArrayAttr,
+                                         "array of arrays of i64">,
+                      "{}">:$transpose_paddings);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::linalg::LinalgOp> applyToOne(
+        ::mlir::linalg::LinalgOp target);
+  }];
+}
+
 def BufferizeOp : Transform_Op<"bufferize"> {
   let description = [{Indicates that the entire module should be bufferized.}];
   let assemblyFormat = "attr-dict";

--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -136,9 +136,30 @@ def TileOp : Linalg_Transform_Operation<"tile",
   }];
 }
 
+def TileAndFuseOp : Linalg_Transform_Operation<"tile_and_fuse",
+    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+  let description = [{Tiles the operations pointed to by the target handle and
+  fuses their producers greedily using the options provided as attributes.}];
+
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_sizes,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$tile_interchange
+                  );
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::linalg::LinalgOp> applyToOne(
+        ::mlir::linalg::LinalgOp target);
+  }];
+}
+
 def GeneralizeOp : Linalg_Transform_Operation<"generalize",
     [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
-  let description = [{Generalizes the op pointed to by the target handle.}];
+  let description = [{Generalizes the operations pointed to
+  by the target handle.}];
 
   let arguments = (ins PDL_Operation:$target);
   let results = (outs PDL_Operation:$transformed);
@@ -153,8 +174,8 @@ def GeneralizeOp : Linalg_Transform_Operation<"generalize",
 
 def InterchangeOp : Linalg_Transform_Operation<"interchange",
     [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
-  let description = [{Interchanges the iterators of the op pointed to by the
-  target handle using the iterator interchange attribute.}];
+  let description = [{Interchanges the iterators of the operations pointed to
+  by the target handle using the iterator interchange attribute.}];
 
   let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$iterator_interchange);

--- a/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -355,6 +355,71 @@ LogicalResult transform::InterchangeOp::verify() {
 }
 
 //===---------------------------------------------------------------------===//
+// PadOp
+//===---------------------------------------------------------------------===//
+
+FailureOr<LinalgOp> transform::PadOp::applyToOne(LinalgOp target) {
+  // Copy the stack allocated options since the lambdas have a longer lifetime.
+  SmallVector<int64_t> packPaddings = extractI64Array(this->pack_paddings());
+  auto packFunc = [=](OpOperand &opOperand) {
+    return opOperand.getOperandNumber() < packPaddings.size()
+               ? packPaddings[opOperand.getOperandNumber()] != 0
+               : false;
+  };
+  SmallVector<int64_t> hoistPaddings = extractI64Array(this->hoist_paddings());
+  auto hoistingFunc = [=](OpOperand &opOperand) {
+    return opOperand.getOperandNumber() < hoistPaddings.size()
+               ? hoistPaddings[opOperand.getOperandNumber()]
+               : 0;
+  };
+  ArrayAttr transposePaddings = this->transpose_paddings().cast<ArrayAttr>();
+  auto transposeFunc = [=](OpOperand &opOperand) {
+    if (opOperand.getOperandNumber() >= transposePaddings.size())
+      return SmallVector<int64_t>();
+    return extractI64Array(
+        transposePaddings[opOperand.getOperandNumber()].cast<ArrayAttr>());
+  };
+  LinalgPaddingOptions paddingOptions;
+  paddingOptions.setPaddingValueComputationFunction(getNeutralOfLinalgOp);
+  paddingOptions.setPaddingNoFoldComputationFunction(packFunc);
+  paddingOptions.setPaddingHoistComputationFunction(hoistingFunc);
+  paddingOptions.setPaddingTransposeComputationFunction(transposeFunc);
+
+  return functional::applyAt(target, callLinalgPattern<LinalgPaddingPattern>(
+                                         getContext(), paddingOptions));
+}
+
+LogicalResult transform::PadOp::verify() {
+  SmallVector<int64_t> packPaddings = extractI64Array(pack_paddings());
+  if (any_of(packPaddings, [](int64_t packPadding) {
+        return packPadding != 0 && packPadding != 1;
+      })) {
+    return emitOpError()
+           << "expects pack_paddings to contain booleans (0/1), found "
+           << pack_paddings();
+  }
+  SmallVector<int64_t> hoistPaddings = extractI64Array(hoist_paddings());
+  if (any_of(hoistPaddings,
+             [](int64_t hoistPadding) { return hoistPadding < 0; })) {
+    return emitOpError()
+           << "expects hoist_paddings to contain positive integers, found "
+           << hoist_paddings();
+  }
+  ArrayAttr transposes = transpose_paddings();
+  for (Attribute attr : transposes) {
+    SmallVector<int64_t> transpose = extractFromI64ArrayAttr(attr);
+    auto sequence = llvm::seq<int64_t>(0, transpose.size());
+    if (!std::is_permutation(sequence.begin(), sequence.end(),
+                             transpose.begin(), transpose.end())) {
+      return emitOpError()
+             << "expects transpose_paddings to be a permutation, found "
+             << attr;
+    }
+  }
+  return success();
+}
+
+//===---------------------------------------------------------------------===//
 // DecomposeOp
 //===---------------------------------------------------------------------===//
 

--- a/test/LinalgTransform/fuse.mlir
+++ b/test/LinalgTransform/fuse.mlir
@@ -1,0 +1,31 @@
+// RUN: mlir-proto-opt -linalg-interp-transforms %s | FileCheck %s
+
+
+// CHECK-LABEL: func @fuse_unary
+func @fuse_unary(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+
+  //     CHECK:   scf.for
+  //     CHECK:     scf.for
+  //     CHECK:       linalg.elemwise_unary
+  //     CHECK:       linalg.elemwise_binary
+  %0 = linalg.elemwise_unary ins(%arg0 : tensor<?x?xf32>)
+                             outs(%arg1: tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = linalg.elemwise_binary ins(%0, %arg0 : tensor<?x?xf32>, tensor<?x?xf32>)
+                             outs(%arg1: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+
+
+pdl.pattern @pdl_target : benefit(1) {
+  %args = operands
+  %results = types
+  %0 = pdl.operation "linalg.elemwise_binary"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  apply_native_constraint "nestedInFunc"[@fuse_unary](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  rewrite %0 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  %0 = match @pdl_target
+  %1 = tile_and_fuse %0 {tile_sizes = [32, 32], tile_interchange = [0, 1]}
+}

--- a/test/LinalgTransform/invalid.mlir
+++ b/test/LinalgTransform/invalid.mlir
@@ -41,3 +41,27 @@ linalg_transform.sequence {
   // expected-error@below {{expects interchange to be a permutation, found [1, 1]}}
   tile_and_fuse %0 {tile_sizes=[0, 1], tile_interchange = [1, 1]}
 }
+
+// -----
+
+linalg_transform.sequence {
+  %0 = match @match
+  // expected-error@below {{expects pack_paddings to contain booleans (0/1), found [1, 7]}}
+  pad %0 {pack_paddings=[1, 7]}
+}
+
+// -----
+
+linalg_transform.sequence {
+  %0 = match @match
+  // expected-error@below {{expects hoist_paddings to contain positive integers, found [1, -7]}}
+  pad %0 {hoist_paddings=[1, -7]}
+}
+
+// -----
+
+linalg_transform.sequence {
+  %0 = match @match
+  // expected-error@below {{expects transpose_paddings to be a permutation, found [1, 1]}}
+  pad %0 {transpose_paddings=[[1, 1]]}
+}

--- a/test/LinalgTransform/invalid.mlir
+++ b/test/LinalgTransform/invalid.mlir
@@ -33,3 +33,11 @@ linalg_transform.sequence {
   // expected-error@below {{expects iterator_interchange to be a permutation, found [1, 1]}}
   interchange %0 {iterator_interchange = [1, 1]}
 }
+
+// -----
+
+linalg_transform.sequence {
+  %0 = match @match
+  // expected-error@below {{expects interchange to be a permutation, found [1, 1]}}
+  tile_and_fuse %0 {tile_sizes=[0, 1], tile_interchange = [1, 1]}
+}

--- a/test/LinalgTransform/pad.mlir
+++ b/test/LinalgTransform/pad.mlir
@@ -1,0 +1,42 @@
+// RUN: mlir-proto-opt -linalg-interp-transforms %s | FileCheck %s
+
+
+// CHECK-LABEL: func @pad_unary
+func @pad_unary(%arg0: tensor<24x12xf32>,
+                %arg1: tensor<24x12xf32>) -> tensor<24x12xf32> {
+  %c0 = arith.constant 0 : index
+  %c12 = arith.constant 12 : index
+  %c4 = arith.constant 4 : index
+
+  //     CHECK:   scf.for
+  //     CHECK:     tensor.pad
+  //     CHECK:     linalg.generic
+  //     CHECK:   scf.for
+  %0 = scf.for %arg3 = %c0 to %c12 step %c4 iter_args(%arg2 = %arg1) -> (tensor<24x12xf32>) {
+    %1 = tensor.extract_slice %arg0[0, %arg3] [24, 4] [1, 1] : tensor<24x12xf32> to tensor<24x4xf32>
+    %2 = tensor.extract_slice %arg2[0, %arg3] [24, 4] [1, 1] : tensor<24x12xf32> to tensor<24x4xf32>
+
+    //     CHECK:     linalg.generic
+    //     CHECK:     tensor.pad
+    //     CHECK:     linalg.elemwise_unary
+    %3 = linalg.elemwise_unary ins(%1 : tensor<24x4xf32>)
+                              outs(%2: tensor<24x4xf32>) -> tensor<24x4xf32>
+    %4 = tensor.insert_slice %3 into %arg2[0, %arg3] [24, 4] [1, 1] : tensor<24x4xf32> into tensor<24x12xf32>
+    scf.yield %4 : tensor<24x12xf32>
+  }
+  return %0 : tensor<24x12xf32>
+}
+
+pdl.pattern @pdl_target : benefit(1) {
+  %args = operands
+  %results = types
+  %0 = pdl.operation "linalg.elemwise_unary"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  apply_native_constraint "nestedInFunc"[@pad_unary](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  rewrite %0 with "linalg_transform.apply"
+}
+
+linalg_transform.sequence {
+  %0 = match @pdl_target
+  %1 = pad %0 {pack_paddings=[1, 1], hoist_paddings=[1, 0], transpose_paddings=[[1, 0], [0, 1]]}
+}


### PR DESCRIPTION
Add a padOp to control padding and hoisting. The operation takes target since one needs to control the pattern applies only once to avoid endless hoist padding chains.