### PR TITLE
Iterators: Rename IteratorType to StreamType

### DIFF
--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -18,18 +18,18 @@ class Iterators_Op<string mnemonic, list<Trait> traits = []> :
 
 def Iterators_SampleInputOp : Iterators_Op<"sampleInput"> {
   let summary = "Create some sample input";
-  let results = (outs Iterators_Iterator);
+  let results = (outs Iterators_Stream);
 }
 
 def Iterators_ReduceOp : Iterators_Op<"reduce"> {
   let summary = "Reduce the input to a single tuple";
-  let arguments = (ins Iterators_Iterator);
-  let results = (outs Iterators_Iterator);
+  let arguments = (ins Iterators_Stream);
+  let results = (outs Iterators_Stream);
 }
 
 def Iterators_SinkOp : Iterators_Op<"sink"> {
   let summary = "Consume tuples from an iterator";
-  let arguments = (ins Iterators_Iterator);
+  let arguments = (ins Iterators_Stream);
 }
 
 #endif // ITERATORS_DIALECT_ITERATORS_IR_ITERATORSOPS

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
@@ -19,10 +19,10 @@ class Iterators_Type<string name, string typeMnemonic>
   let mnemonic = typeMnemonic;
 }
 
-def Iterators_Iterator : Iterators_Type<"Iterator", "iterator"> {
-  let summary = "Basic iterator type";
-  let parameters = (ins "Type":$typesTuple);
-  let assemblyFormat = "`<` qualified($typesTuple) `>`";
+def Iterators_Stream : Iterators_Type<"Stream", "stream"> {
+  let summary = "Stream of elements of the given type";
+  let parameters = (ins "Type":$elementType);
+  let assemblyFormat = "`<` qualified($elementType) `>`";
 }
 
 #endif // ITERATORS_DIALECT_ITERATORS_IR_ITERATORSTYPES

--- a/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
@@ -35,18 +35,18 @@ struct ConvertIteratorsToStandardPass
 };
 } // namespace
 
-/// Maps IteratorType to llvm.ptr<i8>.
+/// Maps StreamType to llvm.ptr<i8>.
 class IteratorsTypeConverter : public TypeConverter {
 public:
   IteratorsTypeConverter() {
     addConversion([](Type type) { return type; });
-    addConversion(convertIteratorType);
+    addConversion(convertStreamType);
   }
 
 private:
-  /// Maps IteratorType to llvm.ptr<i8>.
-  static Optional<Type> convertIteratorType(Type type) {
-    if (type.isa<iterators::IteratorType>())
+  /// Maps StreamType to llvm.ptr<i8>.
+  static Optional<Type> convertStreamType(Type type) {
+    if (type.isa<iterators::StreamType>())
       return LLVM::LLVMPointerType::get(IntegerType::get(type.getContext(), 8));
     return llvm::None;
   }

--- a/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToStandard/IteratorsToStandard.cpp
@@ -71,7 +71,7 @@ FuncOp lookupOrCreateFuncOp(llvm::StringRef fnName, FunctionType fnType,
   return funcOp;
 }
 
-/// Replaces a instances of a certain IteratorOp with a call to the given
+/// Replaces an instance of a certain IteratorOp with a call to the given
 /// external constructor as well as a call to the given destructor at the end of
 /// the block.
 struct IteratorConversionPattern : public ConversionPattern {

--- a/experimental/iterators/test/Conversion/IteratorsToStandard/iterators-to-standard.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToStandard/iterators-to-standard.mlir
@@ -9,11 +9,11 @@
 // CHECK-NEXT:   func private @iteratorsMakeSampleInputOperator() -> !llvm.ptr<i8>
 func @main() {
 // CHECK-NEXT:   func @main() {
-  %input = "iterators.sampleInput"() : () -> (!iterators.iterator<tuple<i32>>)
+  %input = "iterators.sampleInput"() : () -> (!iterators.stream<tuple<i32>>)
 // CHECK-NEXT:     %[[V0:.*]] = call @iteratorsMakeSampleInputOperator() : () -> !llvm.ptr<i8>
-  %reduce = "iterators.reduce"(%input) : (!iterators.iterator<tuple<i32>>) -> (!iterators.iterator<tuple<i32>>)
+  %reduce = "iterators.reduce"(%input) : (!iterators.stream<tuple<i32>>) -> (!iterators.stream<tuple<i32>>)
 // CHECK-NEXT:     %[[V1:.*]] = call @iteratorsMakeReduceOperator(%[[V0]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
-  "iterators.sink"(%reduce) : (!iterators.iterator<tuple<i32>>) -> ()
+  "iterators.sink"(%reduce) : (!iterators.stream<tuple<i32>>) -> ()
 // CHECK-NEXT:     call @iteratorsComsumeAndPrint(%[[V1]]) : (!llvm.ptr<i8>) -> ()
   return
 // CHECK-NEXT:     call @iteratorsDestroySampleInputOperator(%[[V0]]) : (!llvm.ptr<i8>) -> ()

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/simple-plan-e2e.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/simple-plan-e2e.mlir
@@ -4,9 +4,9 @@
 // RUN: | FileCheck %s
 
 func @main() {
-  %input = "iterators.sampleInput"() : () -> (!iterators.iterator<tuple<i32>>)
-  %reduce = "iterators.reduce"(%input) : (!iterators.iterator<tuple<i32>>) -> (!iterators.iterator<tuple<i32>>)
-  "iterators.sink"(%reduce) : (!iterators.iterator<tuple<i32>>) -> ()
+  %input = "iterators.sampleInput"() : () -> (!iterators.stream<tuple<i32>>)
+  %reduce = "iterators.reduce"(%input) : (!iterators.stream<tuple<i32>>) -> (!iterators.stream<tuple<i32>>)
+  "iterators.sink"(%reduce) : (!iterators.stream<tuple<i32>>) -> ()
   // CHECK: (6)
   return
 }


### PR DESCRIPTION
I realized that the current operations we have don't *work on* iterators; they *are* iterators, and what they work on are *streams* (of elements of some type).