### PR TITLE
Port rewriting of linalg_ext::TileOp as an scf::ForOp to the transform dialect.

### DIFF
--- a/include/Dialects/LinalgExt/Passes.h
+++ b/include/Dialects/LinalgExt/Passes.h
@@ -15,13 +15,12 @@ class DialectRegistry;
 
 namespace linalg_ext {
 
-/// Creates a pass to drive tiling of LinalgExt operations to scf::ForOp.
+/// Create a pass to drive tiling of LinalgExt operations to scf::ForOp.
 std::unique_ptr<OperationPass<FuncOp>>
 createLinalgExtTilingPass(ArrayRef<int64_t> tileSizes = {});
 
 std::unique_ptr<OperationPass<FuncOp>> createInParallelToAsyncPass();
 std::unique_ptr<OperationPass<FuncOp>> createInParallelToSequentialForPass();
-std::unique_ptr<OperationPass<FuncOp>> createTileToSequentialForPass();
 std::unique_ptr<OperationPass<FuncOp>> createTileToInParallelPass();
 
 void registerTilingInterfaceExternalModels(DialectRegistry &registry);

--- a/include/Dialects/LinalgExt/Passes.td
+++ b/include/Dialects/LinalgExt/Passes.td
@@ -73,16 +73,6 @@ def InParallelToSequentialFor : Pass<"linalg-in-parallel-to-sequential-for", "Fu
   ];
 }
 
-def TileToSequentialFor : Pass<"linalg-tile-to-sequential-for", "FuncOp"> {
-  let summary = "Pass to lower linalg_ext.tile to scf.for.";
-  let constructor = "mlir::linalg_ext::createTileToSequentialForPass()";
-  let dependentDialects = [
-    "AffineDialect",
-    "tensor::TensorDialect",
-    "scf::SCFDialect"
-  ];
-}
-
 def TileToInParallel : Pass<"linalg-tile-to-in-parallel", "FuncOp"> {
   let summary = "Pass to lower linalg_ext.tile to linalg_ext.in_parallel.";
   let constructor = "mlir::linalg_ext::createTileToInParallelPass()";

--- a/include/Dialects/LinalgExt/Transforms/Transforms.h
+++ b/include/Dialects/LinalgExt/Transforms/Transforms.h
@@ -13,6 +13,10 @@
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
+namespace scf {
+class ForOp;
+}
+
 namespace linalg_ext {
 
 /// Pattern to tile a TilingInterface op using a linalg_ext::TileOp.
@@ -31,6 +35,20 @@ struct LinalgExtTilingPattern
 
 private:
   linalg::LinalgTilingOptions options;
+};
+
+/// Pattern to rewrite a linalg_ext::TileOp to an scf::ForOp.
+struct TileOpToSCFRewriter : public OpRewritePattern<linalg_ext::TileOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  FailureOr<scf::ForOp>
+  returningMatchAndRewrite(linalg_ext::TileOp tileOp,
+                           PatternRewriter &rewriter) const;
+
+  LogicalResult matchAndRewrite(linalg_ext::TileOp tileOp,
+                                PatternRewriter &rewriter) const override {
+    return returningMatchAndRewrite(tileOp, rewriter);
+  }
 };
 
 } // namespace linalg_ext

--- a/include/Dialects/LinalgTransform/LinalgTransformOps.h
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.h
@@ -9,6 +9,7 @@
 #ifndef MLIR_DIALECT_LINALG_IR_LINALGTRANSFORMOPS_H
 #define MLIR_DIALECT_LINALG_IR_LINALGTRANSFORMOPS_H
 
+#include "Dialects/LinalgExt/LinalgExtOps.h"
 #include "Dialects/LinalgTransform/TrackingListener.h"
 #include "Dialects/LinalgTransform/TransformOpInterface.h"
 #include "TrackingListener.h"

--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -348,6 +348,22 @@ def TileToLinalgExtTileOp : Linalg_Transform_Operation<"tile_to_linalg_ext_tile_
   }];
 }
 
+def RewriteLinalgExtTileToScfForOp : 
+  Linalg_Transform_Operation<"rewrite_linalg_ext_tile_to_scf_for",
+    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+ 
+  let description = [{Rewrite linalg_ext.tile op to scf.for.}];
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$transformed);
+ 
+  let assemblyFormat = "$target attr-dict";
+ 
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::scf::ForOp> applyToOne(
+        ::mlir::linalg_ext::TileOp target);
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 
 def ExpertOp : Linalg_Transform_Operation<"expert"> {

--- a/lib/Dialects/LinalgExt/Transforms/TileToSequentialFor.cpp
+++ b/lib/Dialects/LinalgExt/Transforms/TileToSequentialFor.cpp
@@ -9,6 +9,7 @@
 #include "Dialects/LinalgExt/LinalgExtOps.h"
 #include "Dialects/LinalgExt/PassDetail.h"
 #include "Dialects/LinalgExt/Passes.h"
+#include "Dialects/LinalgExt/Transforms/Transforms.h"
 #include "Dialects/LinalgExt/Transforms/Utils.h"
 #include "Transforms/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -27,106 +28,82 @@
 using namespace mlir;
 using namespace mlir::linalg_ext;
 
-namespace {
+FailureOr<scf::ForOp>
+mlir::linalg_ext::TileOpToSCFRewriter::returningMatchAndRewrite(
+    linalg_ext::TileOp tileOp, PatternRewriter &rewriter) const {
 
-struct TileOpToSCFRewriter : public OpRewritePattern<linalg_ext::TileOp> {
-  using OpRewritePattern::OpRewritePattern;
+  // TODO: verifier.
+  assert(tileOp.getNumResults() > 0 &&
+         tileOp.outs().size() == tileOp.getNumResults());
 
-  LogicalResult matchAndRewrite(linalg_ext::TileOp tileOp,
-                                PatternRewriter &rewriter) const override {
-    // TODO: verifier.
-    assert(tileOp.getNumResults() > 0 &&
-           tileOp.outs().size() == tileOp.getNumResults());
+  // TODO: when supported, iterate over the tensor of sizes. This will be
+  // iterating through a level of indirection.
 
-    // TODO: when supported, iterate over the tensor of sizes. This will be
-    // iterating through a level of indirection.
+  // Construct the loop bounds based on the canonical arithmetic progression.
+  Location loc = tileOp.getLoc();
+  Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value totalSize =
+      rewriter.create<tensor::DimOp>(loc, tileOp.outs().front(), zero);
+  Value step = tileOp.tile_size();
+  assert(step.getType().isa<IndexType>() && "NYI: not an index type");
 
-    // Construct the loop bounds based on the canonical arithmetic progression.
-    Location loc = tileOp.getLoc();
-    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value totalSize =
-        rewriter.create<tensor::DimOp>(loc, tileOp.outs().front(), zero);
-    Value step = tileOp.tile_size();
-    assert(step.getType().isa<IndexType>() && "NYI: not an index type");
+  // Construct the op without a body builder: we need to clone the ops in the
+  // body explicitly after having access to the new bbArgs.
+  // As a consequence, `ensureTerminator` is not called and the body has no
+  // terminator.
+  scf::ForOp forOp =
+      rewriter.create<scf::ForOp>(loc, zero, totalSize, step, tileOp.outs());
 
-    // Construct the op without a body builder: we need to clone the ops in the
-    // body explicitly after having access to the new bbArgs.
-    // As a consequence, `ensureTerminator` is not called and the body has no
-    // terminator.
-    scf::ForOp forOp =
-        rewriter.create<scf::ForOp>(loc, zero, totalSize, step, tileOp.outs());
+  rewriter.setInsertionPointToStart(forOp.getBody());
 
-    rewriter.setInsertionPointToStart(forOp.getBody());
+  // TODO: when supported, also compute from the tensor of sizes.
+  using AV = AffineValueExpr;
+  AffineBuilder ab(rewriter, loc);
+  AffineExpr i, j, M;
+  bindDims(rewriter.getContext(), i, j);
+  bindSymbols(rewriter.getContext(), M);
 
-    // TODO: when supported, also compute from the tensor of sizes.
-    using AV = AffineValueExpr;
-    AffineBuilder ab(rewriter, loc);
-    AffineExpr i, j, M;
-    bindDims(rewriter.getContext(), i, j);
-    bindSymbols(rewriter.getContext(), M);
-
-    // Materialize the implicit subtensors as explicit subset_extract.
-    // TODO: generalize to multiple offset/chunk_size bbargs if needed.
-    // TODO: generalize the subset op.
-    Value offset = forOp.getInductionVar();
-    // clang-format off
+  // Materialize the implicit subtensors as explicit subset_extract.
+  // TODO: generalize to multiple offset/chunk_size bbargs if needed.
+  // TODO: generalize the subset op.
+  Value offset = forOp.getInductionVar();
+  // clang-format off
     Value size = ab.min(
       ValueRange{ab.sub(AV(i).bind(totalSize), AV(j).bind(offset)),
       step});
-    // clang-format on
-    SmallVector<Value> implicitSubtensorExtracts;
-    for (Value tensor : forOp.getRegionIterArgs()) {
-      implicitSubtensorExtracts.push_back(
-          createSubsetExtractOpFromLeadingOffsetsSizesAndStrides(
-              rewriter, loc, tensor, offset, size, one));
-    }
-
-    // Regroup the values that replace the tileOp's bbArg and move the body.
-    SmallVector<Value> bbArgsTranslated{offset, size};
-    llvm::append_range(bbArgsTranslated, implicitSubtensorExtracts);
-    rewriter.mergeBlocks(&tileOp.region().front(), forOp.getBody(),
-                         bbArgsTranslated);
-    // tileOp's terminator is not the terminator, insert explicit subset_insert
-    // ops and feed them to a new scf.yield terminator that we can now add.
-    auto tileYieldOp = cast<TileYieldOp>(&forOp.getBody()->back());
-    SmallVector<Value> implicitSubtensorInserts;
-    for (auto it :
-         llvm::zip(implicitSubtensorExtracts, tileYieldOp.getOperands(),
-                   forOp.getRegionIterArgs())) {
-      implicitSubtensorInserts.push_back(createMatchingSubsetInsertOp(
-          rewriter, loc,
-          /*subsetExtractOp=*/
-          std::get<0>(it).getDefiningOp<tensor::ExtractSliceOp>(),
-          /*source=*/std::get<1>(it), /*dest=*/std::get<2>(it)));
-    }
-    // Insert terminator.
-    rewriter.setInsertionPointToEnd(forOp.getBody());
-    rewriter.create<scf::YieldOp>(loc, implicitSubtensorInserts);
-
-    // Cleanup and replace.
-    rewriter.eraseOp(tileYieldOp);
-    rewriter.replaceOp(tileOp, forOp.getResults());
-
-    return success();
+  // clang-format on
+  SmallVector<Value> implicitSubtensorExtracts;
+  for (Value tensor : forOp.getRegionIterArgs()) {
+    implicitSubtensorExtracts.push_back(
+        createSubsetExtractOpFromLeadingOffsetsSizesAndStrides(
+            rewriter, loc, tensor, offset, size, one));
   }
-};
 
-struct TileToSequentialForPass
-    : public TileToSequentialForBase<TileToSequentialForPass> {
-  void runOnOperation() override;
-};
-} // namespace
+  // Regroup the values that replace the tileOp's bbArg and move the body.
+  SmallVector<Value> bbArgsTranslated{offset, size};
+  llvm::append_range(bbArgsTranslated, implicitSubtensorExtracts);
+  rewriter.mergeBlocks(&tileOp.region().front(), forOp.getBody(),
+                       bbArgsTranslated);
+  // tileOp's terminator is not the terminator, insert explicit subset_insert
+  // ops and feed them to a new scf.yield terminator that we can now add.
+  auto tileYieldOp = cast<TileYieldOp>(&forOp.getBody()->back());
+  SmallVector<Value> implicitSubtensorInserts;
+  for (auto it : llvm::zip(implicitSubtensorExtracts, tileYieldOp.getOperands(),
+                           forOp.getRegionIterArgs())) {
+    implicitSubtensorInserts.push_back(createMatchingSubsetInsertOp(
+        rewriter, loc,
+        /*subsetExtractOp=*/
+        std::get<0>(it).getDefiningOp<tensor::ExtractSliceOp>(),
+        /*source=*/std::get<1>(it), /*dest=*/std::get<2>(it)));
+  }
+  // Insert terminator.
+  rewriter.setInsertionPointToEnd(forOp.getBody());
+  rewriter.create<scf::YieldOp>(loc, implicitSubtensorInserts);
 
-void TileToSequentialForPass::runOnOperation() {
-  FuncOp funcOp = getOperation();
-  MLIRContext *context = funcOp.getContext();
-  RewritePatternSet patterns(context);
-  patterns.insert<TileOpToSCFRewriter>(context);
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
-}
+  // Cleanup and replace.
+  rewriter.eraseOp(tileYieldOp);
+  rewriter.replaceOp(tileOp, forOp.getResults());
 
-std::unique_ptr<OperationPass<FuncOp>>
-mlir::linalg_ext::createTileToSequentialForPass() {
-  return std::make_unique<TileToSequentialForPass>();
+  return forOp;
 }

--- a/test/LinalgExt/tile-to-sequential-for.mlir
+++ b/test/LinalgExt/tile-to-sequential-for.mlir
@@ -1,49 +1,58 @@
-// RUN: mlir-proto-opt %s -linalg-tile-to-sequential-for | FileCheck %s
+// RUN: mlir-proto-opt %s -linalg-interp-transforms --split-input-file | FileCheck %s
 
-// CHECK-DAG: #[[$SUB_MAP:.*]] = affine_map<(d0, d1) -> (d0 - d1)>
+// CHECK-DAG: #[[$SUB_MAP:.*]] = affine_map<(d0)[s0, s1] -> (-d0 + s1, s0)>
 // CHECK-DAG: #[[$ID1_MAP:.*]] = affine_map<(d0) -> (d0)>
-// CHECK-DAG: #[[$ID2_MAP:.*]] = affine_map<(d0, d1) -> (d0, d1)>
 
-// CHECK-LABEL: func @static_tile
-//  CHECK-SAME:   %[[CHUNK_SIZE:[0-9a-z]+]]: index
-//  CHECK-SAME:   %[[IN:[0-9a-z]+]]: tensor<?xf32>
-func @static_tile(%chunk_size: index, %in: tensor<?xf32>, %out: tensor<?xf32>, %out2: tensor<?xf32>) -> (tensor<?xf32>) {
-  %c0 = arith.constant 0: index
+module {
+  // CHECK-LABEL: func @static_tile
+  //  CHECK-SAME:   %[[CHUNK_SIZE:[0-9a-z]+]]: index
+  //  CHECK-SAME:   %[[IN:[0-9a-z]+]]: tensor<?xf32>
+  func @static_tile(%chunk_size: index, %in: tensor<?xf32>, %out: tensor<?xf32>, %out2: tensor<?xf32>) -> (tensor<?xf32>) {
+    %c0 = arith.constant 0: index
 
-  // CHECK: %[[M:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?xf32>
-  // CHECK: scf.for %[[IV:.*]] = {{.*}} iter_args(%[[OUT:.*]] = %{{.*}}, %[[OUT2:.*]] = %{{.*}}) -> (tensor<?xf32>, tensor<?xf32>) {
-  %0:2 = linalg_ext.tile %chunk_size outs(%out: tensor<?xf32>, %out2: tensor<?xf32>)
-      -> (tensor<?xf32>, tensor<?xf32>) {
+    // CHECK: %[[M:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?xf32>
+    // CHECK: scf.for %[[IV:.*]] = {{.*}} iter_args(%[[OUT:.*]] = %{{.*}}, %[[OUT2:.*]] = %{{.*}}) -> (tensor<?xf32>, tensor<?xf32>) {
+    %0:2 = linalg_ext.tile %chunk_size outs(%out: tensor<?xf32>, %out2: tensor<?xf32>)
+        -> (tensor<?xf32>, tensor<?xf32>) {
 
-  // CHECK:    %[[REST:.*]] = affine.apply #[[$SUB_MAP]](%[[M]], %[[IV]])
-  // CHECK:    %[[SIZE:.*]] = affine.min #[[$ID2_MAP]](%[[REST]], %[[CHUNK_SIZE]])
-  // CHECK:    %[[O:.*]] = tensor.extract_slice %[[OUT]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
-  // CHECK:    %[[O2:.*]] = tensor.extract_slice %[[OUT2]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
+    // CHECK:    %[[SIZE:.*]] = affine.min #[[$SUB_MAP]](%[[IV]])[%[[CHUNK_SIZE]], %[[M]]]
+    // CHECK:    %[[O:.*]] = tensor.extract_slice %[[OUT]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
+    // CHECK:    %[[O2:.*]] = tensor.extract_slice %[[OUT2]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
 
-    // TODO: one offset and one size per tensor?
-    // If not necessary in the dense strided-array world, what about the rest?
-    ^bb0(%offset: index, %size: index, %st1: tensor<?xf32>, %st2: tensor<?xf32>):
+      // TODO: one offset and one size per tensor?
+      // If not necessary in the dense strided-array world, what about the rest?
+      ^bb0(%offset: index, %size: index, %st1: tensor<?xf32>, %st2: tensor<?xf32>):
 
-      // TODO: atm this is just 1-1: out-chunk-size -> in-size.
-  // CHECK:    %[[I:.*]] = tensor.extract_slice %[[IN]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
-      %1 = tensor.extract_slice %in[%offset][%size][1] : tensor<?xf32> to tensor<?xf32>
+        // TODO: atm this is just 1-1: out-chunk-size -> in-size.
+    // CHECK:    %[[I:.*]] = tensor.extract_slice %[[IN]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
+        %1 = tensor.extract_slice %in[%offset][%size][1] : tensor<?xf32> to tensor<?xf32>
 
-  // CHECK:    %[[R:.*]] = linalg.generic {{.*}} ins(%[[I]] : tensor<?xf32>) outs(%[[O]] : tensor<?xf32>)
-      %3 = linalg.generic {
-           indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
-           iterator_types = ["parallel"]}
-         ins(%1: tensor<?xf32>) outs(%st1: tensor<?xf32>) {
-         ^bb0(%a: f32, %b:f32):  // no predecessors
-           %f42 = arith.constant 42.0: f32
-           %tmp = arith.mulf %a, %f42: f32
-           linalg.yield %tmp: f32
-      } -> tensor<?xf32>
+    // CHECK:    %[[R:.*]] = linalg.generic {{.*}} ins(%[[I]] : tensor<?xf32>) outs(%[[O]] : tensor<?xf32>)
+        %3 = linalg.generic {
+            indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+            iterator_types = ["parallel"]}
+          ins(%1: tensor<?xf32>) outs(%st1: tensor<?xf32>) {
+          ^bb0(%a: f32, %b:f32):  // no predecessors
+            %f42 = arith.constant 42.0: f32
+            %tmp = arith.mulf %a, %f42: f32
+            linalg.yield %tmp: f32
+        } -> tensor<?xf32>
 
-  // CHECK:    %[[RES:.*]] = tensor.insert_slice %[[R]] into %[[OUT]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> into tensor<?xf32>
-  // CHECK:    %[[RES2:.*]] = tensor.insert_slice %[[O2]] into %[[OUT2]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> into tensor<?xf32>
-  // CHECK:    scf.yield %[[RES]], %[[RES2]] : tensor<?xf32>, tensor<?xf32>
-      linalg_ext.tile_yield %3, %st2: tensor<?xf32>, tensor<?xf32> // assumes dim is 0 and stacks
+    // CHECK:    %[[RES:.*]] = tensor.insert_slice %[[R]] into %[[OUT]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> into tensor<?xf32>
+    // CHECK:    %[[RES2:.*]] = tensor.insert_slice %[[O2]] into %[[OUT2]][%[[IV]]] [%[[SIZE]]] [{{.*}}] : tensor<?xf32> into tensor<?xf32>
+    // CHECK:    scf.yield %[[RES]], %[[RES2]] : tensor<?xf32>, tensor<?xf32>
+        linalg_ext.tile_yield %3, %st2: tensor<?xf32>, tensor<?xf32> // assumes dim is 0 and stacks
+    }
+    return %0#0: tensor<?xf32>
   }
-  return %0#0: tensor<?xf32>
+  pdl.pattern @match_linalg_ext_tile : benefit(1) {
+    %0 = operands
+    %1 = types
+    %2 = operation "linalg_ext.tile"(%0 : !pdl.range<value>)  -> (%1 : !pdl.range<type>)
+    rewrite %2 with "linalg_transform.apply"
+  }
+  linalg_transform.sequence {
+    %0 = match @match_linalg_ext_tile
+    %1 = rewrite_linalg_ext_tile_to_scf_for %0
+  }
 }
-


### PR DESCRIPTION
In the process, retire the TileToSequentialFor pass.