### PR TITLE
Iterators: Address review to #406.

### DIFF
--- a/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
@@ -16,7 +16,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/ScopedPrinter.h" // XXX
 
 #include <memory>
 
@@ -30,7 +29,7 @@ struct ConvertIteratorsToStandardPass
 };
 } // namespace
 
-/// Maps IteratorType to llvm.ptr<i8>
+/// Maps IteratorType to llvm.ptr<i8>.
 class IteratorsTypeConverter : public TypeConverter {
 public:
   IteratorsTypeConverter() {
@@ -38,6 +37,8 @@ public:
     addConversion(convertIteratorType);
   }
 
+private:
+  /// Maps IteratorType to llvm.ptr<i8>.
   static Optional<Type> convertIteratorType(Type type) {
     if (type.isa<iterators::IteratorType>())
       return LLVM::LLVMPointerType::get(IntegerType::get(type.getContext(), 8));
@@ -46,19 +47,19 @@ public:
 };
 
 /// Returns or creates a function declaration at the module of the provided
-/// original op,
+/// original op.
 FuncOp lookupOrCreateFuncOp(llvm::StringRef fnName, FunctionType fnType,
                             Operation *op, PatternRewriter &rewriter) {
   ModuleOp module = op->getParentOfType<ModuleOp>();
+  assert(module);
 
-  // Return function if already declared
+  // Return function if already declared.
   if (FuncOp funcOp = module.lookupSymbol<mlir::FuncOp>(fnName))
     return funcOp;
 
-  // Add new declaration at the end of the module
+  // Add new declaration at the start of the module.
   OpBuilder::InsertionGuard guard(rewriter);
-  rewriter.setInsertionPoint(module.getBody(),
-                             std::prev(module.getBody()->end()));
+  rewriter.setInsertionPointToStart(module.getBody());
   FuncOp funcOp = rewriter.create<FuncOp>(op->getLoc(), fnName, fnType);
   funcOp.setPrivate();
   return funcOp;
@@ -78,7 +79,7 @@ struct IteratorConversionPattern : public ConversionPattern {
   LogicalResult
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    // Convert result types
+    // Convert result types.
     llvm::SmallVector<Type, 4> resultTypes;
     if (typeConverter->convertTypes(op->getResultTypes(), resultTypes).failed())
       return failure();
@@ -87,33 +88,35 @@ struct IteratorConversionPattern : public ConversionPattern {
 
     // Constructor (aka "iteratorsMake*Operator")
 
-    // Look up or declare function symbol
+    // Look up or declare function symbol.
     auto const fnType =
         FunctionType::get(getContext(), TypeRange(operands), resultTypes);
     FuncOp funcOp = lookupOrCreateFuncOp(constructorName, fnType, op, rewriter);
 
-    // Replace op with call to function
+    // Replace op with call to function.
     func::CallOp callOp =
         rewriter.replaceOpWithNewOp<func::CallOp>(op, funcOp, operands);
 
     // Destructor (aka "iteratorsDestroy*Operator")
 
-    // No destructor necessary for sinks
+    // No destructor necessary for sinks.
     if (resultTypes.empty())
       return success();
     assert(resultTypes.size() == 1);
 
     {
       Value result = callOp.getResult(0);
-      assert(result.use_empty() && "It is not allowed to return an iterator.");
+      assert(result.use_empty() &&
+             "Values of type Iterator cannot outlive their consumers, so "
+             "functions are not allowed to return them.");
 
-      // Look up or declare function symbol
+      // Look up or declare function symbol.
       auto const fnType =
           FunctionType::get(getContext(), TypeRange(resultTypes), TypeRange());
       FuncOp funcOp =
           lookupOrCreateFuncOp(destructorName, fnType, op, rewriter);
 
-      // Add call to destructor to the end of the block
+      // Add call to destructor to the end of the block.
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(callOp->getBlock()->getTerminator());
       rewriter.create<func::CallOp>(op->getLoc(), funcOp, result);

--- a/experimental/iterators/test/Conversion/IteratorsToStandard/iterators-to-standard.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToStandard/iterators-to-standard.mlir
@@ -1,24 +1,24 @@
 // RUN: mlir-proto-opt %s -convert-iterators-to-std \
 // RUN: | FileCheck %s
 
-func @main() {
-  %input = "iterators.sampleInput"() : () -> (!iterators.iterator<tuple<i32>>)
-  %reduce = "iterators.reduce"(%input) : (!iterators.iterator<tuple<i32>>) -> (!iterators.iterator<tuple<i32>>)
-  "iterators.sink"(%reduce) : (!iterators.iterator<tuple<i32>>) -> ()
-  return
-}
 // CHECK:      module {
-// CHECK-NEXT:   func private @iteratorsMakeSampleInputOperator() -> !llvm.ptr<i8>
-// CHECK-NEXT:   func private @iteratorsDestroySampleInputOperator(!llvm.ptr<i8>)
-// CHECK-NEXT:   func private @iteratorsMakeReduceOperator(!llvm.ptr<i8>) -> !llvm.ptr<i8>
-// CHECK-NEXT:   func private @iteratorsDestroyReduceOperator(!llvm.ptr<i8>)
 // CHECK-NEXT:   func private @iteratorsComsumeAndPrint(!llvm.ptr<i8>)
+// CHECK-NEXT:   func private @iteratorsDestroyReduceOperator(!llvm.ptr<i8>)
+// CHECK-NEXT:   func private @iteratorsMakeReduceOperator(!llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK-NEXT:   func private @iteratorsDestroySampleInputOperator(!llvm.ptr<i8>)
+// CHECK-NEXT:   func private @iteratorsMakeSampleInputOperator() -> !llvm.ptr<i8>
+func @main() {
 // CHECK-NEXT:   func @main() {
-// CHECK-NEXT:     %0 = call @iteratorsMakeSampleInputOperator() : () -> !llvm.ptr<i8>
-// CHECK-NEXT:     %1 = call @iteratorsMakeReduceOperator(%0) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
-// CHECK-NEXT:     call @iteratorsComsumeAndPrint(%1) : (!llvm.ptr<i8>) -> ()
-// CHECK-NEXT:     call @iteratorsDestroySampleInputOperator(%0) : (!llvm.ptr<i8>) -> ()
-// CHECK-NEXT:     call @iteratorsDestroyReduceOperator(%1) : (!llvm.ptr<i8>) -> ()
+  %input = "iterators.sampleInput"() : () -> (!iterators.iterator<tuple<i32>>)
+// CHECK-NEXT:     %[[V0:.*]] = call @iteratorsMakeSampleInputOperator() : () -> !llvm.ptr<i8>
+  %reduce = "iterators.reduce"(%input) : (!iterators.iterator<tuple<i32>>) -> (!iterators.iterator<tuple<i32>>)
+// CHECK-NEXT:     %[[V1:.*]] = call @iteratorsMakeReduceOperator(%[[V0]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
+  "iterators.sink"(%reduce) : (!iterators.iterator<tuple<i32>>) -> ()
+// CHECK-NEXT:     call @iteratorsComsumeAndPrint(%[[V1]]) : (!llvm.ptr<i8>) -> ()
+  return
+// CHECK-NEXT:     call @iteratorsDestroySampleInputOperator(%[[V0]]) : (!llvm.ptr<i8>) -> ()
+// CHECK-NEXT:     call @iteratorsDestroyReduceOperator(%[[V1]]) : (!llvm.ptr<i8>) -> ()
 // CHECK-NEXT:     return
+}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }


### PR DESCRIPTION
I accidentally merged #406 before the review was complete, so this
commit addresses the issues raised in that review:

* Do not use SSA value names in CHECK but bind their name with [[]].
* Interleave CHECKs with original code (where possible).
* Add periods to one-line comments.
* Check for empty ModuleOp.
* Use setInsertionPointToStart (and reorder CHECKs accordingly).
* Improve assertion message.
* Nits.