### PR TITLE
Add an option to the transform interpreter to take a transform file (policy).

### DIFF
--- a/test/LinalgTransform/vectorize-transforms.mlir
+++ b/test/LinalgTransform/vectorize-transforms.mlir
@@ -1,0 +1,16 @@
+// This test only checks the content of the file parses.
+// RUN: mlir-proto-opt %s
+
+pdl.pattern @pdl_target : benefit(1) {
+  %args = operands
+  %results = types
+  %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  rewrite %0 with "iree_linalg_transform.apply"
+}
+
+iree_linalg_transform.sequence {
+  %0 = match @pdl_target
+  vectorize %0 {vectorize_padding = true}
+}

--- a/test/LinalgTransform/vectorize.mlir
+++ b/test/LinalgTransform/vectorize.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-proto-opt -linalg-interp-transforms %s | FileCheck %s
+// RUN: mlir-proto-opt -linalg-interp-transforms -linalg-transform-file-name=%p/vectorize-transforms.mlir %s | FileCheck %s
 
 // CHECK-LABEL: func @matmul_tensors(
 // CHECK-SAME:    %[[TA:[0-9a-z]+]]: tensor<128x128xf32>
@@ -18,19 +18,4 @@ func @matmul_tensors(
     -> tensor<128x128xf32>
 
   return %0 : tensor<128x128xf32>
-}
-
-
-pdl.pattern @pdl_target : benefit(1) {
-  %args = operands
-  %results = types
-  %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-  apply_native_constraint "nestedInFunc"[@matmul_tensors](%0 : !pdl.operation)
-  // TODO: we don't want this, but it is the required terminator for pdl.pattern
-  rewrite %0 with "iree_linalg_transform.apply"
-}
-
-iree_linalg_transform.sequence {
-  %0 = match @pdl_target
-  vectorize %0 {vectorize_padding = true}
 }


### PR DESCRIPTION
The transform file is parsed into a top-level ModuleOp which is then used to
drive the application of transformations.