### PR TITLE
Iterators: Create Optional type with conversion to LLVM struct.

### DIFF
--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -16,6 +16,10 @@ class Iterators_Op<string mnemonic, list<Trait> traits = []> :
     Op<Iterators_Dialect, mnemonic, traits> {
 }
 
+//===----------------------------------------------------------------------===//
+// Iterators
+//===----------------------------------------------------------------------===//
+
 def Iterators_SampleInputOp : Iterators_Op<"sampleInput"> {
   let summary = "Create some sample input";
   let results = (outs Iterators_Iterator);
@@ -30,6 +34,35 @@ def Iterators_ReduceOp : Iterators_Op<"reduce"> {
 def Iterators_SinkOp : Iterators_Op<"sink"> {
   let summary = "Consume tuples from an iterator";
   let arguments = (ins Iterators_Iterator);
+}
+
+//===----------------------------------------------------------------------===//
+// Optional
+//===----------------------------------------------------------------------===//
+
+def Iterators_OptionalEmptyOp : Iterators_Op<"emptyoptional"> {
+  let summary = "Creates an empty optional";
+  let results = (outs Iterators_Optional);
+}
+
+def Iterators_OptionalInsertValueOp : Iterators_Op<"insertvalue"> {
+  let summary = "Inserts a value into an optional (and sets the valid bit)";
+  let arguments = (ins Iterators_Optional:$optional, AnyType:$value);
+  let results = (outs Iterators_Optional:$result);
+  let hasVerifier = true;
+}
+
+def Iterators_OptionalExtractValueOp : Iterators_Op<"extractvalue"> {
+  let summary = "Extracts the value of a non-empty optional";
+  let arguments = (ins Iterators_Optional:$input);
+  let results = (outs AnyType:$result);
+  let hasVerifier = true;
+}
+
+def Iterators_OptionalHasValueOp : Iterators_Op<"hasvalue"> {
+  let summary = "Extracts the valid bit of an optional";
+  let arguments = (ins Iterators_Optional);
+  let results = (outs I1);
 }
 
 #endif // ITERATORS_DIALECT_ITERATORS_IR_ITERATORSOPS

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
@@ -25,4 +25,16 @@ def Iterators_Iterator : Iterators_Type<"Iterator", "iterator"> {
   let assemblyFormat = "`<` qualified($typesTuple) `>`";
 }
 
+def Iterators_Optional : Iterators_Type<"Optional", "optional"> {
+  let summary = "Optional (or \"nullable\") type";
+
+  let description = [{
+    Wraps a given type such that it may be empty like C++'s `std::optional`
+    (or database types, which may be `NULL`.)
+  }];
+
+  let parameters = (ins "Type":$elementType);
+  let assemblyFormat = "`<` qualified($elementType) `>`";
+}
+
 #endif // ITERATORS_DIALECT_ITERATORS_IR_ITERATORSTYPES

--- a/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
@@ -71,7 +71,7 @@ FuncOp lookupOrCreateFuncOp(llvm::StringRef fnName, FunctionType fnType,
   return funcOp;
 }
 
-/// Replaces a instances of a certain IteratorOp with a call to the given
+/// Replaces an instance of a certain IteratorOp with a call to the given
 /// external constructor as well as a call to the given destructor at the end of
 /// the block.
 struct IteratorConversionPattern : public ConversionPattern {

--- a/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
@@ -9,12 +9,15 @@
 #include "iterators/Conversion/IteratorsToStandard/IteratorsToStandard.h"
 
 #include "../PassDetail.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeRange.h"
+#include "mlir/IR/Types.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -35,12 +38,17 @@ struct ConvertIteratorsToStandardPass
 };
 } // namespace
 
+//===----------------------------------------------------------------------===//
+// Type conversion
+//===----------------------------------------------------------------------===//
+
 /// Maps IteratorType to llvm.ptr<i8>.
 class IteratorsTypeConverter : public TypeConverter {
 public:
   IteratorsTypeConverter() {
     addConversion([](Type type) { return type; });
     addConversion(convertIteratorType);
+    addConversion(convertOptional);
   }
 
 private:
@@ -50,7 +58,26 @@ private:
       return LLVM::LLVMPointerType::get(IntegerType::get(type.getContext(), 8));
     return llvm::None;
   }
+
+  static Optional<Type> convertOptional(Type type) {
+    OptionalType optionalType = type.dyn_cast<OptionalType>();
+    if (!optionalType)
+      return llvm::None;
+
+    Type boolType = IntegerType::get(type.getContext(), 1);
+    Type elementType = optionalType.getElementType();
+    SmallVector<Type, 4> types = {boolType, elementType};
+
+    auto structType = LLVM::LLVMStructType::getNewIdentified(type.getContext(),
+                                                             "Optional", types);
+
+    return structType;
+  }
 };
+
+//===----------------------------------------------------------------------===//
+// Iterators
+//===----------------------------------------------------------------------===//
 
 /// Returns or creates a function declaration at the module of the provided
 /// original op.
@@ -136,6 +163,109 @@ private:
   StringRef destructorName;
 };
 
+//===----------------------------------------------------------------------===//
+// Optional
+//===----------------------------------------------------------------------===//
+
+/// Replaces an instance of EmptyOptionalOp with the construction of an LLVM
+/// struct whose first bit is set to false.
+struct EmptyOptionalConversionPattern : public ConversionPattern {
+  EmptyOptionalConversionPattern(TypeConverter &typeConverter,
+                                 MLIRContext *context,
+                                 PatternBenefit benefit = 1)
+      : ConversionPattern(typeConverter, "iterators.emptyoptional", benefit,
+                          context) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Create undefined LLVM struct.
+    llvm::SmallVector<Type, 4> types;
+    LogicalResult res =
+        typeConverter->convertTypes(op->getResultTypes(), types);
+    assert(res.succeeded());
+    auto undefOp = rewriter.create<LLVM::UndefOp>(op->getLoc(), types);
+
+    // Set first field of struct (the valid bit) to false.
+    Type boolType = IntegerType::get(getContext(), 1);
+    arith::ConstantOp falseOp = rewriter.create<arith::ConstantOp>(
+        op->getLoc(), IntegerAttr::get(boolType, 0));
+
+    auto zero = ArrayAttr::get(
+        getContext(), {IntegerAttr::get(IndexType::get(getContext()), 0)});
+    rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(op, undefOp, falseOp,
+                                                     zero);
+    return success();
+  }
+};
+
+/// Replaces an instance of InsertValueOp with the corresponding op for LLVM
+/// structs.
+struct InsertValueConversionPattern : public ConversionPattern {
+  InsertValueConversionPattern(TypeConverter &typeConverter,
+                               MLIRContext *context, PatternBenefit benefit = 1)
+      : ConversionPattern(typeConverter, "iterators.insertvalue", benefit,
+                          context) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    assert(operands.size() == 2);
+    auto one = ArrayAttr::get(
+        getContext(), {IntegerAttr::get(IndexType::get(getContext()), 1)});
+    rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(op, operands[0],
+                                                     operands[1], one);
+    return success();
+  }
+};
+
+/// Replaces an instance of ExtractValueOp with the corresponding op for LLVM
+/// structs.
+struct ExtractValueConversionPattern : public ConversionPattern {
+  ExtractValueConversionPattern(TypeConverter &typeConverter,
+                                MLIRContext *context,
+                                PatternBenefit benefit = 1)
+      : ConversionPattern(typeConverter, "iterators.extractvalue", benefit,
+                          context) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    assert(operands.size() == 1);
+    auto one = ArrayAttr::get(
+        getContext(), {IntegerAttr::get(IndexType::get(getContext()), 1)});
+    assert(op->getNumResults() == 1);
+    rewriter.replaceOpWithNewOp<LLVM::ExtractValueOp>(
+        op, op->getResult(0).getType(), operands[0], one);
+    return success();
+  }
+};
+
+/// Replaces an instance of HasValueOp with the corresponding op for LLVM
+/// structs.
+struct HasValueConversionPattern : public ConversionPattern {
+  HasValueConversionPattern(TypeConverter &typeConverter, MLIRContext *context,
+                            PatternBenefit benefit = 1)
+      : ConversionPattern(typeConverter, "iterators.hasvalue", benefit,
+                          context) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    assert(operands.size() == 1);
+    auto zero = ArrayAttr::get(
+        getContext(), {IntegerAttr::get(IndexType::get(getContext()), 0)});
+    Type boolType = IntegerType::get(getContext(), 1);
+    rewriter.replaceOpWithNewOp<LLVM::ExtractValueOp>(op, boolType, operands[0],
+                                                      zero);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Set-up
+//===----------------------------------------------------------------------===//
+
 void mlir::iterators::populateIteratorsToStandardConversionPatterns(
     RewritePatternSet &patterns, TypeConverter &typeConverter) {
   patterns.add<IteratorConversionPattern>(
@@ -148,12 +278,16 @@ void mlir::iterators::populateIteratorsToStandardConversionPatterns(
   patterns.add<IteratorConversionPattern>(typeConverter, patterns.getContext(),
                                           "iterators.sink",
                                           "iteratorsComsumeAndPrint", "_dummy");
+  patterns.add<EmptyOptionalConversionPattern, InsertValueConversionPattern,
+               ExtractValueConversionPattern, HasValueConversionPattern>(
+      typeConverter, patterns.getContext());
 }
 
 void ConvertIteratorsToStandardPass::runOnOperation() {
   auto module = getOperation();
   ConversionTarget target(getContext());
-  target.addLegalDialect<func::FuncDialect, memref::MemRefDialect>();
+  target.addLegalDialect<func::FuncDialect, memref::MemRefDialect,
+                         LLVM::LLVMDialect, arith::ArithmeticDialect>();
   target.addLegalOp<ModuleOp, FuncOp, func::ReturnOp>();
   RewritePatternSet patterns(&getContext());
   IteratorsTypeConverter typeConverter;

--- a/experimental/iterators/lib/Dialects/Iterators/IR/Iterators.cpp
+++ b/experimental/iterators/lib/Dialects/Iterators/IR/Iterators.cpp
@@ -44,3 +44,46 @@ void IteratorsDialect::initialize() {
 
 #define GET_TYPEDEF_CLASSES
 #include "iterators/Dialect/Iterators/IR/IteratorsOpsTypes.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// Optional
+//===----------------------------------------------------------------------===//
+
+LogicalResult OptionalInsertValueOp::verify() {
+  // Check result type.
+  if (optional().getType() != result().getType()) {
+    return emitOpError() << "Type mismatch: Inserting into "
+                         << optional().getType() << " should produce a "
+                         << optional().getType() << " but this op returns "
+                         << result().getType();
+  }
+
+  // Check value type.
+  OptionalType inputType = optional().getType().dyn_cast<OptionalType>();
+  if (!inputType)
+    return failure();
+
+  if (inputType.getElementType() != value().getType()) {
+    return emitOpError() << "Type mismatch: Inserting into " << inputType
+                         << " requires to insert a "
+                         << inputType.getElementType()
+                         << " but this op inserts a " << value().getType();
+  }
+
+  return success();
+}
+
+LogicalResult OptionalExtractValueOp::verify() {
+  // Check return type.
+  OptionalType inputType = input().getType().dyn_cast<OptionalType>();
+  if (!inputType)
+    return failure();
+
+  if (inputType.getElementType() != result().getType()) {
+    return emitOpError() << "Type mismatch: Extracting from a " << inputType
+                         << " should produce a " << inputType.getElementType()
+                         << " but this op returns a " << result().getType();
+  }
+
+  return success();
+}

--- a/experimental/iterators/test/Conversion/IteratorsToStandard/optional.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToStandard/optional.mlir
@@ -1,0 +1,21 @@
+// RUN: mlir-proto-opt %s -convert-iterators-to-std \
+// RUN: | FileCheck %s
+
+func @main() {
+  %emtpyOptional = "iterators.emptyoptional"() : () -> !iterators.optional<i32>
+  // CHECK:      %[[V0:.*]] = llvm.mlir.undef : !llvm.struct<"Optional[[S0:.*]]", (i1, i32)>
+  // CHECK-NEXT: %[[V1:.*]] = arith.constant false
+  // CHECK-NEXT: %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[V0]][0 : index] : !llvm.struct<"Optional[[S0]]", (i1, i32)>
+
+  %fourtyTwo = arith.constant 42 : i32
+  // CHECK-NEXT: %[[V3:.*]] = arith.constant 42 : i32
+  %optionalInt = "iterators.insertvalue"(%emtpyOptional, %fourtyTwo) : (!iterators.optional<i32>, i32) -> !iterators.optional<i32>
+  // CHECK-NEXT: %[[V4:.*]] = llvm.insertvalue %[[V3]], %[[V2]][1 : index] : !llvm.struct<"Optional[[S0]]", (i1, i32)>
+
+  %hasValue = "iterators.hasvalue"(%optionalInt) : (!iterators.optional<i32>) -> i1
+  // CHECK-NEXT: %[[V5:.*]] = llvm.extractvalue %[[V4]][0 : index] : !llvm.struct<"Optional[[S0]]", (i1, i32)>
+
+  %value = "iterators.extractvalue"(%optionalInt) : (!iterators.optional<i32>) -> i32
+  // CHECK-NEXT: %[[V6:.*]] = llvm.extractvalue %[[V4]][1 : index] : !llvm.struct<"Optional[[S0]]", (i1, i32)>
+  return
+}

--- a/experimental/iterators/test/Dialect/Iterators/optional.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/optional.mlir
@@ -1,0 +1,17 @@
+// Test that we can parse optionals without errors
+// RUN: mlir-proto-opt %s
+
+func @main() {
+  %emtpyOptional = "iterators.emptyoptional"() : () -> !iterators.optional<i32>
+  %fourtyTwo = arith.constant 42 : i32
+  %optionalInt = "iterators.insertvalue"(%emtpyOptional, %fourtyTwo) : (!iterators.optional<i32>, i32) -> !iterators.optional<i32>
+  %hasValue = "iterators.hasvalue"(%optionalInt) : (!iterators.optional<i32>) -> i1
+  %valueOrZero = scf.if %hasValue -> i32 {
+    %value = "iterators.extractvalue"(%optionalInt) : (!iterators.optional<i32>) -> i32
+    scf.yield %value : i32
+  } else {
+    %zero = arith.constant 0 : i32
+    scf.yield %zero : i32
+  }
+  return
+}

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/optional.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/optional.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-proto-opt -convert-iterators-to-std \
+// RUN:                -convert-arith-to-llvm -convert-func-to-llvm %s \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=i32 \
+// RUN: | FileCheck %s
+
+func @main() -> i32 {
+  %emtpyOptional = "iterators.emptyoptional"() : () -> !iterators.optional<i32>
+  %fourtyTwo = arith.constant 42 : i32
+  %optionalInt = "iterators.insertvalue"(%emtpyOptional, %fourtyTwo) : (!iterators.optional<i32>, i32) -> !iterators.optional<i32>
+  %hasValue = "iterators.hasvalue"(%optionalInt) : (!iterators.optional<i32>) -> i1
+  %value = "iterators.extractvalue"(%optionalInt) : (!iterators.optional<i32>) -> i32
+  // CHECK: 42
+  return %value : i32
+}


### PR DESCRIPTION
This seems to be one of the building blocks required to implement the conversion sketched in #421.