### PR TITLE
Update python fill op uses and enable tests.

### DIFF
--- a/experimental/alp/python/alp/benchmark/blas/gemm.py
+++ b/experimental/alp/python/alp/benchmark/blas/gemm.py
@@ -66,8 +66,8 @@ def emit_benchmarking_function(trA, sizes, niter,
     B0 = linalg.InitTensorOp([K, N], F32Type.get())
     C = linalg.InitTensorOp([M, N], F32Type.get())
 
-    A = linalg.FillOp(output=A0.results[0], value=elem)
-    B = linalg.FillOp(output=B0.results[0], value=elem)
+    A = linalg.fill(elem, outs=[A0.results[0]])
+    B = linalg.fill(elem, outs=[B0.results[0]])
     func.CallOp(print_pid, [])
 
     call = func.CallOp(func, [A.results[0], B.results[0], C.results[0]])

--- a/experimental/alp/python/alp/test/blas/gemm.py
+++ b/experimental/alp/python/alp/test/blas/gemm.py
@@ -72,8 +72,8 @@ def emit_test_function(trA, sizes, func: builtin.FuncOp) -> builtin.FuncOp:
                            one_f64,
                            c6789_i32,
                            outs=[B0.results[0]])
-    # A = linalg.FillOp(output=A0.results[0], value=elem)
-    # B = linalg.FillOp(output=B0.results[0], value=elem)
+    # A = linalg.fill(elem, outs=[A0.results[0]])
+    # B = linalg.fill(elem, outs=[B0.results[0]])
 
     # Evaluate actual function and the reference
     func.CallOp(func, [A, B, C.results[0]])

--- a/lib/Dialects/LinalgExt/Transforms/LinalgExtBufferization.cpp
+++ b/lib/Dialects/LinalgExt/Transforms/LinalgExtBufferization.cpp
@@ -204,9 +204,9 @@ static bool hasMatchingExtractSliceOp(const BufferizationState &state,
 struct ParallelInsertSliceOpInterface
     : public BufferizableOpInterface::ExternalModel<
           ParallelInsertSliceOpInterface, ParallelInsertSliceOp> {
-  SmallVector<OpResult> getAliasingOpResult(
-      Operation *op, OpOperand &opOperand,
-      const BufferizationState &state) const {
+  SmallVector<OpResult>
+  getAliasingOpResult(Operation *op, OpOperand &opOperand,
+                      const BufferizationState &state) const {
     if (&opOperand != &op->getOpOperand(1) /*dest*/)
       return {};
 

--- a/lib/Transforms/FuseFillIntoReduction.cpp
+++ b/lib/Transforms/FuseFillIntoReduction.cpp
@@ -24,7 +24,7 @@ using mlir::tensor::ExtractSliceOp;
 using mlir::tensor::InsertSliceOp;
 
 SmallVector<OpFoldResult> GetParallelDimStep(scf::LoopNest nest,
-                                              GenericOp tiled_op) {
+                                             GenericOp tiled_op) {
   assert(nest.loops.size() == 2 && "Expected a 2D loop");
   assert(tiled_op.getNumLoops() && "Expected a 2D tiled op");
   SmallVector<unsigned> parallelDims;
@@ -165,8 +165,8 @@ private:
         loc, output_tile_bb_arg, offset, extract_output_slice.getMixedSizes(),
         extract_output_slice.getMixedStrides());
 
-    auto fused_fill =
-        rewriter.create<FillOp>(loc, fill.value(), slice_of_output_tile);
+    auto fused_fill = rewriter.create<FillOp>(loc, ValueRange{fill.value()},
+                                              ValueRange{slice_of_output_tile});
     rewriter.updateRootInPlace(tiled_op, [&]() {
       tiled_op.getOutputOperand(0)->set(fused_fill.result());
     });

--- a/python/examples/contraction/definitions.py
+++ b/python/examples/contraction/definitions.py
@@ -138,7 +138,7 @@ class EinsumProblem(ProblemDefinition):
       output_tensor = bench.arguments[-1]
       if self.specification.reduction_dims and zero_at_each_iteration:
         zero = arith.ConstantOp(types[-1].element_type, -0.0)
-        output_tensor = linalg.FillOp(output=bench.arguments[-1], value=zero)
+        output_tensor = linalg.fill(zero, outs=[bench.arguments[-1]])
       print('Einsum spec: ', str(self.specification))
       einsum_op = make_einsum(self.specification)(*bench.arguments[:-1],
                                                   outs=[output_tensor])

--- a/python/examples/conv/definitions.py
+++ b/python/examples/conv/definitions.py
@@ -399,7 +399,7 @@ class ConvolutionProblem(ProblemDefinition):
       tensor_zero = bench.arguments[-1]
       if zero_at_each_iteration:
         zero = arith.ConstantOp(output_type.element_type, 0.0)
-        tensor_zero = linalg.FillOp(output=tensor_zero, value=zero)
+        tensor_zero = linalg.fill(zero, outs=[tensor_zero])
       conv = self.__op_builder(bench.arguments[0],
                                bench.arguments[1],
                                outs=[tensor_zero],

--- a/python/examples/depthwise_conv/definitions.py
+++ b/python/examples/depthwise_conv/definitions.py
@@ -434,7 +434,7 @@ class DepthwiseConvolutionProblem(ProblemDefinition):
       tensor_zero = bench.arguments[-1]
       if zero_at_each_iteration:
         zero = arith.ConstantOp(output_type.element_type, 0.0)
-        tensor_zero = linalg.FillOp(output=tensor_zero, value=zero)
+        tensor_zero = linalg.fill(zero, outs=[tensor_zero])
       conv = self.__op_builder(bench.arguments[0],
                                bench.arguments[1],
                                outs=[tensor_zero],

--- a/python/examples/fusion/definitions.py
+++ b/python/examples/fusion/definitions.py
@@ -126,7 +126,7 @@ class MatmulProblem(ProblemDefinition):
       tensor_zero = bench.arguments[2]
       if zero_at_each_iteration:
         zero = arith.ConstantOp(types[-1].element_type, 0.0)
-        tensor_zero = linalg.FillOp(output=tensor_zero, value=zero)
+        tensor_zero = linalg.fill(zero, outs=[tensor_zero])
       matmul = linalg.matmul(bench.arguments[0],
                              bench.arguments[1],
                              outs=[tensor_zero])
@@ -252,7 +252,7 @@ class MatmulBiasAddProblem(ProblemDefinition):
       tensor_zero = bench.arguments[3]
       if zero_at_each_iteration:
         zero = arith.ConstantOp(types[-1].element_type, 0.0)
-        tensor_zero = linalg.FillOp(output=tensor_zero, value=zero)
+        tensor_zero = linalg.fill(zero, outs=[tensor_zero])
       matmul = linalg.matmul(bench.arguments[0],
                              bench.arguments[1],
                              outs=[tensor_zero])

--- a/python/examples/padding/definitions.py
+++ b/python/examples/padding/definitions.py
@@ -184,7 +184,7 @@ class Padded_Conv1d_NWC_WCF_Problem(ProblemDefinition):
       tensor_zero = bench.arguments[-1]
       if zero_at_each_iteration:
         zero = arith.ConstantOp(output_element_type, 0.0)
-        tensor_zero = linalg.FillOp(output=tensor_zero, value=zero)
+        tensor_zero = linalg.fill(zero, outs=[tensor_zero])
 
       padded_input = tensor.PadOp(
           result=types[-1],

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -38,10 +38,7 @@ config.excludes = [
   "pack-2d-to-4d-by-8x4-blocks.mlir",
   "test_matmul_f16_cuda_mma.mlir",
   "vector-distribution.mlir",
-  "matmul-f32-base.mlir",
-  # FIXME: Enable after landing D121369.
-  "double-tiling.mlir",
-  "tile-interchange.mlir"
+  "matmul-f32-base.mlir"
 ]
 
 config.substitutions.extend([

--- a/test/outline-one-parent-loop.mlir
+++ b/test/outline-one-parent-loop.mlir
@@ -36,7 +36,7 @@ func @matmul(%arg0: tensor<24x48xf32> {linalg.buffer_layout = affine_map<(d0, d1
         %13 = affine.min affine_map<(d0, d1) -> (8, -d0 + d1)>(%arg7, %5)
         %14 = scf.for %arg9 = %c0 to %c16 step %c8 iter_args(%arg10 = %arg8) -> (tensor<?x16xf32>) {
           %15 = tensor.extract_slice %arg10[%arg7, %arg9] [%13, 8] [1, 1] : tensor<?x16xf32> to tensor<?x8xf32>
-          %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<?x8xf32>) -> tensor<?x8xf32> 
+          %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<?x8xf32>) -> tensor<?x8xf32>
           %17 = tensor.insert_slice %16 into %arg10[%arg7, %arg9] [%13, 8] [1, 1] : tensor<?x8xf32> into tensor<?x16xf32>
           scf.yield %17 : tensor<?x16xf32>
         }


### PR DESCRIPTION
- update python fill uses
- reactivate "double-tiling.mlir" and "tile-interchange.mlir"