### PR TITLE
SQL: ibis dialect + tests (+ background)

### DIFF
--- a/.github/workflows/testSQLDialect.yml
+++ b/.github/workflows/testSQLDialect.yml
@@ -1,0 +1,39 @@
+name: SQLDialectTest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Test SQL Dialect
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Checkout project
+      uses: actions/checkout@v2
+      with:
+        path: sandbox
+
+    - name: Install Python depends
+      run: |
+        python -m pip install -r ${GITHUB_WORKSPACE}/sandbox/experimental/sql/requirements.txt
+
+    - name: Check format with yapf
+      run: |
+        # Returns en error code if the files are not formatted
+        yapf --diff -r ${GITHUB_WORKSPACE}/sandbox/experimental/sql
+
+    - name: Test
+      run: |
+        cd ${GITHUB_WORKSPACE}/sandbox
+        lit -v ${GITHUB_WORKSPACE}/sandbox/experimental/sql/test

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ compile_commands.json
 
 # Benchmark dir
 benchmarks/
+
+# lit files
+.lit_test_times.txt
+Output/

--- a/experimental/sql/.style.yapf
+++ b/experimental/sql/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style: google
+indent_width: 2

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -1,0 +1,259 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from typing import Any
+from xdsl.ir import Block, Region, Operation, SSAValue, ParametrizedAttribute, Data, MLContext, Attribute
+from xdsl.dialects.builtin import StringAttr, ArrayAttr, ArrayOfConstraint, IntegerAttr
+from xdsl.irdl import AttributeDef, OperandDef, ResultDef, RegionDef, SingleBlockRegionDef, irdl_attr_definition, irdl_op_definition, ParameterDef, AnyAttr, VarOperandDef, builder
+
+# This file defines a dialect that mirrors the internal data structures of the
+# ibis framework (https://ibis-project.org/docs/dev/). In ibis, there exists an
+# additional layer of abstractions called `expressions`. Each operation in a
+# query references the expressions of its subqueries and is itself reference by
+# an expression. This is a remainder of the ibis UI that allows
+# printing/executing/... of expressions. Notice that the additional layer of
+# indirection can make ibis queries DAGs rather than trees. This only happens if
+# the user enters the query in a specific way, so this is also only a left-over
+# of the API. This dialect represents a cleaned up version of queries without
+# the expression layer for each node. In this version, all queries are trees, so
+# every part of the query is modeled as an operation with regions for its
+# respective subqueries. Hence, every operation is a single region terminator
+# and there are no SSAValues in this dialect.
+#
+# DISCLAIMER: This design tries to avoid premature complexity and is subject to
+# change. In particular, comples predicates might involve operations that are
+# not single region terminators.
+
+
+@irdl_attr_definition
+class DataType(ParametrizedAttribute):
+  """
+  Models an ibis datatype.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/datatypes.py#L34
+  """
+  name = "ibis.datatype"
+
+
+@irdl_attr_definition
+class int32(DataType):
+  """
+  Models the ibis int32 type.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/datatypes.py#L294
+
+  Example:
+
+  ```
+  !ibis.int32
+  ```
+  """
+  name = "ibis.int32"
+
+
+@irdl_attr_definition
+class String(DataType):
+  """
+  Models the ibis string type. The Parameter `nullable` defines whether the
+  string can be null.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/datatypes.py#L176
+
+  Example:
+
+  ```
+  !ibis.string<0 : !i1>
+  ```
+  """
+  name = "ibis.string"
+
+  nullable = ParameterDef(IntegerAttr)
+
+  @builder
+  @staticmethod
+  def get(val: int) -> 'String':
+    return String([IntegerAttr.from_int_and_width(val, 1)])
+
+
+@irdl_op_definition
+class TableColumn(Operation):
+  """
+  References a specific column with name `col_name` from `table`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/generic.py#L32
+
+  Example:
+  ```
+  ibis.table_column() ["col_name" = "a"] {
+    ibis.pandas_table() ...
+  }
+  ```
+  """
+  name = "ibis.table_column"
+
+  table = SingleBlockRegionDef()
+  col_name = AttributeDef(StringAttr)
+
+  @builder
+  @staticmethod
+  def get(table: Region, col_name: str) -> 'TableColumn':
+    return TableColumn.build(
+        attributes={"col_name": StringAttr.from_str(col_name)}, regions=[table])
+
+
+@irdl_op_definition
+class Selection(Operation):
+  """
+  Selects all tuples from `table` that fulfill `predicates`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/relations.py#L375
+
+  Example:
+
+  ```
+  ibis.selection() {
+    // table
+    ibis.table() ...
+  } {
+    // predicates
+    ibis.equals() ...
+  }
+  ```
+  """
+  name = "ibis.selection"
+
+  table = SingleBlockRegionDef()
+  predicates = SingleBlockRegionDef()
+
+  @staticmethod
+  @builder
+  def get(table: Region, predicates: Region) -> 'Selection':
+    return Selection.build(regions=[table, predicates])
+
+
+@irdl_op_definition
+class Equals(Operation):
+  """
+  Checks whether each entry of `left` is equal to `right`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/logical.py#L79
+
+  Example:
+
+  ```
+  ibis.equals() {
+    // left
+    ibis.table_column() ...
+  } {
+    // right
+    ibis.literal() ...
+  }
+  ```
+  """
+  name = "ibis.equals"
+
+  left = SingleBlockRegionDef()
+  right = SingleBlockRegionDef()
+
+  @builder
+  @staticmethod
+  def get(left: Region, right: Region) -> 'Equals':
+    return Equals.build(regions=[left, right])
+
+
+@irdl_op_definition
+class PandasTable(Operation):
+  """
+  Defines a table with name `table_name` and schema `schema`. The table is
+  backed by a pandas dataframe (https://pandas.pydata.org/docs/reference/frame.html).
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/backends/pandas/client.py#L282
+
+  Example:
+
+  ```
+  ibis.pandas_table() ["table_name" = "t"] {
+    ibis.schema_element() ...
+    ...
+  }
+  ```
+  """
+  name = "ibis.pandas_table"
+
+  table_name = AttributeDef(StringAttr)
+  schema = SingleBlockRegionDef()
+
+  @staticmethod
+  @builder
+  def get(name: str, Schema: Region) -> 'PandasTable':
+    return PandasTable.build(
+        attributes={"table_name": StringAttr.from_str(name)}, regions=[Schema])
+
+
+@irdl_op_definition
+class SchemaElement(Operation):
+  """
+  Defines a schema element with name `elt_name` and type `elt_type`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/schema.py#L35
+
+  Example:
+
+  ```
+  ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.int32]
+  ```
+  """
+  name = "ibis.schema_element"
+
+  elt_name = AttributeDef(StringAttr)
+  elt_type = AttributeDef(DataType)
+
+  @staticmethod
+  def get(name: str, type: DataType):
+    return SchemaElement.build(attributes={
+        "elt_name": StringAttr.from_str(name),
+        "elt_type": type
+    })
+
+
+@irdl_op_definition
+class Literal(Operation):
+  """
+  Defines a literal with value `val` and type `type`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/generic.py#L225
+
+  Example:
+
+  ```
+  ibis.literal() ["val" = "A", "type" = ibis.string<1 : !i1>]
+  ```
+  """
+  name = "ibis.literal"
+
+  val = AttributeDef(AnyAttr())
+  type = AttributeDef(DataType)
+
+  @builder
+  @staticmethod
+  def get(val: Attribute, type: DataType) -> 'Literal':
+    return Literal.build(attributes={"val": val, "type": type})
+
+
+@dataclass
+class Ibis:
+  ctx: MLContext
+
+  def __post_init__(self: 'Ibis'):
+    self.ctx.register_attr(DataType)
+    self.ctx.register_attr(String)
+    self.ctx.register_attr(int32)
+
+    self.ctx.register_op(PandasTable)
+    self.ctx.register_op(SchemaElement)
+    self.ctx.register_op(Selection)
+    self.ctx.register_op(Equals)
+    self.ctx.register_op(TableColumn)
+    self.ctx.register_op(Literal)

--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -1,0 +1,9 @@
+filecheck==0.0.18
+lit==14.0.0
+pytest==6.2.5
+xdsl==0.4.1
+yapf==0.32.0
+pyright==0.0.13
+frozenlist==1.2.*
+psutil==5.9.0
+ibis-framework==2.1.1

--- a/experimental/sql/test/ibis_dialect_tests/simple_query.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/simple_query.xdsl
@@ -1,0 +1,40 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+// Query: table.filter(table['a'] == 'AS')
+module() {
+  ibis.selection() {
+    // selection input
+    ibis.pandas_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+    }
+  } {
+    // selection predicate
+    ibis.equals() {
+      // predicate column
+      ibis.table_column() ["col_name" = "a"] {
+        ibis.pandas_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+        }
+      }
+    } {
+      // predicate literal
+      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
+    }
+  }
+}
+
+CHECK: ibis.selection() {
+CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
+CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+CHECK-NEXT:    }
+CHECK-NEXT:  } {
+CHECK-NEXT:    ibis.equals() {
+CHECK-NEXT:      ibis.table_column() ["col_name" = "a"] {
+CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
+CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+CHECK-NEXT:        }
+CHECK-NEXT:      }
+CHECK-NEXT:    } {
+CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
+CHECK-NEXT:    }
+CHECK-NEXT:  }

--- a/experimental/sql/test/lit.cfg
+++ b/experimental/sql/test/lit.cfg
@@ -1,0 +1,27 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import lit.formats
+import os
+
+config.name = "Relation"
+config.test_format = lit.formats.ShTest(execute_external=True)
+config.suffixes = ['.ibis', '.xdsl']
+
+config.test_source_root = os.path.dirname(__file__)
+
+if "PYTHONPATH" in os.environ.keys():
+  config.environment[
+      "PYTHONPATH"] = config.test_source_root + "/../:" + os.environ[
+          "PYTHONPATH"]
+else:
+  config.environment["PYTHONPATH"] = config.test_source_root + "/../"
+
+config.environment[
+    "PATH"] = config.test_source_root + "/../tools/:" + os.environ["PATH"]
+
+config.available_features = []
+
+if sys.version_info[0] == 3 and sys.version_info[1] == 8:
+  config.available_features.append('python38')

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from xdsl.xdsl_opt_main import xDSLOptMain
+
+from dialects.ibis_dialect import Ibis
+
+
+class RelOptMain(xDSLOptMain):
+
+  def register_all_dialects(self):
+    super().register_all_dialects()
+    """Register all dialects that can be used."""
+    ibis = Ibis(self.ctx)
+
+
+def __main__():
+  rel_main = RelOptMain()
+  try:
+    module = rel_main.parse_input()
+    rel_main.apply_passes(module)
+  except Exception as e:
+    print(e)
+    exit(0)
+
+  contents = rel_main.output_resulting_program(module)
+  rel_main.print_to_output_stream(contents)
+
+
+if __name__ == "__main__":
+  __main__()


### PR DESCRIPTION
This PR adds the ibis dialect and a simple roundtrip testcase, that shows how an example IR can look like. The ibis dialect mirrors the structure of the [ibis](https://ibis-project.org/docs/dev/) internal data structures. There are `Attribute`s for all types encountered in the simple query. Types are defined as being in defined `ibis/expr/types` in the ibis source repo. All other nodes encountered in this query are encoded as Operations.