### PR TITLE
Iterators: Use dedicated namespaces and other clean-ups.

### DIFF
--- a/experimental/iterators/examples/Main.cpp
+++ b/experimental/iterators/examples/Main.cpp
@@ -4,6 +4,9 @@
 #include "iterators/Operators/ColumnScanOperator.h"
 #include "iterators/Utils/Tuple.h"
 
+using namespace mlir::iterators::operators;
+using namespace mlir::iterators::utils;
+
 int main(int /*unused*/, char ** /*unused*/) {
   std::vector<int32_t> numbers = {1, 2, 3, 4};
   auto scan = makeColumnScanOperator(numbers, numbers, numbers);

--- a/experimental/iterators/include/iterators/Operators/ColumnScanOperator.h
+++ b/experimental/iterators/include/iterators/Operators/ColumnScanOperator.h
@@ -12,6 +12,8 @@
 #include <tuple>
 #include <vector>
 
+namespace mlir::iterators::operators {
+
 /// Co-iterates over a set of vectors representing the columns of a table.
 ///
 /// This operator takes as an input a set of vectors that represent the columns
@@ -71,5 +73,7 @@ template <typename... InputTypes>
 auto makeColumnScanOperator(std::vector<InputTypes>... inputs) {
   return ColumnScanOperator<InputTypes...>(inputs...);
 }
+
+} // namespace mlir::iterators::operators
 
 #endif // OPERATORS_COLUMN_SCAN_H

--- a/experimental/iterators/include/iterators/Operators/ColumnScanOperator.h
+++ b/experimental/iterators/include/iterators/Operators/ColumnScanOperator.h
@@ -5,8 +5,8 @@
 /// as related helpers.
 ///
 //===----------------------------------------------------------------------===//
-#ifndef OPERATORS_COLUMN_SCAN_H
-#define OPERATORS_COLUMN_SCAN_H
+#ifndef ITERATORS_OPERATORS_COLUMNSCANOPERATOR_H
+#define ITERATORS_OPERATORS_COLUMNSCANOPERATOR_H
 
 #include <optional>
 #include <tuple>
@@ -76,4 +76,4 @@ auto makeColumnScanOperator(std::vector<InputTypes>... inputs) {
 
 } // namespace mlir::iterators::operators
 
-#endif // OPERATORS_COLUMN_SCAN_H
+#endif // ITERATORS_OPERATORS_COLUMNSCANOPERATOR_H

--- a/experimental/iterators/include/iterators/Operators/ColumnScanOperator.h
+++ b/experimental/iterators/include/iterators/Operators/ColumnScanOperator.h
@@ -29,7 +29,7 @@ public:
   /// Copies the given vectors into its internal state. All provided vectors
   /// have to have the same length.
   explicit ColumnScanOperator(std::vector<InputTypes>... inputs)
-      : inputs(std::make_tuple(std::move(inputs)...)), currentPos(0) {}
+      : inputs(std::make_tuple(std::move(inputs)...)) {}
 
   /// Does nothing.
   void open() {}
@@ -64,7 +64,7 @@ private:
   std::tuple<std::vector<InputTypes>...> inputs;
   /// Position of the tuple values that are returned in the next call to
   /// `computeNext`.
-  size_t currentPos;
+  size_t currentPos{0};
 };
 
 /// Creates a new `ColumnScanOperator` deriving its template parameters from

--- a/experimental/iterators/include/iterators/Operators/FilterOperator.h
+++ b/experimental/iterators/include/iterators/Operators/FilterOperator.h
@@ -5,8 +5,8 @@
 /// related helpers.
 ///
 //===----------------------------------------------------------------------===//
-#ifndef OPERATORS_FILTER_H
-#define OPERATORS_FILTER_H
+#ifndef ITERATORS_OPERATORS_FILTEROPERATOR_H
+#define ITERATORS_OPERATORS_FILTEROPERATOR_H
 
 #include <optional>
 #include <tuple>
@@ -66,4 +66,4 @@ auto makeFilterOperator(UpstreamType *const upstream,
 
 } // namespace mlir::iterators::operators
 
-#endif // OPERATORS_FILTER_H
+#endif // ITERATORS_OPERATORS_FILTEROPERATOR_H

--- a/experimental/iterators/include/iterators/Operators/FilterOperator.h
+++ b/experimental/iterators/include/iterators/Operators/FilterOperator.h
@@ -11,6 +11,8 @@
 #include <optional>
 #include <tuple>
 
+namespace mlir::iterators::operators {
+
 /// Produces all tuples from upstream that pass the given filter.
 ///
 /// This operator returns all those tuples produced by its upstream operator
@@ -61,5 +63,7 @@ auto makeFilterOperator(UpstreamType *const upstream,
   return FilterOperator<UpstreamType, FilterFunctionType>(
       upstream, std::move(filterFunction));
 }
+
+} // namespace mlir::iterators::operators
 
 #endif // OPERATORS_FILTER_H

--- a/experimental/iterators/include/iterators/Operators/HashJoinOperator.h
+++ b/experimental/iterators/include/iterators/Operators/HashJoinOperator.h
@@ -5,8 +5,8 @@
 /// as related helpers.
 ///
 //===----------------------------------------------------------------------===//
-#ifndef OPERATORS_HASH_JOIN_H
-#define OPERATORS_HASH_JOIN_H
+#ifndef ITERATORS_OPERATORS_HASHJOINOPERATOR_H
+#define ITERATORS_OPERATORS_HASHJOINOPERATOR_H
 
 #include <optional>
 #include <tuple>
@@ -141,4 +141,4 @@ auto MakeHashJoinOperator(BuildUpstreamType *const buildUpstream,
 
 } // namespace mlir::iterators::operators
 
-#endif // OPERATORS_HASH_JOIN_H
+#endif // ITERATORS_OPERATORS_HASHJOINOPERATOR_H

--- a/experimental/iterators/include/iterators/Operators/HashJoinOperator.h
+++ b/experimental/iterators/include/iterators/Operators/HashJoinOperator.h
@@ -133,7 +133,7 @@ private:
 /// provided arguments.
 template <std::size_t kNumKeyAttributes, typename BuildUpstreamType,
           typename ProbeUpstreamType>
-auto MakeHashJoinOperator(BuildUpstreamType *const buildUpstream,
+auto makeHashJoinOperator(BuildUpstreamType *const buildUpstream,
                           ProbeUpstreamType *const probeUpstream) {
   return HashJoinOperator<BuildUpstreamType, ProbeUpstreamType,
                           kNumKeyAttributes>(buildUpstream, probeUpstream);

--- a/experimental/iterators/include/iterators/Operators/MapOperator.h
+++ b/experimental/iterators/include/iterators/Operators/MapOperator.h
@@ -11,6 +11,8 @@
 #include <optional>
 #include <tuple>
 
+namespace mlir::iterators::operators {
+
 /// Maps (or "transforms") all input tuples to a new one using a map function.
 ///
 /// This operator consumes the tuples produced by its upstream operator and
@@ -61,5 +63,7 @@ auto makeMapOperator(UpstreamType *const upstream,
   return MapOperator<UpstreamType, MapFunctionType>(upstream,
                                                     std::move(mapFunction));
 }
+
+} // namespace mlir::iterators::operators
 
 #endif // OPERATORS_MAP_H

--- a/experimental/iterators/include/iterators/Operators/MapOperator.h
+++ b/experimental/iterators/include/iterators/Operators/MapOperator.h
@@ -5,8 +5,8 @@
 /// related helpers.
 ///
 //===----------------------------------------------------------------------===//
-#ifndef OPERATORS_MAP_H
-#define OPERATORS_MAP_H
+#ifndef ITERATORS_OPERATORS_MAPOPERATOR_H
+#define ITERATORS_OPERATORS_MAPOPERATOR_H
 
 #include <optional>
 #include <tuple>
@@ -66,4 +66,4 @@ auto makeMapOperator(UpstreamType *const upstream,
 
 } // namespace mlir::iterators::operators
 
-#endif // OPERATORS_MAP_H
+#endif // ITERATORS_OPERATORS_MAPOPERATOR_H

--- a/experimental/iterators/include/iterators/Operators/ReduceByKeyOperator.h
+++ b/experimental/iterators/include/iterators/Operators/ReduceByKeyOperator.h
@@ -5,8 +5,8 @@
 /// well as related helpers.
 ///
 //===----------------------------------------------------------------------===//
-#ifndef OPERATORS_REDUCE_BY_KEY_H
-#define OPERATORS_REDUCE_BY_KEY_H
+#ifndef ITERATORS_OPERATORS_REDUCEBYKEYOPERATOR_H
+#define ITERATORS_OPERATORS_REDUCEBYKEYOPERATOR_H
 
 #include <optional>
 #include <tuple>
@@ -126,4 +126,4 @@ auto makeReduceByKeyOperator(UpstreamType *const upstream,
 
 } // namespace mlir::iterators::operators
 
-#endif // OPERATORS_REDUCE_BY_KEY_H
+#endif // ITERATORS_OPERATORS_REDUCEBYKEYOPERATOR_H

--- a/experimental/iterators/include/iterators/Operators/ReduceByKeyOperator.h
+++ b/experimental/iterators/include/iterators/Operators/ReduceByKeyOperator.h
@@ -8,6 +8,7 @@
 #ifndef ITERATORS_OPERATORS_REDUCEBYKEYOPERATOR_H
 #define ITERATORS_OPERATORS_REDUCEBYKEYOPERATOR_H
 
+#include <cassert>
 #include <optional>
 #include <tuple>
 #include <unordered_map>

--- a/experimental/iterators/include/iterators/Operators/ReduceOperator.h
+++ b/experimental/iterators/include/iterators/Operators/ReduceOperator.h
@@ -11,6 +11,8 @@
 #include <optional>
 #include <tuple>
 
+namespace mlir::iterators::operators {
+
 /// Reduces (or "folds") all input tuples into one given a reduce function.
 ///
 /// This operator consumes the tuples produced by its upstream operator and
@@ -71,5 +73,7 @@ auto makeReduceOperator(UpstreamType *const upstream,
   return ReduceOperator<UpstreamType, ReduceFunctionType>(
       upstream, std::move(reduceFunction));
 }
+
+} // namespace mlir::iterators::operators
 
 #endif // OPERATORS_REDUCE_H

--- a/experimental/iterators/include/iterators/Operators/ReduceOperator.h
+++ b/experimental/iterators/include/iterators/Operators/ReduceOperator.h
@@ -5,8 +5,8 @@
 /// related helpers.
 ///
 //===----------------------------------------------------------------------===//
-#ifndef OPERATORS_REDUCE_H
-#define OPERATORS_REDUCE_H
+#ifndef ITERATORS_OPERATORS_REDUCEOPERATOR_H
+#define ITERATORS_OPERATORS_REDUCEOPERATOR_H
 
 #include <optional>
 #include <tuple>
@@ -76,4 +76,4 @@ auto makeReduceOperator(UpstreamType *const upstream,
 
 } // namespace mlir::iterators::operators
 
-#endif // OPERATORS_REDUCE_H
+#endif // ITERATORS_OPERATORS_REDUCEOPERATOR_H

--- a/experimental/iterators/include/iterators/Utils/Tuple.h
+++ b/experimental/iterators/include/iterators/Utils/Tuple.h
@@ -1,5 +1,5 @@
-#ifndef UTILS_PRINT_H
-#define UTILS_PRINT_H
+#ifndef ITERATORS_UTILS_TUPLE_H
+#define ITERATORS_UTILS_TUPLE_H
 
 #include <iostream>
 #include <tuple>
@@ -101,4 +101,4 @@ void printTuple(const std::tuple<Types...> &tuple) {
 
 } // namespace mlir::iterators::utils
 
-#endif // UTILS_PRINT_H
+#endif // ITERATORS_UTILS_TUPLE_H

--- a/experimental/iterators/include/iterators/Utils/Tuple.h
+++ b/experimental/iterators/include/iterators/Utils/Tuple.h
@@ -19,7 +19,7 @@ auto extractElements(const TupleType &tuple,
 
 template <std::size_t kFrontSize, typename TupleType, std::size_t... kIndices>
 auto dropFront(const TupleType &tuple,
-                 const std::index_sequence<kIndices...> & /*unused*/) {
+               const std::index_sequence<kIndices...> & /*unused*/) {
   using IndexSequence =
       std::integer_sequence<std::size_t, kIndices + kFrontSize...>;
   return extractElements(tuple, IndexSequence{});

--- a/experimental/iterators/include/iterators/Utils/Tuple.h
+++ b/experimental/iterators/include/iterators/Utils/Tuple.h
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <tuple>
 
+namespace mlir::iterators::utils {
+
 namespace impl {
 template <typename TupleType, std::size_t... kIndices>
 auto extractElements(const TupleType &tuple,
@@ -96,5 +98,7 @@ template <typename... Types>
 void printTuple(const std::tuple<Types...> &tuple) {
   printTuple(std::cout, tuple);
 }
+
+} // namespace mlir::iterators::utils
 
 #endif // UTILS_PRINT_H

--- a/experimental/iterators/unittests/ColumnScanOperatorTest.cpp
+++ b/experimental/iterators/unittests/ColumnScanOperatorTest.cpp
@@ -5,6 +5,8 @@
 
 #include "iterators/Operators/ColumnScanOperator.h"
 
+using namespace mlir::iterators::operators;
+
 TEST(ColumnScanTest, SingleColumn) {
   std::vector<int32_t> numbers = {1, 2, 3, 4};
   auto scan = makeColumnScanOperator(numbers);

--- a/experimental/iterators/unittests/FilterOperatorTest.cpp
+++ b/experimental/iterators/unittests/FilterOperatorTest.cpp
@@ -6,6 +6,8 @@
 #include "iterators/Operators/ColumnScanOperator.h"
 #include "iterators/Operators/FilterOperator.h"
 
+using namespace mlir::iterators::operators;
+
 TEST(FilterTest, SingleColumn) {
   std::vector<int32_t> numbers = {1, 2, 3, 4, 5, 6};
   auto scan = makeColumnScanOperator(numbers);

--- a/experimental/iterators/unittests/HashJoinOperatorTest.cpp
+++ b/experimental/iterators/unittests/HashJoinOperatorTest.cpp
@@ -6,6 +6,8 @@
 #include "iterators/Operators/ColumnScanOperator.h"
 #include "iterators/Operators/HashJoinOperator.h"
 
+using namespace mlir::iterators::operators;
+
 TEST(HashJoinTest, SingleColumnKey) {
   std::vector<int32_t> leftKeys = {1, 2, 1, 2, 5};
   std::vector<int32_t> leftValues = {1, 1, 2, 2, 5};

--- a/experimental/iterators/unittests/HashJoinOperatorTest.cpp
+++ b/experimental/iterators/unittests/HashJoinOperatorTest.cpp
@@ -16,7 +16,7 @@ TEST(HashJoinTest, SingleColumnKey) {
 
   auto leftScan = makeColumnScanOperator(leftKeys, leftValues);
   auto rightScan = makeColumnScanOperator(rightKeys, rightValues);
-  auto hashJoin = MakeHashJoinOperator<1>(&leftScan, &rightScan);
+  auto hashJoin = makeHashJoinOperator<1>(&leftScan, &rightScan);
 
   using ResultTuple = decltype(hashJoin)::OutputTuple;
 
@@ -50,7 +50,7 @@ TEST(HashJoinTest, TwoColumnKey) {
 
   auto leftScan = makeColumnScanOperator(leftKeys1, leftKeys2, leftValues);
   auto rightScan = makeColumnScanOperator(rightKeys1, rightKeys2, rightValues);
-  auto hashJoin = MakeHashJoinOperator<2>(&leftScan, &rightScan);
+  auto hashJoin = makeHashJoinOperator<2>(&leftScan, &rightScan);
 
   using ResultTuple = decltype(hashJoin)::OutputTuple;
 
@@ -75,7 +75,7 @@ TEST(HashJoinTest, NoValueLeft) {
 
   auto leftScan = makeColumnScanOperator(leftKeys);
   auto rightScan = makeColumnScanOperator(rightKeys, rightValues);
-  auto hashJoin = MakeHashJoinOperator<1>(&leftScan, &rightScan);
+  auto hashJoin = makeHashJoinOperator<1>(&leftScan, &rightScan);
 
   using ResultTuple = decltype(hashJoin)::OutputTuple;
 
@@ -100,7 +100,7 @@ TEST(HashJoinTest, NoValueRight) {
 
   auto leftScan = makeColumnScanOperator(leftKeys, LeftValues);
   auto rightScan = makeColumnScanOperator(rightKeys);
-  auto hashJoin = MakeHashJoinOperator<1>(&leftScan, &rightScan);
+  auto hashJoin = makeHashJoinOperator<1>(&leftScan, &rightScan);
 
   using ResultTuple = decltype(hashJoin)::OutputTuple;
 

--- a/experimental/iterators/unittests/MapOperatorTest.cpp
+++ b/experimental/iterators/unittests/MapOperatorTest.cpp
@@ -6,6 +6,8 @@
 #include "iterators/Operators/ColumnScanOperator.h"
 #include "iterators/Operators/MapOperator.h"
 
+using namespace mlir::iterators::operators;
+
 TEST(MapTest, SingleColumnMap) {
   std::vector<int32_t> numbers = {1, 2};
   auto scan = makeColumnScanOperator(numbers);

--- a/experimental/iterators/unittests/ReduceByKeyOperatorTest.cpp
+++ b/experimental/iterators/unittests/ReduceByKeyOperatorTest.cpp
@@ -7,6 +7,9 @@
 #include "iterators/Operators/ColumnScanOperator.h"
 #include "iterators/Operators/ReduceByKeyOperator.h"
 
+using namespace mlir::iterators::operators;
+using namespace mlir::iterators::utils;
+
 TEST(ReduceByKeyTest, SingleColumnKey) {
   std::vector<int32_t> keys = {1, 2, 1, 2};
   std::vector<int32_t> values = {1, 2, 3, 4};

--- a/experimental/iterators/unittests/ReduceOperatorTest.cpp
+++ b/experimental/iterators/unittests/ReduceOperatorTest.cpp
@@ -6,6 +6,8 @@
 #include "iterators/Operators/ColumnScanOperator.h"
 #include "iterators/Operators/ReduceOperator.h"
 
+using namespace mlir::iterators::operators;
+
 TEST(ReduceTest, SingleColumnSum) {
   std::vector<int32_t> numbers = {1, 2, 3, 4};
   auto scan = makeColumnScanOperator(numbers);

--- a/experimental/iterators/unittests/UtilsTest.cpp
+++ b/experimental/iterators/unittests/UtilsTest.cpp
@@ -5,6 +5,8 @@
 
 #include "iterators/Utils/Tuple.h"
 
+using namespace mlir::iterators::utils;
+
 TEST(ExtractHeadTest, Head0) {
   std::tuple<int16_t, int32_t> tuple = {1, 2};
   auto const head = takeFront<0>(tuple);


### PR DESCRIPTION
This PR introduces namespaces for the Iterators subproject. I am also piggy-backing some other clean-ups: fix header guard names and other fixes suggested by clang-tidy.