### PR TITLE
Add missing options to LLVMLoweringOp and properly use for row_reduct…

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -258,6 +258,15 @@ def LowerToLLVMOp : Transform_Op<"lower_to_llvm"> {
   let description = [{Indicates that the entire module should be converted
   to the LLVM dialect. This is expected to be the last transformation in
   a sequence.}];
+  
+  let arguments =
+    (ins DefaultValuedAttr<BoolAttr, "false">:$reassociate_fp_reductions,
+     DefaultValuedAttr<BoolAttr, "false">:$enable_index_optimizations,
+     DefaultValuedAttr<BoolAttr, "false">:$enable_arm_neon,
+     DefaultValuedAttr<BoolAttr, "false">:$enable_arm_sve,
+     DefaultValuedAttr<BoolAttr, "false">:$enable_amx,
+     DefaultValuedAttr<BoolAttr, "false">:$enable_x86vector
+    );
 
   let assemblyFormat = "attr-dict";
 }

--- a/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -683,12 +683,12 @@ transform::LowerToLLVMOp::apply(transform::TransformResults &result,
   pm.addPass(createConvertVectorToLLVMPass(
       // clang-format off
       LowerVectorToLLVMOptions()
-        .enableReassociateFPReductions(false)
-        .enableIndexOptimizations(false)
-        .enableArmNeon(false)
-        .enableArmSVE(false)
-        .enableAMX(false)
-        .enableX86Vector(false)));
+        .enableReassociateFPReductions(reassociate_fp_reductions())
+        .enableIndexOptimizations(enable_index_optimizations())
+        .enableArmNeon(enable_arm_neon())
+        .enableArmSVE(enable_arm_sve())
+        .enableAMX(enable_amx())
+        .enableX86Vector(enable_x86vector())));
   // clang-format on
   pm.addNestedPass<FuncOp>(createConvertMathToLLVMPass());
   pm.addPass(createMemRefToLLVMPass());

--- a/python/examples/core/transforms.py
+++ b/python/examples/core/transforms.py
@@ -340,11 +340,25 @@ class LowerToLLVM(Transform):
   """Trigger lowering to LLVM on the whole module.
   """
 
+  variables = {
+      'reassociate_fp_reductions': (BoolVariable, False),
+      'enable_index_optimizations': (BoolVariable, False),
+      'enable_arm_neon': (BoolVariable, False),
+      'enable_arm_sve': (BoolVariable, False),
+      'enable_amx': (BoolVariable, False),
+      'enable_x86vector': (BoolVariable, False),
+  }
+
   def __init__(self, **kwargs):
-    pass
+    self._parse_variables_in_kwargs(kwargs)
 
   def build_transform_ir(self):
-    tx.LowerToLLVMOp()
+    tx.LowerToLLVMOp(reassociate_fp_reductions=self.reassociate_fp_reductions,
+                     enable_index_optimizations=self.enable_index_optimizations,
+                     enable_arm_neon=self.enable_arm_neon,
+                     enable_arm_sve=self.enable_arm_sve,
+                     enable_amx=self.enable_amx,
+                     enable_x86vector=self.enable_x86vector)
 
 
 class UnrollOneParentLoop(Transform):

--- a/python/examples/reduction/reduction_1d_bench.py
+++ b/python/examples/reduction/reduction_1d_bench.py
@@ -34,8 +34,9 @@ def all_experts(problem_sizes: List[int]):
            peel=[0])
       .then(Vectorize(fun_name, ''))
       .then(LoweringOnlyExpert(fun_name,
-                                op_name,
-                                multi_reduction_lowering='innerreduction')),
+                               op_name,
+                               multi_reduction_lowering='innerreduction',
+                               reassociate_fp_reductions=True)),
     ]
   ]
 

--- a/python/examples/reduction/row_reduction_2d_bench.py
+++ b/python/examples/reduction/row_reduction_2d_bench.py
@@ -49,7 +49,8 @@ def all_experts(problem_sizes: List[int]):
         .then(Vectorize(fun_name, ''))
         .then(LoweringOnlyExpert(fun_name,
                                  op_name,
-                                 multi_reduction_lowering='innerreduction')),
+                                 multi_reduction_lowering='innerreduction',
+                                 reassociate_fp_reductions=True)),
     )
   return [e.print_ir(after_all=False, at_begin=False, llvm=False) for e in res]
 

--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -12,7 +12,8 @@ except ImportError as e:
 BoolArg = Optional[Union[bool, ir.BoolAttr]]
 IntArg = Optional[Union[int, ir.IntegerAttr]]
 IntListArg = Optional[Union[Sequence[int], ir.ArrayAttr]]
-IntListListArg = Optional[Union[Sequence[Union[Sequence[int], ir.ArrayAttr]], ir.ArrayAttr]]
+IntListListArg = Optional[Union[Sequence[Union[Sequence[int], ir.ArrayAttr]],
+                                ir.ArrayAttr]]
 StringArg = Optional[Union[str, ir.StringAttr]]
 
 
@@ -107,6 +108,29 @@ class LowerVectorsOp:
                      ip=ip)
 
 
+class LowerToLLVMOp:
+  """Specialization for the LowerToLLVMOp class."""
+
+  def __init__(self,
+               *,
+               reassociate_fp_reductions: BoolArg = None,
+               enable_index_optimizations: BoolArg = None,
+               enable_arm_neon: BoolArg = None,
+               enable_arm_sve: BoolArg = None,
+               enable_amx: BoolArg = None,
+               enable_x86vector: BoolArg = None,
+               loc=None,
+               ip=None):
+    super().__init__(_ensure_bool_attr(reassociate_fp_reductions, False),
+                     _ensure_bool_attr(enable_index_optimizations, False),
+                     _ensure_bool_attr(enable_arm_neon, False),
+                     _ensure_bool_attr(enable_arm_sve, False),
+                     _ensure_bool_attr(enable_amx, False),
+                     _ensure_bool_attr(enable_x86vector, False),
+                     loc=loc,
+                     ip=ip)
+
+
 class FuseOp:
   """Specialization for the FuseOp class."""
 
@@ -121,13 +145,12 @@ class FuseOp:
     tile_interchange = _ensure_array_attr(tile_interchange, [])
     operation_type = pdl.OperationType.get()
 
-    super().__init__(
-        operation_type,
-        target,
-        tile_sizes,
-        tile_interchange,
-        loc=loc,
-        ip=ip)
+    super().__init__(operation_type,
+                     target,
+                     tile_sizes,
+                     tile_interchange,
+                     loc=loc,
+                     ip=ip)
 
 
 class TileOp:
@@ -158,20 +181,19 @@ class TileOp:
     generalize = _ensure_bool_attr(generalize, False)
     operation_type = pdl.OperationType.get()
 
-    super().__init__(
-        operation_type,
-        target,
-        sizes,
-        interchange,
-        peel,
-        pad,
-        pack_paddings,
-        hoist_paddings,
-        transpose_paddings,
-        scalarize_dyn_dims,
-        generalize,
-        loc=loc,
-        ip=ip)
+    super().__init__(operation_type,
+                     target,
+                     sizes,
+                     interchange,
+                     peel,
+                     pad,
+                     pack_paddings,
+                     hoist_paddings,
+                     transpose_paddings,
+                     scalarize_dyn_dims,
+                     generalize,
+                     loc=loc,
+                     ip=ip)
 
 
 class PadOp:
@@ -190,14 +212,13 @@ class PadOp:
     transpose_paddings = _ensure_array_of_array_attr(transpose_paddings, [])
     operation_type = pdl.OperationType.get()
 
-    super().__init__(
-        operation_type,
-        target,
-        pack_paddings,
-        hoist_paddings,
-        transpose_paddings,
-        loc=loc,
-        ip=ip)
+    super().__init__(operation_type,
+                     target,
+                     pack_paddings,
+                     hoist_paddings,
+                     transpose_paddings,
+                     loc=loc,
+                     ip=ip)
 
 
 class GeneralizeOp:
@@ -210,11 +231,7 @@ class GeneralizeOp:
                ip=None):
     operation_type = pdl.OperationType.get()
 
-    super().__init__(
-        operation_type,
-        target,
-        loc=loc,
-        ip=ip)
+    super().__init__(operation_type, target, loc=loc, ip=ip)
 
 
 class InterchangeOp:
@@ -229,30 +246,29 @@ class InterchangeOp:
     iterator_interchange = _ensure_array_attr(iterator_interchange, [])
     operation_type = pdl.OperationType.get()
 
-    super().__init__(
-        operation_type,
-        target,
-        iterator_interchange,
-        loc=loc,
-        ip=ip)
+    super().__init__(operation_type,
+                     target,
+                     iterator_interchange,
+                     loc=loc,
+                     ip=ip)
 
 
 class VectorizeOp:
 
   def __init__(self,
-               target: Optional[Union[ir.Value, ir.Operation, ir.OpView]] = None,
+               target: Optional[Union[ir.Value, ir.Operation,
+                                      ir.OpView]] = None,
                *,
                vectorize_padding: BoolArg = None,
                loc=None,
                ip=None):
     operation_type = pdl.OperationType.get()
 
-    super().__init__(
-        operation_type if target is not None else None,
-        target,
-        _ensure_bool_attr(vectorize_padding, False),
-        loc=loc,
-        ip=ip)
+    super().__init__(operation_type if target is not None else None,
+                     target,
+                     _ensure_bool_attr(vectorize_padding, False),
+                     loc=loc,
+                     ip=ip)
 
 
 class GetParentLoopOp:
@@ -293,7 +309,12 @@ class PipelineLoopOp:
     iteration_interval = _ensure_int_attr(iteration_interval, 1)
     read_latency = _ensure_int_attr(read_latency, 10)
     operation_type = pdl.OperationType.get()
-    super().__init__(operation_type, target, iteration_interval, read_latency, loc=loc, ip=ip)
+    super().__init__(operation_type,
+                     target,
+                     iteration_interval,
+                     read_latency,
+                     loc=loc,
+                     ip=ip)
 
 
 class OutlineLoopOp:


### PR DESCRIPTION
…ion bench.

The lack of reassociate_fp_reductions when lowering resulted in large slowdowns.