### PR TITLE
Add support for non-string padding values.

### DIFF
--- a/include/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/include/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -201,7 +201,7 @@ def PadOp : Linalg_Transform_Operation<"pad",
   using the options provides as operation attributes.}];
 
   let arguments = (ins PDL_Operation:$target,
-                   DefaultValuedAttr<StrArrayAttr, "{}">:$padding_values,
+                   DefaultValuedAttr<ArrayAttr, "{}">:$padding_values,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$padding_dimensions,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$pack_paddings,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$hoist_paddings,
@@ -281,7 +281,7 @@ def LowerToLLVMOp : Transform_Op<"lower_to_llvm"> {
 }
 
 def GetParentLoopOp : Linalg_Transform_Operation<"get_parent_loop", [
-    TransformOpInterface, 
+    TransformOpInterface,
     TargetableSingleOperandTransformOpTrait
   ]> {
   let description = [{Obtains a handle to a parent loop of the given
@@ -300,7 +300,7 @@ def GetParentLoopOp : Linalg_Transform_Operation<"get_parent_loop", [
 }
 
 def UnrollLoopOp : Linalg_Transform_Operation<"unroll_loop", [
-    TransformOpInterface, 
+    TransformOpInterface,
     TargetableSingleOperandTransformOpTrait
   ]> {
   let description = [{Unrolls the given loop with the given unroll factor.}];
@@ -354,7 +354,7 @@ def OutlineLoopOp : Linalg_Transform_Operation<"outline_loop", [
   let assemblyFormat = "$target attr-dict";
 }
 
-def PrintOp : Transform_Op<"print", [ 
+def PrintOp : Transform_Op<"print", [
     DeclareOpInterfaceMethods<TransformOpInterface, ["apply"]>
   ]> {
   let arguments = (ins Optional<PDL_Operation>:$target,
@@ -367,7 +367,7 @@ def PrintOp : Transform_Op<"print", [
 // LinalgExt specific transforms
 //===----------------------------------------------------------------------===//
 
-def TileToLinalgExtTileOp : 
+def TileToLinalgExtTileOp :
     Linalg_Transform_Operation<"tile_to_iree_linalg_ext_tile_op", [
       DeclareOpInterfaceMethods<TransformOpInterface, ["apply"]>
     ]> {

--- a/test/Dialect/linalg_transform/double-tiling.mlir
+++ b/test/Dialect/linalg_transform/double-tiling.mlir
@@ -39,6 +39,6 @@ iree_linalg_transform.sequence {
   %0 = match @pdl_target
   %1, %loops1:3 = tile %0 {interchange = [0, 2, 1], sizes = [32, 32, 32]}
   %2, %loops2:3 = tile %1 {interchange = [0, 1, 2], sizes = [4, 4, 1]}
-  %3 = pad %2 {padding_values=["0.0", "0.0", "0.0"], pack_paddings = [1, 1, 1], hoist_paddings = [6, 6, 0], transpose_paddings = [[1, 0], [0, 1]]}
+  %3 = pad %2 {padding_values=[0.0 : f32, 0.0 : f32, 0.0 : f32], pack_paddings = [1, 1, 1], hoist_paddings = [6, 6, 0], transpose_paddings = [[1, 0], [0, 1]]}
   %4 = vectorize %3  {vectorize_padding = true}
 }

--- a/test/Dialect/linalg_transform/pad.mlir
+++ b/test/Dialect/linalg_transform/pad.mlir
@@ -44,5 +44,5 @@ pdl.pattern @pdl_target : benefit(1) {
 
 iree_linalg_transform.sequence {
   %0 = match @pdl_target
-  %1 = pad %0 {padding_values=["0.0", "0.0"], padding_dimensions=[1], pack_paddings=[1, 1], hoist_paddings=[1, 0], transpose_paddings=[[1, 0], [0, 1]]}
+  %1 = pad %0 {padding_values=[0.0 : f32, 0.0 : f32], padding_dimensions=[1], pack_paddings=[1, 1], hoist_paddings=[1, 0], transpose_paddings=[[1, 0], [0, 1]]}
 }


### PR DESCRIPTION
Previously only string padding values, that later on would be parsed to the element type of the padded operation, were supported. After the change, it is possible to hand in a floating point attribute directly.