### PR TITLE
Add a pass to drop the schedule from C++

### DIFF
--- a/include/Dialects/LinalgTransform/Passes.h
+++ b/include/Dialects/LinalgTransform/Passes.h
@@ -4,6 +4,7 @@ namespace transform {
 
 void registerLinalgTransformInterpreterPass();
 void registerLinalgTransformExpertExpansionPass();
+void registerDropScheduleFromModulePass();
 
 } // namespace transform
 } // namespace linalg
@@ -12,4 +13,5 @@ void registerLinalgTransformExpertExpansionPass();
 namespace mlir {
 class Pass;
 std::unique_ptr<Pass> createLinalgTransformInterpreterPass();
+std::unique_ptr<Pass> createDropScheduleFromModulePass();
 } // namespace mlir

--- a/lib/Registration.cpp
+++ b/lib/Registration.cpp
@@ -91,6 +91,7 @@ void mlir::registerOutsideOfDialectRegistry() {
   registerExperimentalPasses();
   registerTestPasses();
   transform::registerLinalgTransformInterpreterPass();
+  transform::registerDropScheduleFromModulePass();
   transform::registerLinalgTransformExpertExpansionPass();
 }
 

--- a/python/examples/core/transforms.py
+++ b/python/examples/core/transforms.py
@@ -413,15 +413,8 @@ class ApplySchedule(Transform):
 
   def __call__(self, module: Module, **kwargs):
     PassManager.parse('linalg-interp-transforms').run(module)
-    self.drop_schedule_from_module(module)
+    PassManager.parse('linalg-drop-schedule-from-module').run(module)
     return module
-
-  def drop_schedule_from_module(self, module):
-    for op in module.body.operations:
-      op_name = op.operation.name
-      if op_name == 'pdl.pattern' or op_name == 'linalg_transform.sequence':
-        op.operation.erase()
-
 
 ###############################################################################
 # TODO: Port to the transform dialect

--- a/test/LinalgTransform/drop-schedule.mlir
+++ b/test/LinalgTransform/drop-schedule.mlir
@@ -1,0 +1,26 @@
+// RUN: mlir-proto-opt -linalg-drop-schedule-from-module %s | FileCheck %s
+
+func @matmul_tensors(
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true}) 
+    -> tensor<128x128xf32> {
+  %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
+                     outs(%arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+// CHECK-NOT: pdl.pattern
+pdl.pattern @pdl_target : benefit(1) {
+  %args = operands
+  %results = types
+  %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  rewrite %0 with "linalg_transform.apply"
+}
+
+// CHECK-NOT: linalg_transform.sequence
+linalg_transform.sequence {
+  %0 = match @pdl_target
+  tile %0 {sizes = [4, 4, 4], pad = false}
+}


### PR DESCRIPTION
The idea is to have a pass instead of the python method `drop_schedule_from_module`. This also exposes the functionality to C++ users.