### PR TITLE
Port rewriting of linalg_ext::TileOp as a linalg_ext::InParallelOp to the transform dialect.

### DIFF
--- a/include/Dialects/LinalgExt/Passes.h
+++ b/include/Dialects/LinalgExt/Passes.h
@@ -21,7 +21,6 @@ createLinalgExtTilingPass(ArrayRef<int64_t> tileSizes = {});
 
 std::unique_ptr<OperationPass<FuncOp>> createInParallelToAsyncPass();
 std::unique_ptr<OperationPass<FuncOp>> createInParallelToSequentialForPass();
-std::unique_ptr<OperationPass<FuncOp>> createTileToInParallelPass();
 
 void registerTilingInterfaceExternalModels(DialectRegistry &registry);
 

--- a/include/Dialects/LinalgExt/Passes.td
+++ b/include/Dialects/LinalgExt/Passes.td
@@ -73,14 +73,4 @@ def InParallelToSequentialFor : Pass<"linalg-in-parallel-to-sequential-for", "Fu
   ];
 }
 
-def TileToInParallel : Pass<"linalg-tile-to-in-parallel", "FuncOp"> {
-  let summary = "Pass to lower linalg_ext.tile to linalg_ext.in_parallel.";
-  let constructor = "mlir::linalg_ext::createTileToInParallelPass()";
-  let dependentDialects = [
-    "AffineDialect",
-    "tensor::TensorDialect",
-    "scf::SCFDialect"
-  ];
-}
- 
 #endif // DIALECTS_LINALGEXT_PASSES

--- a/include/Dialects/LinalgExt/Transforms/Transforms.h
+++ b/include/Dialects/LinalgExt/Transforms/Transforms.h
@@ -51,6 +51,21 @@ struct TileOpToSCFRewriter : public OpRewritePattern<linalg_ext::TileOp> {
   }
 };
 
+/// Pattern to rewrite a linalg_ext::TileOp to a linalg_ext::InParallelOp.
+struct TileOpToInParallelRewriter
+    : public OpRewritePattern<linalg_ext::TileOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  FailureOr<linalg_ext::InParallelOp>
+  returningMatchAndRewrite(linalg_ext::TileOp tileOp,
+                           PatternRewriter &rewriter) const;
+
+  LogicalResult matchAndRewrite(linalg_ext::TileOp tileOp,
+                                PatternRewriter &rewriter) const override {
+    return returningMatchAndRewrite(tileOp, rewriter);
+  }
+};
+
 } // namespace linalg_ext
 } // namespace mlir
 

--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -364,6 +364,22 @@ def RewriteLinalgExtTileToScfForOp :
   }];
 }
 
+def RewriteLinalgExtTileToInParallelOp :
+  Linalg_Transform_Operation<"rewrite_linalg_ext_tile_to_in_parallel",
+    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+
+  let description = [{Rewrite linalg_ext.tile op to linalg_ext.in_parallel.}];
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::linalg_ext::InParallelOp> applyToOne(
+        ::mlir::linalg_ext::TileOp target);
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 
 def ExpertOp : Linalg_Transform_Operation<"expert"> {

--- a/lib/Dialects/LinalgExt/Transforms/TileToInParallel.cpp
+++ b/lib/Dialects/LinalgExt/Transforms/TileToInParallel.cpp
@@ -12,6 +12,7 @@
 #include "Dialects/LinalgExt/LinalgExtOps.h"
 #include "Dialects/LinalgExt/PassDetail.h"
 #include "Dialects/LinalgExt/Passes.h"
+#include "Dialects/LinalgExt/Transforms/Transforms.h"
 #include "Dialects/LinalgExt/Transforms/Utils.h"
 #include "Transforms/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -29,132 +30,107 @@
 using namespace mlir;
 using namespace mlir::linalg_ext;
 
-namespace {
+FailureOr<linalg_ext::InParallelOp>
+mlir::linalg_ext::TileOpToInParallelRewriter::returningMatchAndRewrite(
+    linalg_ext::TileOp tileOp, PatternRewriter &rewriter) const {
 
-struct TileOpToInParallelRewriter
-    : public OpRewritePattern<linalg_ext::TileOp> {
-  using OpRewritePattern::OpRewritePattern;
+  // TODO: verifier.
+  assert(tileOp.getNumResults() > 0 &&
+         tileOp.outs().size() == tileOp.getNumResults());
 
-  LogicalResult matchAndRewrite(linalg_ext::TileOp tileOp,
-                                PatternRewriter &rewriter) const override {
-    // TODO: verifier.
-    assert(tileOp.getNumResults() > 0 &&
-           tileOp.outs().size() == tileOp.getNumResults());
+  // TODO: when supported, iterate over the tensor of sizes. This will be
+  // iterating through a level of indirection.
 
-    // TODO: when supported, iterate over the tensor of sizes. This will be
-    // iterating through a level of indirection.
+  int64_t tiledDim = tileOp.tiled_dim();
 
-    int64_t tiledDim = tileOp.tiled_dim();
+  // Construct the loop bounds based on the canonical arithmetic progression.
+  Location loc = tileOp.getLoc();
+  Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value tiledDimValue = rewriter.create<arith::ConstantIndexOp>(loc, tiledDim);
+  Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value totalSize =
+      rewriter.create<tensor::DimOp>(loc, tileOp.outs().front(), tiledDimValue);
+  Value step = tileOp.tile_size();
+  assert(step.getType().isa<IndexType>() && "NYI: not an index type");
 
-    // Construct the loop bounds based on the canonical arithmetic progression.
-    Location loc = tileOp.getLoc();
-    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value tiledDimValue =
-        rewriter.create<arith::ConstantIndexOp>(loc, tiledDim);
-    Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value totalSize = rewriter.create<tensor::DimOp>(loc, tileOp.outs().front(),
-                                                     tiledDimValue);
-    Value step = tileOp.tile_size();
-    assert(step.getType().isa<IndexType>() && "NYI: not an index type");
+  using AV = AffineValueExpr;
+  AffineBuilder ab(rewriter, loc);
+  AffineExpr i, j, M;
+  bindDims(rewriter.getContext(), i, j);
+  bindSymbols(rewriter.getContext(), M);
+  Value numThreads = ab.ceil(AV(i).bind(totalSize), AV(M).bind(step));
 
-    using AV = AffineValueExpr;
-    AffineBuilder ab(rewriter, loc);
-    AffineExpr i, j, M;
-    bindDims(rewriter.getContext(), i, j);
-    bindSymbols(rewriter.getContext(), M);
-    Value numThreads = ab.ceil(AV(i).bind(totalSize), AV(M).bind(step));
+  // Construct the op without a body builder: we need to clone the ops in the
+  // body explicitly after having access to the new bbArgs.
+  // As a consequence, `ensureTerminator` is not called and the body has no
+  // terminator.
+  linalg_ext::InParallelOp inParallelOp =
+      rewriter.create<linalg_ext::InParallelOp>(loc, tileOp->getResultTypes(),
+                                                numThreads);
 
-    // Construct the op without a body builder: we need to clone the ops in the
-    // body explicitly after having access to the new bbArgs.
-    // As a consequence, `ensureTerminator` is not called and the body has no
-    // terminator.
-    linalg_ext::InParallelOp inParallelOp =
-        rewriter.create<linalg_ext::InParallelOp>(loc, tileOp->getResultTypes(),
-                                                  numThreads);
+  // At the beginning of the InParallelOp, compute offset and sizes.
+  rewriter.setInsertionPointToStart(inParallelOp.getBody());
 
-    // At the beginning of the InParallelOp, compute offset and sizes.
-    rewriter.setInsertionPointToStart(inParallelOp.getBody());
-
-    // Materialize the implicit subtensors as explicit subset_extract.
-    // TODO: generalize to multiple offset/chunk_size bbargs if needed.
-    // TODO: generalize the subset op.
-    SmallVector<Value> leadingOffsets, leadingSizes, leadingStrides;
-    for (int64_t i = 0; i < tiledDim; ++i) {
-      leadingOffsets.push_back(zero);
-      leadingSizes.push_back(
-          rewriter.createOrFold<tensor::DimOp>(loc, tileOp.outs().front(), i));
-      leadingStrides.push_back(one);
-    }
-    // clang-format off
+  // Materialize the implicit subtensors as explicit subset_extract.
+  // TODO: generalize to multiple offset/chunk_size bbargs if needed.
+  // TODO: generalize the subset op.
+  SmallVector<Value> leadingOffsets, leadingSizes, leadingStrides;
+  for (int64_t i = 0; i < tiledDim; ++i) {
+    leadingOffsets.push_back(zero);
+    leadingSizes.push_back(
+        rewriter.createOrFold<tensor::DimOp>(loc, tileOp.outs().front(), i));
+    leadingStrides.push_back(one);
+  }
+  // clang-format off
     Value offset = ab.mul(AV(i).bind(inParallelOp.getThreadIndex()), 
                           AV(M).bind(step));
     Value size = ab.min(
       ValueRange{ab.sub(AV(i).bind(totalSize), AV(j).bind(offset)),
       step});
-    // clang-format on
-    leadingOffsets.push_back(offset);
-    leadingSizes.push_back(size);
-    leadingStrides.push_back(one);
+  // clang-format on
+  leadingOffsets.push_back(offset);
+  leadingSizes.push_back(size);
+  leadingStrides.push_back(one);
 
-    SmallVector<Value> implicitSubtensorExtracts;
-    for (Value tensor : tileOp.outs()) {
-      implicitSubtensorExtracts.push_back(
-          createSubsetExtractOpFromLeadingOffsetsSizesAndStrides(
-              rewriter, loc, tensor, leadingOffsets, leadingSizes,
-              leadingStrides));
-    }
-
-    // Get a reference to the TileOp terminator before the body is merged and it
-    // becomes too hard to get to the terminator.
-    auto tileYieldOp = cast<TileYieldOp>(tileOp.getBody()->getTerminator());
-
-    // Regroup the values that replace the tileOp's bbArg and move the body.
-    SmallVector<Value> bbArgsTranslated{offset, size};
-    llvm::append_range(bbArgsTranslated, implicitSubtensorExtracts);
-    rewriter.mergeBlockBefore(&tileOp.region().front(),
-                              inParallelOp.getBody()->getTerminator(),
-                              bbArgsTranslated);
-
-    // tileOp's terminator is not the terminator, insert explicit subset_insert
-    // ops and feed them to a new scf.yield terminator that we can now add.
-    PerformConcurrentlyOp performConcurrentlyOp = inParallelOp.getTerminator();
-
-    for (auto it : llvm::zip(tileYieldOp->getOperands(), tileOp.outs())) {
-      SmallVector<Value> offsets, sizes, strides;
-      completeOffsetsSizesAndStrides(rewriter, loc, std::get<0>(it),
-                                     leadingOffsets, leadingSizes,
-                                     leadingStrides, offsets, sizes, strides);
-      OpBuilder::InsertionGuard g(rewriter);
-      rewriter.setInsertionPoint(
-          performConcurrentlyOp.getBody()->getTerminator());
-      createParallelInsertSliceOpFromLeadingOffsetsSizesAndStrides(
-          rewriter, loc, std::get<0>(it), std::get<1>(it), offsets, sizes,
-          strides);
-    }
-
-    // Cleanup and replace.
-    rewriter.eraseOp(tileYieldOp);
-    rewriter.replaceOp(tileOp, inParallelOp.getResults());
-
-    return success();
+  SmallVector<Value> implicitSubtensorExtracts;
+  for (Value tensor : tileOp.outs()) {
+    implicitSubtensorExtracts.push_back(
+        createSubsetExtractOpFromLeadingOffsetsSizesAndStrides(
+            rewriter, loc, tensor, leadingOffsets, leadingSizes,
+            leadingStrides));
   }
-};
 
-struct TileToInParallelPass
-    : public TileToInParallelBase<TileToInParallelPass> {
-  void runOnOperation() override;
-};
-} // namespace
+  // Get a reference to the TileOp terminator before the body is merged and it
+  // becomes too hard to get to the terminator.
+  auto tileYieldOp = cast<TileYieldOp>(tileOp.getBody()->getTerminator());
 
-void TileToInParallelPass::runOnOperation() {
-  FuncOp funcOp = getOperation();
-  MLIRContext *context = funcOp.getContext();
-  RewritePatternSet patterns(context);
-  patterns.insert<TileOpToInParallelRewriter>(context);
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
-}
+  // Regroup the values that replace the tileOp's bbArg and move the body.
+  SmallVector<Value> bbArgsTranslated{offset, size};
+  llvm::append_range(bbArgsTranslated, implicitSubtensorExtracts);
+  rewriter.mergeBlockBefore(&tileOp.region().front(),
+                            inParallelOp.getBody()->getTerminator(),
+                            bbArgsTranslated);
 
-std::unique_ptr<OperationPass<FuncOp>>
-mlir::linalg_ext::createTileToInParallelPass() {
-  return std::make_unique<TileToInParallelPass>();
+  // tileOp's terminator is not the terminator, insert explicit subset_insert
+  // ops and feed them to a new scf.yield terminator that we can now add.
+  PerformConcurrentlyOp performConcurrentlyOp = inParallelOp.getTerminator();
+
+  for (auto it : llvm::zip(tileYieldOp->getOperands(), tileOp.outs())) {
+    SmallVector<Value> offsets, sizes, strides;
+    completeOffsetsSizesAndStrides(rewriter, loc, std::get<0>(it),
+                                   leadingOffsets, leadingSizes, leadingStrides,
+                                   offsets, sizes, strides);
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(
+        performConcurrentlyOp.getBody()->getTerminator());
+    createParallelInsertSliceOpFromLeadingOffsetsSizesAndStrides(
+        rewriter, loc, std::get<0>(it), std::get<1>(it), offsets, sizes,
+        strides);
+  }
+
+  // Cleanup and replace.
+  rewriter.eraseOp(tileYieldOp);
+  rewriter.replaceOp(tileOp, inParallelOp.getResults());
+
+  return inParallelOp;
 }

--- a/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/lib/Dialects/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -820,5 +820,20 @@ FailureOr<scf::ForOp> transform::RewriteLinalgExtTileToScfForOp::applyToOne(
   return functional::applyAt(target, functionalRewrite);
 }
 
+FailureOr<linalg_ext::InParallelOp>
+transform::RewriteLinalgExtTileToInParallelOp::applyToOne(
+    linalg_ext::TileOp target) {
+  linalg_ext::TileOpToInParallelRewriter pattern(this->getContext());
+  auto functionalRewrite =
+      [&](linalg_ext::TileOp op,
+          PatternRewriter &rewriter) -> FailureOr<linalg_ext::InParallelOp> {
+    auto result = pattern.returningMatchAndRewrite(op, rewriter);
+    if (failed(result))
+      return failure();
+    return result;
+  };
+  return functional::applyAt(target, functionalRewrite);
+}
+
 #define GET_OP_CLASSES
 #include "Dialects/LinalgTransform/LinalgTransformOps.cpp.inc"

--- a/test/LinalgExt/tile-to-in-parallel.mlir
+++ b/test/LinalgExt/tile-to-in-parallel.mlir
@@ -1,51 +1,62 @@
-// RUN: mlir-proto-opt %s -linalg-tile-to-in-parallel| FileCheck %s
+// RUN: mlir-proto-opt %s  -linalg-interp-transforms --split-input-file | FileCheck %s
 
-// CHECK-DAG: #[[$CEIL_MAP:.*]] = affine_map<(d0)[s0] -> (d0 ceildiv s0)>
+// CHECK-DAG: #[[$CEIL_MAP:.*]] = affine_map<()[s0, s1] -> (s1 ceildiv s0)>
 // CHECK-DAG: #[[$MUL_MAP:.*]] = affine_map<(d0)[s0] -> (d0 * s0)>
-// CHECK-DAG: #[[$SUB_MAP:.*]] = affine_map<(d0, d1) -> (d0 - d1)>
+// CHECK-DAG: #[[$SUB_MAP:.*]] = affine_map<(d0)[s0, s1] -> (-(d0 * s0) + s1, s0)>
 // CHECK-DAG: #[[$ID1_MAP:.*]] = affine_map<(d0) -> (d0)>
-// CHECK-DAG: #[[$ID2_MAP:.*]] = affine_map<(d0, d1) -> (d0, d1)>
 
-// CHECK-LABEL: func @static_tile
-//  CHECK-SAME:   %[[CHUNK_SIZE:[0-9a-z]+]]: index
-//  CHECK-SAME:   %[[IN:[0-9a-z]+]]: tensor<?xf32>
-//  CHECK-SAME:   %[[OUT:[0-9a-z]+]]: tensor<?xf32>
-func @static_tile(%chunk_size: index, %in: tensor<?xf32>, %out: tensor<?xf32>) -> (tensor<?xf32>) {
-  %c0 = arith.constant 0: index
+module {
+  // CHECK-LABEL: func @static_tile
+  //  CHECK-SAME:   %[[CHUNK_SIZE:[0-9a-z]+]]: index
+  //  CHECK-SAME:   %[[IN:[0-9a-z]+]]: tensor<?xf32>
+  //  CHECK-SAME:   %[[OUT:[0-9a-z]+]]: tensor<?xf32>
+  func @static_tile(%chunk_size: index, %in: tensor<?xf32>, %out: tensor<?xf32>) -> (tensor<?xf32>) {
+    %c0 = arith.constant 0: index
 
-  // CHECK: %[[M:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?xf32>
-  // CHECK: %[[CEIL:.*]] = affine.apply #[[$CEIL_MAP]](%[[M]])[%[[CHUNK_SIZE]]]
-  // CHECK: linalg_ext.in_parallel %[[CEIL]] -> (tensor<?xf32>) {
-  %0 = linalg_ext.tile %chunk_size outs(%out: tensor<?xf32>) -> (tensor<?xf32>) {
+    // CHECK: %[[M:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?xf32>
+    // CHECK: %[[CEIL:.*]] = affine.apply #[[$CEIL_MAP]]()[%[[CHUNK_SIZE]], %[[M]]]
+    // CHECK: linalg_ext.in_parallel %[[CEIL]] -> (tensor<?xf32>) {
+    %0 = linalg_ext.tile %chunk_size outs(%out: tensor<?xf32>) -> (tensor<?xf32>) {
 
-  // CHECK: ^bb0(%[[TIDX:.*]]: index):
-  // CHECK:    %[[OFFSET:.*]] = affine.apply #[[$MUL_MAP]](%[[TIDX]])[%[[CHUNK_SIZE]]]
-  // CHECK:    %[[REST:.*]] = affine.apply #[[$SUB_MAP]](%[[M]], %[[OFFSET]])
-  // CHECK:    %[[SIZE:.*]] = affine.min #[[$ID2_MAP]](%[[REST]], %[[CHUNK_SIZE]])
-  // CHECK:    %[[O:.*]] = tensor.extract_slice %[[OUT]][%[[OFFSET]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
+    // CHECK: ^bb0(%[[TIDX:.*]]: index):
+    // CHECK:    %[[OFFSET:.*]] = affine.apply #[[$MUL_MAP]](%[[TIDX]])[%[[CHUNK_SIZE]]]
+    // CHECK:    %[[SIZE:.*]] = affine.min #[[$SUB_MAP]](%[[TIDX]])[%[[CHUNK_SIZE]], %[[M]]]
+    // CHECK:    %[[O:.*]] = tensor.extract_slice %[[OUT]][%[[OFFSET]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
 
-    // TODO: one offset and one size per tensor?
-    // If not necessary in the dense strided-array world, what about the rest?
-    ^bb0(%offset: index, %size: index, %st1: tensor<?xf32>):
+      // TODO: one offset and one size per tensor?
+      // If not necessary in the dense strided-array world, what about the rest?
+      ^bb0(%offset: index, %size: index, %st1: tensor<?xf32>):
 
-      // TODO: atm this is just 1-1: out-chunk-size -> in-size.
-  // CHECK:    %[[I:.*]] = tensor.extract_slice %[[IN]][%[[OFFSET]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
-      %1 = tensor.extract_slice %in[%offset][%size][1] : tensor<?xf32> to tensor<?xf32>
+        // TODO: atm this is just 1-1: out-chunk-size -> in-size.
+    // CHECK:    %[[I:.*]] = tensor.extract_slice %[[IN]][%[[OFFSET]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
+        %1 = tensor.extract_slice %in[%offset][%size][1] : tensor<?xf32> to tensor<?xf32>
 
-  // CHECK:    %[[R:.*]] = linalg.generic {{.*}} ins(%[[I]] : tensor<?xf32>) outs(%[[O]] : tensor<?xf32>)
-      %3 = linalg.generic {
-           indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
-           iterator_types = ["parallel"]}
-         ins(%1: tensor<?xf32>) outs(%st1: tensor<?xf32>) {
-         ^bb0(%a: f32, %b:f32):  // no predecessors
-           %f42 = arith.constant 42.0: f32
-           %tmp = arith.mulf %a, %f42: f32
-           linalg.yield %tmp: f32
-      } -> tensor<?xf32>
+    // CHECK:    %[[R:.*]] = linalg.generic {{.*}} ins(%[[I]] : tensor<?xf32>) outs(%[[O]] : tensor<?xf32>)
+        %3 = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%1: tensor<?xf32>) outs(%st1: tensor<?xf32>) {
+          ^bb0(%a: f32, %b:f32):  // no predecessors
+            %f42 = arith.constant 42.0: f32
+            %tmp = arith.mulf %a, %f42: f32
+            linalg.yield %tmp: f32
+        } -> tensor<?xf32>
 
-  // CHECK: linalg_ext.perform_concurrently {
-  // CHECK:    linalg_ext.parallel_insert_slice %[[R]] into %[[OUT]][%[[OFFSET]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> into tensor<?xf32>
-      linalg_ext.tile_yield %3: tensor<?xf32> 
+    // CHECK: linalg_ext.perform_concurrently {
+    // CHECK:    linalg_ext.parallel_insert_slice %[[R]] into %[[OUT]][%[[OFFSET]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> into tensor<?xf32>
+        linalg_ext.tile_yield %3: tensor<?xf32> 
+    }
+    return %0: tensor<?xf32>
   }
-  return %0: tensor<?xf32>
+
+  pdl.pattern @match_linalg_ext_tile : benefit(1) {
+    %0 = operands
+    %1 = types
+    %2 = operation "linalg_ext.tile"(%0 : !pdl.range<value>)  -> (%1 : !pdl.range<type>)
+    rewrite %2 with "linalg_transform.apply"
+  }
+  linalg_transform.sequence {
+    %0 = match @match_linalg_ext_tile
+    %1 = rewrite_linalg_ext_tile_to_in_parallel %0
+  }
 }


### PR DESCRIPTION
In the process, retire the TileToInParallel pass.