### PR TITLE
Add python support for linalg_ext transforms that use the transform dialect.

### DIFF
--- a/include/Dialects/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialects/LinalgTransform/LinalgTransformOps.td
@@ -256,8 +256,8 @@ def LowerToLLVMOp : Transform_Op<"lower_to_llvm"> {
      DefaultValuedAttr<BoolAttr, "false">:$enable_arm_neon,
      DefaultValuedAttr<BoolAttr, "false">:$enable_arm_sve,
      DefaultValuedAttr<BoolAttr, "false">:$enable_amx,
-     DefaultValuedAttr<BoolAttr, "false">:$enable_x86vector
-    );
+     DefaultValuedAttr<BoolAttr, "false">:$enable_x86vector,
+     DefaultValuedAttr<BoolAttr, "false">:$enable_async);
 
   let assemblyFormat = "attr-dict";
 }

--- a/lib/Dialects/LinalgTransform/IR/CMakeLists.txt
+++ b/lib/Dialects/LinalgTransform/IR/CMakeLists.txt
@@ -12,16 +12,22 @@ add_mlir_library(MLIRLinalgTransformOps
   LINK_LIBS PUBLIC
   IREELinalgTensorSandboxTransforms
   MLIRIR
+  # Dialects
+  MLIRAsync
   MLIRLinalg
   MLIRLinalgExt
   MLIRLinalgExtTransforms
   MLIRPDL
   MLIRControlFlowInterfaces
   MLIRRewrite
+  # Transforms
+  MLIRAsyncTransforms
   MLIRLinalgTransforms
   MLIRAffineToStandard
   MLIRTransforms
   MLIRReconcileUnrealizedCasts
+  # Conversions
+  MLIRAsyncToLLVM
   MLIRMemRefToLLVM
   MLIRMathToLLVM
   MLIRVectorToLLVM

--- a/python/examples/core/harness.py
+++ b/python/examples/core/harness.py
@@ -208,6 +208,11 @@ def compiled_function_element_types_mlir_builder(
 
 def emit_schedule_dialect(module: ModuleOp,
                           transformations: TransformationList):
+  # TODO: this is necessary to force-load the dialect, otherwise op creation
+  # complains about "unregistered dialect" despite the registration being called.
+  register_sandbox_passes_and_dialects(module.context)
+  module.context.dialects["linalg_ext"]
+  module.context.dialects["linalg_transform"]
   with InsertionPoint(module.body):
     sequence = tx.SequenceOp()
     with InsertionPoint(sequence.body.blocks[0]):

--- a/python/examples/linalg_ext/test_in_par.py
+++ b/python/examples/linalg_ext/test_in_par.py
@@ -21,35 +21,41 @@ all_experts = [
     e.print_pipeline(before_all=False) for e in [                             \
         e.print_ir(after_all=False, at_begin=False, llvm=False) for e in [    \
             LinalgExtTile(fun_name, op_name, tile_sizes=[4])
-              .then(LinalgExtTileToInParallel(fun_name, op_name))
+              .then(LinalgExtTileToInParallel(fun_name))
               .then(Bufferize())
-              .then(LinalgExtInParallelToSequentialFor(fun_name, op_name))
+              .then(LinalgExtInParallelToScfFor(fun_name))
               .then(LowerToLLVM()),
             LinalgExtTile(fun_name, op_name, tile_sizes=[4])
-              .then(LinalgExtTileToInParallel(fun_name, op_name))
+              .then(LinalgExtTileToInParallel(fun_name))
               .then(Bufferize())
-              .then(LinalgExtInParallelToAsync(fun_name, op_name))
-              .then(LowerToLLVM()),
+              .then(LinalgExtInParallelToAsync(fun_name))
+              .then(LowerToLLVM(enable_async=True)),
             LinalgExtTile(fun_name, op_name, tile_sizes=[16])
-              .then(LinalgExtTileToInParallel(fun_name, op_name))
+              .then(LinalgExtTileToInParallel(fun_name))
               .then(Tile(fun_name,
                          op_name,
-                         tile_sizes=[12, 32, 16],
-                         pad=True,
-                         pack_paddings=[1, 1, 0],
-                         hoist_paddings=[2, 3, 0]))
+                         tile_sizes=[12, 32, 16]))
+              .then(Pad(fun_name,
+                        op_name,
+                        pack_paddings=[1, 1, 0],
+                        hoist_paddings=[2, 3, 0]))
               .then(Vectorize(fun_name, ''))
-              .then(LoweringOnlyExpert(fun_name, op_name)),
+              .then(Bufferize())
+              .then(LinalgExtInParallelToScfFor(fun_name))
+              .then(LowerToLLVM(enable_async=True)),
             LinalgExtTile(fun_name, op_name, tile_sizes=[0, 16])
-              .then(LinalgExtTileToInParallel(fun_name, op_name))
+              .then(LinalgExtTileToInParallel(fun_name))
               .then(Tile(fun_name,
                          op_name,
-                         tile_sizes=[12, 32, 16],
-                         pad=True,
-                         pack_paddings=[1, 1, 0],
-                         hoist_paddings=[2, 3, 0]))
+                         tile_sizes=[12, 32, 16]))
+              .then(Pad(fun_name,
+                        op_name,
+                        pack_paddings=[1, 1, 0],
+                        hoist_paddings=[2, 3, 0]))
               .then(Vectorize(fun_name, ''))
-              .then(LoweringOnlyExpert(fun_name, op_name)),
+              .then(Bufferize())
+              .then(LinalgExtInParallelToScfFor(fun_name))
+              .then(LowerToLLVM(enable_async=True)),
         ]
     ]
 ]

--- a/python/examples/linalg_ext/test_seq.py
+++ b/python/examples/linalg_ext/test_seq.py
@@ -8,23 +8,26 @@ from ..core.transforms import *
 
 from ..contraction.definitions import *
 
+from mlir.iree_sandbox import *
+from mlir.dialects.linalg_ext import *
+from mlir.dialects.linalg_transform import *
+
 import typing as tp
+
+fun_name = 'matmul'
+op_name = 'linalg.generic'
 
 ################################################################################
 # Compilation strategies.
 ################################################################################
 
-expert_linalg_ext_tile = TransformationList(transforms=[
-    LinalgExtTile('matmul_on_tensors', 'linalg.generic', tile_sizes=[2]),
-    LinalgExtTileToSequentialFor('matmul_on_tensors', 'linalg.generic'),
-    Vectorize('matmul_on_tensors', 'linalg.generic'),
-    Bufferize(),
-    LowerToLLVM(),
-])
-
-all_experts = [
-    e.print_ir(after_all=False, llvm=False) for e in [expert_linalg_ext_tile]
+expert_linalg_ext_tile = [                                 \
+    LinalgExtTile(fun_name, op_name, tile_sizes=[2])       \
+    .then(LinalgExtTileToScfFor(fun_name)) \
+    .then(Vectorize(fun_name, ''))\
+    .then(LoweringOnlyExpert(fun_name, op_name, transpose_avx2_lowering=True))\
 ]
+all_experts = expert_linalg_ext_tile
 
 ################################################################################
 # Problem instantiations.
@@ -37,11 +40,12 @@ keys = ['m', 'n', 'k']
 def main():
   n_iters = 1
   problem_size_list = [[3, 5, 7]]
-  test_harness(lambda s, t: EinsumProblem('mk,kn', 'mnk', 2), [[np.float32] * 3],
+  test_harness(lambda s, t: EinsumProblem('mk,kn', 'mnk', 2),
+               [[np.float32] * 3],
                test_sizes(keys, problem_size_list),
                all_experts,
                n_iters=n_iters,
-               function_name='matmul')
+               function_name=fun_name)
 
 
 if __name__ == '__main__':

--- a/python/sandbox/dialects/_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_linalg_transform_ops_ext.py
@@ -119,6 +119,7 @@ class LowerToLLVMOp:
                enable_arm_sve: BoolArg = None,
                enable_amx: BoolArg = None,
                enable_x86vector: BoolArg = None,
+               enable_async: BoolArg = None,
                loc=None,
                ip=None):
     super().__init__(_ensure_bool_attr(reassociate_fp_reductions, False),
@@ -127,6 +128,7 @@ class LowerToLLVMOp:
                      _ensure_bool_attr(enable_arm_sve, False),
                      _ensure_bool_attr(enable_amx, False),
                      _ensure_bool_attr(enable_x86vector, False),
+                     _ensure_bool_attr(enable_async, False),
                      loc=loc,
                      ip=ip)
 
@@ -321,3 +323,70 @@ class SequenceOp:
   def __init__(self, *, loc=None, ip=None):
     super().__init__(loc=loc, ip=ip)
     self.body.blocks.append()
+
+
+##===----------------------------------------------------------------------===##
+## LinalgExt specific transforms
+##===----------------------------------------------------------------------===##
+
+
+class TileToLinalgExtTileOp:
+  """Specialization for the TileToLinalgExtTileOp class."""
+
+  def __init__(self,
+               target: Union[ir.Value, ir.Operation, ir.OpView],
+               *,
+               sizes: IntListArg = None,
+               loc=None,
+               ip=None):
+    sizes = _ensure_array_attr(sizes, [])
+    operation_type = pdl.OperationType.get()
+    super().__init__(operation_type, target, sizes, loc=loc, ip=ip)
+
+
+class RewriteLinalgExtTileToScfForOp:
+  """Specialization for the RewriteLinalgExtTileToScfForOp class."""
+
+  def __init__(self,
+               target: Union[ir.Value, ir.Operation, ir.OpView],
+               *,
+               loc=None,
+               ip=None):
+    operation_type = pdl.OperationType.get()
+    super().__init__(operation_type, target, loc=loc, ip=ip)
+
+
+class RewriteLinalgExtTileToInParallelOp:
+  """Specialization for the RewriteLinalgExtTileToInParallelOp class."""
+
+  def __init__(self,
+               target: Union[ir.Value, ir.Operation, ir.OpView],
+               *,
+               loc=None,
+               ip=None):
+    operation_type = pdl.OperationType.get()
+    super().__init__(operation_type, target, loc=loc, ip=ip)
+
+
+class RewriteLinalgExtInParallelToScfForOp:
+  """Specialization for the RewriteLinalgExtInParallelToScfForOp class."""
+
+  def __init__(self,
+               target: Union[ir.Value, ir.Operation, ir.OpView],
+               *,
+               loc=None,
+               ip=None):
+    operation_type = pdl.OperationType.get()
+    super().__init__(operation_type, target, loc=loc, ip=ip)
+
+
+class RewriteLinalgExtInParallelToAsyncOp:
+  """Specialization for the RewriteLinalgExtInParallelToAsyncOp class."""
+
+  def __init__(self,
+               target: Union[ir.Value, ir.Operation, ir.OpView],
+               *,
+               loc=None,
+               ip=None):
+    operation_type = pdl.OperationType.get()
+    super().__init__(operation_type, target, loc=loc, ip=ip)


### PR DESCRIPTION
This requires some unwelcome dependencies of the transform dialect on the linalg_ext and async dialects.
These dependencies should be cleaned up in the future when we have a proper transform interface.