### PR TITLE
Try importing mlir-prefixed before failing in transform dialect bindings

### DIFF
--- a/python/sandbox/dialects/_iree_linalg_transform_ops_ext.py
+++ b/python/sandbox/dialects/_iree_linalg_transform_ops_ext.py
@@ -8,12 +8,16 @@
 # MLIR.
 # pytype: skip-file
 
+from typing import Optional, Sequence, Union
 try:
   from .. import ir
   from ..dialects import pdl
-  from typing import Optional, Sequence, Union
 except ImportError as e:
-  raise RuntimeError("Error loading imports from extension module") from e
+  try:
+    import mlir.ir as ir
+    import mlir.dialects.pdl as pdl
+  except ImportError as e:
+    raise RuntimeError("Error loading imports from extension module") from e
 
 BoolArg = Optional[Union[bool, ir.BoolAttr]]
 IntArg = Optional[Union[int, ir.IntegerAttr]]


### PR DESCRIPTION
This chang make transform dialect usable even if it's invoked in an environment where transform_dialect is not within `mlir` namespace.