### PR TITLE
Drop assumption that LinalgTransform must operate on ModuleOp.

### DIFF
--- a/lib/Dialect/LinalgTransform/IR/LinalgTransformOps.cpp
+++ b/lib/Dialect/LinalgTransform/IR/LinalgTransformOps.cpp
@@ -45,6 +45,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/InliningUtils.h"
@@ -138,8 +139,8 @@ LogicalResult transform::SequenceOp::verify() {
 
 LogicalResult transform::MatchOp::apply(TransformResults &results,
                                         TransformState &state) {
-  FailureOr<SmallVector<Operation *>> ops =
-      findMatchingOps(*this, cast<ModuleOp>(state.getTopLevel()));
+  Operation *topLevelOp = state.getTopLevel();
+  FailureOr<SmallVector<Operation *>> ops = findMatchingOps(*this, topLevelOp);
   if (failed(ops))
     return failure();
   LLVM_DEBUG(DBGS() << "matched " << ops->size() << " ops\n");

--- a/lib/Dialect/LinalgTransform/IR/PDL.h
+++ b/lib/Dialect/LinalgTransform/IR/PDL.h
@@ -19,13 +19,15 @@
 namespace mlir {
 namespace linalg {
 
-/// Find all operations in `module` that are matched by the specified PDL
-/// pattern, which is also located in `module`.
-FailureOr<SmallVector<Operation *>>
-findMatchingOps(Operation *op, SymbolRefAttr pattern, ModuleOp module);
+/// Find all operations in `containerOp` that are matched by the specified PDL
+/// `matchOp`, which is located in the same parent ModuleOp as `matchOp`.
+FailureOr<SmallVector<Operation *>> findMatchingOps(transform::MatchOp matchOp,
+                                                    SymbolRefAttr pattern,
+                                                    Operation *containerOp);
+
 inline FailureOr<SmallVector<Operation *>>
-findMatchingOps(transform::MatchOp op, ModuleOp module) {
-  return findMatchingOps(op, op.targetMatcher(), module);
+findMatchingOps(transform::MatchOp matchOp, Operation *containerOp) {
+  return findMatchingOps(matchOp, matchOp.targetMatcher(), containerOp);
 }
 
 } // namespace linalg


### PR DESCRIPTION
This revision generalizes the application of transform dialect operations
to Operation*.
Previously, the implementation was artificially constrained to ModuleOp.
This allows applying the transform dialect as part of IREE passes.