### PR TITLE
Iterators: Fix some issues found by clang warnings

### DIFF
--- a/experimental/iterators/include/iterators/Operators/ColumnScanOperator.h
+++ b/experimental/iterators/include/iterators/Operators/ColumnScanOperator.h
@@ -62,7 +62,7 @@ private:
   std::tuple<std::vector<InputTypes>...> inputs;
   /// Position of the tuple values that are returned in the next call to
   /// `computeNext`.
-  int64_t currentPos;
+  size_t currentPos;
 };
 
 /// Creates a new `ColumnScanOperator` deriving its template parameters from

--- a/experimental/iterators/include/iterators/Utils/Tuple.h
+++ b/experimental/iterators/include/iterators/Utils/Tuple.h
@@ -57,7 +57,6 @@ std::size_t hashTuple(const TupleType &tuple,
 /// `std::hash` of the individual fields using XOR.
 template <typename... Types>
 std::size_t hashTuple(const std::tuple<Types...> &tuple) {
-  using TupleType = std::tuple<Types...>;
   using IndexSequence = std::index_sequence_for<Types...>;
   return impl::hashTuple(tuple, IndexSequence{});
 }

--- a/experimental/iterators/unittests/ReduceByKeyOperatorTest.cpp
+++ b/experimental/iterators/unittests/ReduceByKeyOperatorTest.cpp
@@ -19,7 +19,7 @@ TEST(ReduceByKeyTest, SingleColumnKey) {
   reduceByKey.open();
   std::map<int32_t, int32_t> result;
   while (const auto tuple = reduceByKey.computeNext()) {
-    EXPECT_EQ(result.count(std::get<0>(tuple.value())), 0);
+    EXPECT_EQ(result.count(std::get<0>(tuple.value())), 0U);
     result.emplace(std::get<0>(tuple.value()), std::get<1>(tuple.value()));
   }
 
@@ -50,7 +50,7 @@ TEST(ReduceByKeyTest, TwoColumnKey) {
   while (const auto tuple = reduceByKey.computeNext()) {
     auto const key = takeFront<2>(tuple.value());
     auto const value = dropFront<2>(tuple.value());
-    EXPECT_EQ(result.count(key), 0);
+    EXPECT_EQ(result.count(key), 0U);
     result.emplace(key, value);
   }
 


### PR DESCRIPTION
These surfaced after compiling as part of the top-level project (cf #316).

I am not too sure what the best practices are for signed/unsigned comparisons. Input welcome!