### PR TITLE
SQL: prototypes for dialects, frontend and lowering

### DIFF
--- a/.github/workflows/testSQLDialect.yml
+++ b/.github/workflows/testSQLDialect.yml
@@ -1,0 +1,39 @@
+name: SQLDialectTest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Test SQL Dialect
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Checkout project
+      uses: actions/checkout@v2
+      with:
+        path: sandbox
+
+    - name: Install Python depends
+      run: |
+        python -m pip install -r ${GITHUB_WORKSPACE}/sandbox/experimental/sql/requirements.txt
+
+    - name: Check format with yapf
+      run: |
+        # Returns en error code if the files are not formatted
+        yapf --diff -r ${GITHUB_WORKSPACE}/sandbox/experimental/sql
+
+    - name: Test
+      run: |
+        cd ${GITHUB_WORKSPACE}/sandbox
+        lit -v ${GITHUB_WORKSPACE}/sandbox/experimental/sql/test

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ compile_commands.json
 
 # Benchmark dir
 benchmarks/
+
+# lit files
+.lit_test_times.txt
+Output/

--- a/experimental/sql/.style.yapf
+++ b/experimental/sql/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style: google
+indent_width: 2

--- a/experimental/sql/README.md
+++ b/experimental/sql/README.md
@@ -1,1 +1,39 @@
 # Prototype SQL dialect(s)
+
+This folder contains a simple stand-alone project that implements a lowering pipeline from the [ibis frontend](https://ibis-project.org/) to the iterator dialect through [xDSL](https://github.com/xdslproject/xdsl).
+
+## Requirements
+
+To use, first install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Execute a testcase
+
+Run
+
+```bash
+python simple.py
+```
+
+This prints three representations of the query `table.filter(table['a'] == 'AS')`:
+
+- the ibis representation
+- the same representation mirrored in xDSL
+- the query in the relational dialect
+
+## Execute filecheck tests
+
+First, add the path of this subproject to the `PYTHONPATH` environment variable.
+
+```bash
+export PYTHONPATH=$PYHTONPATH:$(git rev-parse --show-toplevel)/experimental/sql
+```
+
+Then run:
+
+```bash
+lit test/
+```

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -1,0 +1,198 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from typing import Any
+from xdsl.ir import Block, Region, Operation, SSAValue, ParametrizedAttribute, Data, MLContext, Attribute
+from xdsl.dialects.builtin import StringAttr, ArrayAttr, ArrayOfConstraint, IntegerAttr
+from xdsl.irdl import AttributeDef, OperandDef, ResultDef, RegionDef, SingleBlockRegionDef, irdl_attr_definition, irdl_op_definition, ParameterDef, AnyAttr, VarOperandDef, builder
+
+# This file define a dialect that mirrors the internal structure of ibis.
+# The file contains an `Attribute` for all types encountered in the simple
+# query. Types are defined as being in defined `ibis/expr/types` in the
+# ibis source repo. All other nodes encountered in this translation are
+# encoded as Operations.
+
+
+@irdl_attr_definition
+class TableExpr(ParametrizedAttribute):
+  name = "ibis.table_expr"
+
+
+@irdl_attr_definition
+class Column(ParametrizedAttribute):
+  name = "ibis.column"
+
+
+@irdl_attr_definition
+class StringColumn(Column):
+  name = "ibis.string_column"
+
+
+@irdl_attr_definition
+class BooleanColumn(Column):
+  name = "ibis.boolean_column"
+
+
+@irdl_attr_definition
+class DataType(ParametrizedAttribute):
+  name = "ibis.datatype"
+
+
+@irdl_attr_definition
+class int32(DataType):
+  name = "ibis.int32"
+
+
+@irdl_attr_definition
+class String(DataType):
+  name = "ibis.String"
+
+  nullable = ParameterDef(IntegerAttr)
+
+  @builder
+  @staticmethod
+  def get(val: int) -> 'String':
+    return String([IntegerAttr.from_int_and_width(val, 1)])
+
+
+@irdl_attr_definition
+class float64(DataType):
+  name = "ibis.float64"
+
+
+@irdl_op_definition
+class TableColumn(Operation):
+  name = "ibis.table_column"
+
+  table = SingleBlockRegionDef()
+  col_name = AttributeDef(StringAttr)
+
+  result = ResultDef(AnyAttr())
+
+  @builder
+  @staticmethod
+  def get(table: Region, col_name: str,
+          result_type: Attribute) -> 'TableColumn':
+    return TableColumn.build(
+        attributes={"col_name": StringAttr.from_str(col_name)},
+        regions=[table],
+        result_types=[result_type])
+
+
+@irdl_op_definition
+class Selection(Operation):
+  name = "ibis.selection"
+
+  table = SingleBlockRegionDef()
+  predicates = SingleBlockRegionDef()
+
+  result = ResultDef(TableExpr)
+
+  @staticmethod
+  @builder
+  def get(table: Region, predicates: Region) -> 'Selection':
+    return Selection.build(regions=[table, predicates],
+                           result_types=[TableExpr()])
+
+
+@irdl_op_definition
+class Equals(Operation):
+  name = "ibis.equals"
+
+  left = SingleBlockRegionDef()
+  right = SingleBlockRegionDef()
+
+  result = ResultDef(BooleanColumn)
+
+  @builder
+  @staticmethod
+  def get(left: Region, right: Region) -> 'Equals':
+    return Equals.build(regions=[left, right], result_types=[BooleanColumn()])
+
+
+@irdl_op_definition
+class PandasTable(Operation):
+  name = "ibis.pandas_table"
+
+  table_name = AttributeDef(StringAttr)
+  schema = SingleBlockRegionDef()
+  result = ResultDef(TableExpr)
+
+  @staticmethod
+  @builder
+  def get(name: str, Schema: Region) -> 'PandasTable':
+    return PandasTable.build(
+        attributes={"table_name": StringAttr.from_str(name)},
+        regions=[Schema],
+        result_types=[TableExpr()])
+
+
+@irdl_op_definition
+class SchemaElement(Operation):
+  name = "ibis.schema_element"
+
+  elt_name = AttributeDef(StringAttr)
+  elt_type = AttributeDef(DataType)
+
+  @staticmethod
+  def get(name: str, type: DataType):
+    return SchemaElement.build(attributes={
+        "elt_name": StringAttr.from_str(name),
+        "elt_type": type
+    })
+
+
+@irdl_op_definition
+class Literal(Operation):
+  name = "ibis.literal"
+
+  val = AttributeDef(AnyAttr())
+  type = AttributeDef(DataType)
+
+  result = ResultDef(DataType)
+
+  @builder
+  @staticmethod
+  def get(val: Attribute, type: DataType) -> 'Literal':
+    return Literal.build(attributes={
+        "val": val,
+        "type": type
+    },
+                         result_types=[type])
+
+
+@irdl_op_definition
+class Yield(Operation):
+  name = "ibis.yield"
+
+  returns = VarOperandDef(AnyAttr())
+
+  @staticmethod
+  @builder
+  def get(ops: list[Operation]) -> 'Yield':
+    return Yield.build(operands=[ops])
+
+
+@dataclass
+class Ibis:
+  ctx: MLContext
+
+  def __post_init__(self: 'Ibis'):
+    self.ctx.register_attr(TableExpr)
+    self.ctx.register_attr(Column)
+    self.ctx.register_attr(StringColumn)
+    self.ctx.register_attr(BooleanColumn)
+    self.ctx.register_attr(DataType)
+    self.ctx.register_attr(String)
+    self.ctx.register_attr(int32)
+    self.ctx.register_attr(float64)
+
+    self.ctx.register_op(PandasTable)
+    self.ctx.register_op(SchemaElement)
+    self.ctx.register_op(Selection)
+    self.ctx.register_op(Equals)
+    self.ctx.register_op(TableColumn)
+    self.ctx.register_op(Literal)
+    self.ctx.register_op(Yield)

--- a/experimental/sql/dialects/relational_dialect.py
+++ b/experimental/sql/dialects/relational_dialect.py
@@ -1,0 +1,164 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from typing import Any
+from xdsl.ir import Block, Region, Operation, SSAValue, ParametrizedAttribute, Data, MLContext, Attribute
+from xdsl.dialects.builtin import StringAttr, ArrayAttr, ArrayOfConstraint, IntegerAttr
+from xdsl.irdl import AttributeDef, OperandDef, ResultDef, RegionDef, SingleBlockRegionDef, irdl_attr_definition, irdl_op_definition, ParameterDef, AnyAttr, VarOperandDef, builder
+
+# This file contains the relational dialect. It is currently
+# only aimed at the simple query and mirrors a lot of the
+# ibis dialect. This is subject to change, once the translation
+# to the iterator dialect starts getting in shape.
+
+
+@irdl_attr_definition
+class DataType(ParametrizedAttribute):
+  name = "rel.datatype"
+
+
+@irdl_attr_definition
+class Int32(DataType):
+  name = "rel.int32"
+
+
+@irdl_attr_definition
+class String(DataType):
+  name = "rel.string"
+
+  nullable = ParameterDef(IntegerAttr)
+
+  @staticmethod
+  @builder
+  def get(val: int) -> 'String':
+    return String([IntegerAttr.from_int_and_width(val, 1)])
+
+
+@irdl_attr_definition
+class Float64(DataType):
+  name = "rel.float64"
+
+
+@irdl_attr_definition
+class Bag(ParametrizedAttribute):
+  name = "rel.bag"
+
+
+@irdl_attr_definition
+class Column(ParametrizedAttribute):
+  name = "rel.column"
+
+
+@irdl_op_definition
+class Equals(Operation):
+  name = "rel.equals"
+
+  table = OperandDef(Bag)
+  column = AttributeDef(StringAttr)
+  comparator = OperandDef(AnyAttr())
+
+  result = ResultDef(Column())
+
+  @staticmethod
+  @builder
+  def get(table: Operation, column: StringAttr,
+          comparator: Operation) -> 'Equals':
+    return Equals.build(operands=[table, comparator],
+                        attributes={"column": column},
+                        result_types=[Column()])
+
+
+@irdl_op_definition
+class PandasTable(Operation):
+  name = "rel.pandas_table"
+
+  table_name = AttributeDef(StringAttr)
+  schema = SingleBlockRegionDef()
+  result = ResultDef(Bag)
+
+  @staticmethod
+  @builder
+  def get(name: str, Schema: Region, result_type: Attribute) -> 'PandasTable':
+    return PandasTable.build(
+        attributes={"table_name": StringAttr.from_str(name)},
+        regions=[Schema],
+        result_types=[result_type])
+
+
+@irdl_op_definition
+class SchemaElement(Operation):
+  name = "rel.schema_element"
+
+  elt_name = AttributeDef(StringAttr)
+  elt_type = AttributeDef(DataType)
+
+  @staticmethod
+  def get(name: str, type: DataType):
+    return SchemaElement.build(attributes={
+        "elt_name": StringAttr.from_str(name),
+        "elt_type": type
+    })
+
+
+@irdl_op_definition
+class Selection(Operation):
+  name = "rel.selection"
+
+  parent_ = OperandDef(Bag)
+  predicates = SingleBlockRegionDef()
+
+  result = ResultDef(Bag)
+
+  @builder
+  @staticmethod
+  def get(table: Operation, predicates: Region) -> 'Selection':
+    return Selection.build(operands=[table],
+                           regions=[predicates],
+                           result_types=[Bag()])
+
+
+@irdl_op_definition
+class Yield(Operation):
+  name = "rel.yield"
+
+  ops = VarOperandDef(AnyAttr())
+
+  @staticmethod
+  @builder
+  def get(ops: list[Operation]) -> 'Yield':
+    return Yield.build(operands=[ops])
+
+
+@irdl_op_definition
+class Literal(Operation):
+  name = "rel.literal"
+
+  # TODO: change IntegerAttr s.t. it can have type !rel.int32
+  value = AttributeDef(AnyAttr())
+  result = ResultDef(DataType)
+
+  @staticmethod
+  @builder
+  def get(val: Attribute, res: DataType) -> 'Literal':
+    return Literal.build(attributes={"value": val}, result_types=[res])
+
+
+@dataclass
+class Relational:
+  ctx: MLContext
+
+  def __post_init__(self: 'Relational'):
+    self.ctx.register_attr(Bag)
+    self.ctx.register_attr(DataType)
+    self.ctx.register_attr(Int32)
+    self.ctx.register_attr(Float64)
+    self.ctx.register_attr(String)
+    self.ctx.register_attr(Column)
+
+    self.ctx.register_op(Selection)
+    self.ctx.register_op(PandasTable)
+    self.ctx.register_op(SchemaElement)
+    self.ctx.register_op(Literal)
+    self.ctx.register_op(Equals)

--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -1,0 +1,9 @@
+filecheck==0.0.18
+lit==14.0.0
+pytest==6.2.5
+xdsl==0.4.1
+yapf==0.32.0
+pyright==0.0.13
+frozenlist==1.2.*
+psutil==5.9.0
+ibis-framework==2.1.1

--- a/experimental/sql/simple.py
+++ b/experimental/sql/simple.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This file contains a simple testcase, that defines a table and runs a selection query on it.
+
+import ibis
+import os
+import sys
+
+import pandas as pd
+
+from xdsl.ir import MLContext
+from xdsl.printer import Printer
+from src.ibis_frontend import ibis_to_xdsl
+from src.ibis_to_rel import ibis_dialect_to_relational
+
+connection = ibis.pandas.connect({"t": pd.DataFrame({"a": ["AS", "EU", "NA"]})})
+
+# Get the table.
+table = connection.table('t')
+
+# Define the query.
+query = table.filter(table['a'] == 'AS')
+print('Ibis AST: ' + '-' * 60)
+print(query)
+
+# Define an xDSL printer (xdsl needs a Printer class to print since printing requires keeping state).
+p = Printer()
+
+# Define a MLContext, which keeps track of which operations are registered.
+ctx = MLContext()
+
+# Translate the query to the xDSL mirrored dialect.
+xdsl_query = ibis_to_xdsl(ctx, query)
+xdsl_query.verify()
+print('Ibis dialect: ' + '-' * 60)
+p.print_op(xdsl_query)
+
+# Rewriter the query to the relational dialect.
+ibis_dialect_to_relational(ctx, xdsl_query)
+
+print('Relational dialect: ' + '-' * 60)
+p.print_op(xdsl_query)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -1,0 +1,116 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from modulefinder import Module
+from unittest import result
+from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr
+from xdsl.ir import Operation, MLContext, Region, Block
+from typing import List, Type, Optional
+
+import ibis
+import ibis.expr.types
+import ibis.expr.datatypes
+import ibis.expr.operations.relations as rels
+import ibis.expr.operations.generic as gen_types
+from ibis.expr.operations.logical import Equals as EQ
+import ibis.backends.pandas.client as PandasBackend
+
+import dialects.ibis_dialect as id
+
+# This file contains the translation from ibis to the ibis_dialect.
+# It is built in a visitor-style, as this is one of the best designs
+# to crawl trees in my experience. The entry-point is the `visit`-
+# function just below. It dispatches to the appropriate translator.
+
+
+@dataclass
+class NodeVisitor:
+  ctx: MLContext
+
+  def visit(self, node: ibis.expr.types.Expr) -> List[Operation]:
+    if isinstance(node, ibis.expr.types.TableExpr):
+      return self.visit_TableExpr(node)
+    if isinstance(node, ibis.expr.types.StringColumn):
+      return self.visit_StringColumn(node)
+    if isinstance(node, ibis.expr.types.BooleanColumn):
+      return self.visit_BooleanColumn(node)
+    if isinstance(node, ibis.expr.types.StringScalar):
+      return self.visit_StringScalar(node)
+    raise KeyError(f"Unknown nodetype {type(node)}")
+
+  def convert_datatype(self, type_: ibis.expr.datatypes) -> id.DataType:
+    if isinstance(type_, ibis.expr.datatypes.String):
+      return id.String.get(1 if type_.nullable else 0)
+    if isinstance(type_, ibis.expr.datatypes.Int32):
+      return id.int32()
+    if isinstance(type_, ibis.expr.datatypes.Float64):
+      return id.float64()
+    raise KeyError(f"Unknown datatype: {type(type_)}")
+
+  def visit_Schema(self, schema: ibis.expr.schema.Schema) -> Region:
+    ops = []
+    for n, t in zip(schema.names, schema.types):
+      ops.append(id.SchemaElement.get(n, self.convert_datatype(t)))
+    return Region.from_operation_list(ops)
+
+  def visit_TableExpr(self,
+                      table: ibis.expr.types.TableExpr) -> List[Operation]:
+    op = table.op()
+    if isinstance(op, PandasBackend.PandasTable):
+      schema = self.visit_Schema(op.schema)
+      new_op = id.PandasTable.get(op.name, schema)
+      yield_op = id.Yield.get([new_op])
+      return [new_op, yield_op]
+    if isinstance(op, rels.Selection):
+      table = Region.from_operation_list(self.visit(op.table))
+      # TODO: handle mulitple predicates
+      predicates = Region.from_operation_list(self.visit(op.predicates[0]))
+      new_op = id.Selection.get(table, predicates)
+      yield_op = id.Yield.get([new_op])
+      return [new_op, yield_op]
+    raise KeyError(f"Unknown tableExpr: {type(op)}")
+
+  def visit_StringColumn(
+      self, stringColumn: ibis.expr.types.StringColumn) -> List[Operation]:
+    op = stringColumn.op()
+    if isinstance(op, gen_types.TableColumn):
+      table = Region.from_operation_list(self.visit(op.table))
+      new_op = id.TableColumn.get(table, op.name, id.StringColumn())
+      yield_op = id.Yield.get([new_op])
+      return [new_op, yield_op]
+    raise Exception(f"Unknown stringcolumn: {type(op)}")
+
+  def visit_BooleanColumn(
+      self, stringColumn: ibis.expr.types.BooleanColumn) -> List[Operation]:
+    op = stringColumn.op()
+    if isinstance(op, gen_types.TableColumn):
+      reg = Region.from_operation_list(self.visit(op.table))
+      return [
+          id.TableColumn.build(
+              attributes={"col_name": StringAttr.from_str(op.name)},
+              regions=[reg])
+      ]
+    if isinstance(op, EQ):
+      left_reg = Region.from_operation_list(self.visit(op.left))
+      right_reg = Region.from_operation_list(self.visit(op.right))
+      new_op = id.Equals.get(left_reg, right_reg)
+      yield_op = id.Yield.get([new_op])
+      return [new_op, yield_op]
+    raise Exception(f"Unknown booleancolumn: {type(op)}")
+
+  def visit_StringScalar(
+      self, strScalar: ibis.expr.types.StringScalar) -> List[Operation]:
+    op = strScalar.op()
+    if isinstance(op, gen_types.Literal):
+      new_op = id.Literal.get(StringAttr.from_str(op.value),
+                              self.convert_datatype(op.dtype))
+      yield_op = id.Yield.get([new_op])
+      return [new_op, yield_op]
+    raise Exception(f"Unknown stringscalar: {type(op)}")
+
+
+def ibis_to_xdsl(ctx: MLContext, query: ibis.expr.types.Expr) -> ModuleOp:
+  return ModuleOp.build(
+      regions=[Region.from_operation_list(NodeVisitor(ctx).visit(query))])

--- a/experimental/sql/src/ibis_to_rel.py
+++ b/experimental/sql/src/ibis_to_rel.py
@@ -1,0 +1,120 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp
+from xdsl.ir import Operation, MLContext, Region, Block
+from typing import List, Type, Optional
+
+from xdsl.pattern_rewriter import RewritePattern, GreedyRewritePatternApplier, PatternRewriteWalker, PatternRewriter, op_type_rewrite_pattern
+import dialects.ibis_dialect as id
+import dialects.relational_dialect as rel
+
+# This file contains the translation from the ibis_dialect to
+# the relational dialect. As both live within xDSL, I am applying
+# the RewriteEngine definedby xDSL. Simply put, there is (line 86) a
+# RewriterWalker that takes a GreedyRewriteApplier that takes a list
+# of RewritePatterns. Each RewritePattern defines a match_and_rewrite
+# function. The rewrite functions I apply here are defined on the type
+# defined in the function declaration. The Patterns are applied to each
+# Node.
+
+
+@dataclass
+class IbisRewriter(RewritePattern):
+
+  def convert_datatype(self, type_: id.DataType) -> rel.DataType:
+    if isinstance(type_, id.String):
+      return rel.String.get(type_.nullable.parameters[0].data)
+    raise Exception(
+        f"datatype conversion not yet implemented for {type(type_)}")
+
+
+@dataclass
+class TableRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: id.PandasTable, rewriter: PatternRewriter):
+    new_op = rel.PandasTable.build(
+        regions=[rewriter.move_region_contents_to_new_regions(op.schema)],
+        attributes={"table_name": op.table_name},
+        result_types=[rel.Bag()])
+    rewriter.replace_matched_op(new_op)
+
+
+@dataclass
+class SchemaElementRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: id.SchemaElement, rewriter: PatternRewriter):
+    new_op = rel.SchemaElement.build(attributes={
+        "elt_name": op.elt_name,
+        "elt_type": self.convert_datatype(op.elt_type)
+    })
+    rewriter.replace_matched_op(new_op)
+
+
+@dataclass
+class TableColumnRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: id.TableColumn, rewriter: PatternRewriter):
+    rewriter.inline_block_before_matched_op(op.table.blocks[0])
+    rewriter.erase_matched_op()
+
+
+@dataclass
+class SelectionRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: id.Selection, rewriter: PatternRewriter):
+    rewriter.inline_block_before_matched_op(op.table.blocks[0])
+    new_op = rel.Selection.get(
+        op.parent_block().ops[0],
+        rewriter.move_region_contents_to_new_regions(op.predicates))
+    rewriter.replace_matched_op([new_op])
+
+
+@dataclass
+class EqualsRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: id.Equals, rewriter: PatternRewriter):
+    rewriter.inline_block_before_matched_op(op.right.blocks[0])
+    new_op = rel.Equals.get(op.parent_op().operands[0],
+                            op.left.blocks[0].ops[0].col_name,
+                            op.parent_block().ops[0])
+    rewriter.replace_matched_op([new_op])
+
+
+@dataclass
+class YieldRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: id.Yield, rewriter: PatternRewriter):
+    rewriter.erase_matched_op()
+
+
+@dataclass
+class LiteralRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: id.Literal, rewriter: PatternRewriter):
+    new_op = rel.Literal.get(op.val, self.convert_datatype(op.type))
+    rewriter.replace_matched_op([new_op])
+
+
+def ibis_dialect_to_relational(ctx: MLContext, query: ModuleOp):
+  walker = PatternRewriteWalker(GreedyRewritePatternApplier([
+      TableRewriter(),
+      SchemaElementRewriter(),
+      SelectionRewriter(),
+      EqualsRewriter(),
+      LiteralRewriter(),
+      YieldRewriter()
+  ]),
+                                walk_regions_first=False,
+                                apply_recursively=True,
+                                walk_reverse=True)
+  walker.rewrite_module(query)

--- a/experimental/sql/test/end-to-end/selection.ibis
+++ b/experimental/sql/test/end-to-end/selection.ibis
@@ -1,0 +1,5 @@
+# RUN: rel_opt.py -f ibis -p ibis-dialect-to-relational %s | filecheck %s
+
+table.filter(table['a'] == 'AS')
+
+# CHECK: module() {

--- a/experimental/sql/test/frontend/selection.ibis
+++ b/experimental/sql/test/frontend/selection.ibis
@@ -1,0 +1,5 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table.filter(table['a'] == 'AS')
+
+# CHECK: module() {

--- a/experimental/sql/test/lit.cfg
+++ b/experimental/sql/test/lit.cfg
@@ -1,0 +1,27 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import lit.formats
+import os
+
+config.name = "Relation"
+config.test_format = lit.formats.ShTest(execute_external=True)
+config.suffixes = ['.ibis', '.xdsl']
+
+config.test_source_root = os.path.dirname(__file__)
+
+if "PYTHONPATH" in os.environ.keys():
+  config.environment[
+      "PYTHONPATH"] = config.test_source_root + "/../:" + os.environ[
+          "PYTHONPATH"]
+else:
+  config.environment["PYTHONPATH"] = config.test_source_root + "/../"
+
+config.environment[
+    "PATH"] = config.test_source_root + "/../tools/:" + os.environ["PATH"]
+
+config.available_features = []
+
+if sys.version_info[0] == 3 and sys.version_info[1] == 8:
+  config.available_features.append('python38')

--- a/experimental/sql/test/relational_dialect_tests/equals_op.xdsl
+++ b/experimental/sql/test/relational_dialect_tests/equals_op.xdsl
@@ -1,0 +1,15 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+    %0 : !rel.bag = rel.pandas_table() ["table_name" = "some_name"] {
+        rel.schema_element() ["elt_name" = "id", "elt_type" = !rel.int32]
+    }
+    %1 : !rel.int32 = rel.literal() ["value" = 5 : !i32]
+    %2 : !rel.column = rel.equals(%0 : !rel.bag, %1 : !rel.int32) ["column" = "id"]
+}
+
+// CHECK:  %{{.*}} : !rel.bag = rel.pandas_table() ["table_name" = "some_name"] {
+// CHECK-NEXT:        rel.schema_element() ["elt_name" = "id", "elt_type" = !rel.int32]
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %{{.*}} : !rel.int32 = rel.literal() ["value" = 5 : !i32]
+// CHECK-NEXT:    %{{.*}} : !rel.column = rel.equals(%{{.*}} : !rel.bag, %{{.*}} : !rel.int32) ["column" = "id"] 

--- a/experimental/sql/test/relational_dialect_tests/literal_op.xdsl
+++ b/experimental/sql/test/relational_dialect_tests/literal_op.xdsl
@@ -1,0 +1,7 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+    %0 : !rel.int32 = rel.literal() ["value" = 5 : !i32]
+}
+
+// CHECK:   %{{.*}} : !rel.int32 = rel.literal() ["value" = 5 : !i32] 

--- a/experimental/sql/test/relational_dialect_tests/schema_element_op.xdsl
+++ b/experimental/sql/test/relational_dialect_tests/schema_element_op.xdsl
@@ -1,0 +1,15 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+    rel.schema_element() ["elt_name" = "id", "elt_type" = !rel.int32]
+    rel.schema_element() ["elt_name" = "name", "elt_type" = !rel.string<0 : !i1>]
+    rel.schema_element() ["elt_name" = "nullable_name", "elt_type" = !rel.string<1 : !i1>]
+    rel.schema_element() ["elt_name" = "distance", "elt_type" = !rel.float64]
+    rel.schema_element() ["elt_name" = "data", "elt_type" = !rel.datatype]
+}
+
+// CHECK:    rel.schema_element() ["elt_name" = "id", "elt_type" = !rel.int32]
+// CHECK-NEXT:    rel.schema_element() ["elt_name" = "name", "elt_type" = !rel.string<0 : !i1>]
+// CHECK-NEXT:    rel.schema_element() ["elt_name" = "nullable_name", "elt_type" = !rel.string<1 : !i1>]
+// CHECK-NEXT:    rel.schema_element() ["elt_name" = "distance", "elt_type" = !rel.float64]
+// CHECK-NEXT:    rel.schema_element() ["elt_name" = "data", "elt_type" = !rel.datatype]

--- a/experimental/sql/test/relational_dialect_tests/selection_op.xdsl
+++ b/experimental/sql/test/relational_dialect_tests/selection_op.xdsl
@@ -1,0 +1,19 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+    %0 : !rel.bag = rel.pandas_table() ["table_name" = "some_name"] {
+        rel.schema_element() ["elt_name" = "id", "elt_type" = !rel.int32]
+    }
+    %1 : !rel.bag = rel.selection(%0 : !rel.bag) {
+        %2 : !rel.int32 = rel.literal() ["value" = 5 : !i32]
+        %3 : !rel.column = rel.equals(%0 : !rel.bag, %2 : !rel.int32) ["column" = "id"]
+    }
+}
+
+// CHECK: %{{.*}} : !rel.bag = rel.pandas_table() ["table_name" = "some_name"] {
+// CHECK-NEXT:        rel.schema_element() ["elt_name" = "id", "elt_type" = !rel.int32]
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %{{.*}} : !rel.bag = rel.selection(%0 : !rel.bag) {
+// CHECK-NEXT:        %{{.*}} : !rel.int32 = rel.literal() ["value" = 5 : !i32]
+// CHECK-NEXT:        %{{.*}} : !rel.column = rel.equals(%{{.*}} : !rel.bag, %{{.*}} : !rel.int32) ["column" = "id"]
+// CHECK-NEXT:    } 

--- a/experimental/sql/test/relational_dialect_tests/table_op.xdsl
+++ b/experimental/sql/test/relational_dialect_tests/table_op.xdsl
@@ -1,0 +1,11 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+    %0 : !rel.bag = rel.pandas_table() ["table_name" = "some_name"] {
+        rel.schema_element() ["elt_name" = "id", "elt_type" = !rel.int32]
+    }
+}
+
+// CHECK: %{{.*}} : !rel.bag = rel.pandas_table() ["table_name" = "some_name"] {
+// CHECK-NEXT:    rel.schema_element() ["elt_name" = "id", "elt_type" = !rel.int32]
+// CHECK-Next: }

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import argparse
+from xdsl.ir import MLContext
+from xdsl.dialects.builtin import ModuleOp
+from typing import Callable, Dict, List
+from xdsl.xdsl_opt_main import xDSLOptMain
+from io import IOBase
+
+from src.ibis_frontend import ibis_to_xdsl
+from src.ibis_to_rel import ibis_dialect_to_relational
+from dialects.ibis_dialect import Ibis
+from dialects.relational_dialect import Relational
+
+
+class RelOptMain(xDSLOptMain):
+
+  def register_all_passes(self):
+    self.available_passes[
+        'ibis-dialect-to-relational'] = ibis_dialect_to_relational
+
+  def register_all_frontends(self):
+    super().register_all_frontends()
+
+    def parse_ibis(f: IOBase):
+      import ibis
+      import pandas as pd
+
+      connection = ibis.pandas.connect(
+          {"t": pd.DataFrame({"a": ["AS", "EU", "NA"]})})
+      table = connection.table('t')
+      f.readline()
+      f.readline()
+      query = f.readline()
+      res = eval(query)
+
+      return ibis_to_xdsl(self.ctx, res)
+
+    self.available_frontends['ibis'] = parse_ibis
+
+  def register_all_dialects(self):
+    super().register_all_dialects()
+    """Register all dialects that can be used."""
+    ibis = Ibis(self.ctx)
+    rel = Relational(self.ctx)
+
+
+def __main__():
+  rel_main = RelOptMain()
+  try:
+    module = rel_main.parse_input()
+    rel_main.apply_passes(module)
+  except Exception as e:
+    print(e)
+    exit(0)
+
+  contents = rel_main.output_resulting_program(module)
+  rel_main.print_to_output_stream(contents)
+
+
+if __name__ == "__main__":
+  __main__()


### PR DESCRIPTION
This PR adds the following:
1. a dialect that mirrors the ibis datastructures
2. a dialect for relational algebra
3. a frontend for ibis to ibis dialect conversion
4. a lowering for a simple query from the ibis dialect to the relational dialect

The only really working query currently is `table.filter(table['a'] == 'AS')`. This is one of the examples of the ibis user guide.