### PR TITLE
Add sandbox-specific MLIR LSP Language server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ python ./run_tests.py
 
 The lit configuration file `test/lit.cfg.py` contains a list of excluded tests.
 
+## Diagnostics via MLIR LSP server
+
+The [MLIR LSP Server](https://mlir.llvm.org/docs/Tools/MLIRLSP/) allows editors
+to display as-you-type diagnostics, code navigation, and similar features. In
+order to extend this functionality to the dialects from this repository, use
+the following LSP server binary:
+
+```
+/path/to/iree-llvm-sandbox/build/bin/mlir-proto-lsp-server
+```
+
+In VS Code, this is done via the `mlir.server_path` property in
+`settings.json`.
+
 ## Running a simple search with Nevergrad
 
 The following command runs a simple search of 1000 iterations distributed across

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(mlir-proto-lsp-server)
 add_subdirectory(mlir-proto-opt)

--- a/tools/mlir-proto-lsp-server/CMakeLists.txt
+++ b/tools/mlir-proto-lsp-server/CMakeLists.txt
@@ -1,0 +1,20 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
+add_llvm_executable(mlir-proto-lsp-server
+  mlir-proto-lsp-server.cpp
+)
+
+target_link_libraries(mlir-proto-lsp-server
+PRIVATE
+  ${dialect_libs}
+  ${conversion_libs}
+  MLIRLspServerLib
+  MLIRSupport
+  MLIRIR
+
+  # Sandbox libs.
+  IREESandboxRegistration
+)
+
+mlir_check_all_link_libraries(mlir-proto-lsp-server)

--- a/tools/mlir-proto-lsp-server/mlir-proto-lsp-server.cpp
+++ b/tools/mlir-proto-lsp-server/mlir-proto-lsp-server.cpp
@@ -1,0 +1,30 @@
+//===-- mlir-proto-lsp-server.cpp - LSP server for sandbox ------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements a sandbox-specific MLIR LSP Language server. This
+/// extends the as-you-type diagnostics in VS Code to dialects defined in the
+/// sandbox. Implementation essentially as explained here:
+/// https://mlir.llvm.org/docs/Tools/MLIRLSP/.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Registration.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/InitAllPasses.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+
+using namespace mlir;
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+  registerAllPasses();
+  registerIntoDialectRegistry(registry);
+  return mlir::failed(mlir::MlirLspServerMain(argc, argv, registry));
+}


### PR DESCRIPTION
This extends the as-you-type diagnostics in VS Code to dialects defined in the sandbox. Implementation essentially as explained here: https://mlir.llvm.org/docs/Tools/MLIRLSP/.