### PR TITLE
SQL: Ibis frontend

### DIFF
--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -7,3 +7,4 @@ pyright==0.0.13
 frozenlist==1.2.*
 psutil==5.9.0
 ibis-framework==2.1.1
+multipledispatch==0.6

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -1,0 +1,104 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from modulefinder import Module
+from unittest import result
+from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr
+from xdsl.ir import Operation, MLContext, Region, Block
+from typing import List, Type, Optional
+
+import ibis
+import ibis.expr.types
+import ibis.expr.datatypes
+import ibis.expr.operations.relations as rels
+import ibis.expr.operations.generic as gen_types
+from ibis.expr.operations.logical import Equals as EQ
+import ibis.backends.pandas.client as PandasBackend
+
+import dialects.ibis_dialect as id
+
+# This file contains the translation from ibis to the ibis_dialect.
+# It is built in a visitor-style, as this is one of the best designs
+# to crawl trees in my experience. The entry-point is the `visit`-
+# function just below. It dispatches to the appropriate translator.
+
+
+@dataclass
+class NodeVisitor:
+  ctx: MLContext
+
+  def visit(self, node: ibis.expr.types.Expr) -> Operation:
+    if isinstance(node, ibis.expr.types.TableExpr):
+      return self.visit_TableExpr(node)
+    if isinstance(node, ibis.expr.types.StringColumn):
+      return self.visit_StringColumn(node)
+    if isinstance(node, ibis.expr.types.BooleanColumn):
+      return self.visit_BooleanColumn(node)
+    if isinstance(node, ibis.expr.types.StringScalar):
+      return self.visit_StringScalar(node)
+    raise KeyError(f"Unknown nodetype {type(node)}")
+
+  def convert_datatype(self, type_: ibis.expr.datatypes) -> id.DataType:
+    if isinstance(type_, ibis.expr.datatypes.String):
+      return id.String.get(1 if type_.nullable else 0)
+    if isinstance(type_, ibis.expr.datatypes.Int32):
+      return id.int32()
+    raise KeyError(f"Unknown datatype: {type(type_)}")
+
+  def visit_Schema(self, schema: ibis.expr.schema.Schema) -> Region:
+    ops = []
+    for n, t in zip(schema.names, schema.types):
+      ops.append(id.SchemaElement.get(n, self.convert_datatype(t)))
+    return Region.from_operation_list(ops)
+
+  def visit_TableExpr(self, table: ibis.expr.types.TableExpr) -> Operation:
+    op = table.op()
+    if isinstance(op, PandasBackend.PandasTable):
+      schema = self.visit_Schema(op.schema)
+      new_op = id.PandasTable.get(op.name, schema)
+      return new_op
+    if isinstance(op, rels.Selection):
+      table = Region.from_operation_list([self.visit(op.table)])
+      # TODO: handle mulitple predicates
+      predicates = Region.from_operation_list([self.visit(op.predicates[0])])
+      new_op = id.Selection.get(table, predicates)
+      return new_op
+    raise KeyError(f"Unknown tableExpr: {type(op)}")
+
+  def visit_StringColumn(
+      self, stringColumn: ibis.expr.types.StringColumn) -> Operation:
+    op = stringColumn.op()
+    if isinstance(op, gen_types.TableColumn):
+      table = Region.from_operation_list([self.visit(op.table)])
+      new_op = id.TableColumn.get(table, op.name)
+      return new_op
+    raise Exception(f"Unknown stringcolumn: {type(op)}")
+
+  def visit_BooleanColumn(
+      self, boolColumn: ibis.expr.types.BooleanColumn) -> Operation:
+    op = boolColumn.op()
+    if isinstance(op, gen_types.TableColumn):
+      reg = Region.from_operation_list([self.visit(op.table)])
+      return id.TableColumn.get(reg, op.name)
+    if isinstance(op, EQ):
+      left_reg = Region.from_operation_list([self.visit(op.left)])
+      right_reg = Region.from_operation_list([self.visit(op.right)])
+      new_op = id.Equals.get(left_reg, right_reg)
+      return new_op
+    raise Exception(f"Unknown booleancolumn: {type(op)}")
+
+  def visit_StringScalar(self,
+                         strScalar: ibis.expr.types.StringScalar) -> Operation:
+    op = strScalar.op()
+    if isinstance(op, gen_types.Literal):
+      new_op = id.Literal.get(StringAttr.from_str(op.value),
+                              self.convert_datatype(op.dtype))
+      return new_op
+    raise Exception(f"Unknown stringscalar: {type(op)}")
+
+
+def ibis_to_xdsl(ctx: MLContext, query: ibis.expr.types.Expr) -> ModuleOp:
+  return ModuleOp.build(
+      regions=[Region.from_operation_list([NodeVisitor(ctx).visit(query)])])

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -8,6 +8,7 @@ from unittest import result
 from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr
 from xdsl.ir import Operation, MLContext, Region, Block
 from typing import List, Type, Optional
+from multipledispatch import dispatch
 
 import ibis
 import ibis.expr.types
@@ -19,86 +20,82 @@ import ibis.backends.pandas.client as PandasBackend
 
 import dialects.ibis_dialect as id
 
-# This file contains the translation from ibis to the ibis_dialect.
-# It is built in a visitor-style, as this is one of the best designs
-# to crawl trees in my experience. The entry-point is the `visit`-
-# function just below. It dispatches to the appropriate translator.
+# This file contains the translation from ibis to the ibis_dialect. This
+# translation is implemented as a visitor-pattern with all functions being
+# called using `visit(*some ibis node*), while the multipledispatch package
+# ensures that the right function is actually called. In particular, this
+# translation removes the expression layer from the ibis internal data
+# structures and abstracts every ibis `op()` as an operation in the IR.
 
 
-@dataclass
-class NodeVisitor:
-  ctx: MLContext
+def convert_datatype(type_: ibis.expr.datatypes) -> id.DataType:
+  if isinstance(type_, ibis.expr.datatypes.String):
+    return id.String.get(1 if type_.nullable else 0)
+  if isinstance(type_, ibis.expr.datatypes.Int32):
+    return id.int32()
+  raise KeyError(f"Unknown datatype: {type(type_)}")
 
-  def visit(self, node: ibis.expr.types.Expr) -> Operation:
-    if isinstance(node, ibis.expr.types.TableExpr):
-      return self.visit_TableExpr(node)
-    if isinstance(node, ibis.expr.types.StringColumn):
-      return self.visit_StringColumn(node)
-    if isinstance(node, ibis.expr.types.BooleanColumn):
-      return self.visit_BooleanColumn(node)
-    if isinstance(node, ibis.expr.types.StringScalar):
-      return self.visit_StringScalar(node)
-    raise KeyError(f"Unknown nodetype {type(node)}")
 
-  def convert_datatype(self, type_: ibis.expr.datatypes) -> id.DataType:
-    if isinstance(type_, ibis.expr.datatypes.String):
-      return id.String.get(1 if type_.nullable else 0)
-    if isinstance(type_, ibis.expr.datatypes.Int32):
-      return id.int32()
-    raise KeyError(f"Unknown datatype: {type(type_)}")
+def visit_schema(schema: ibis.expr.schema.Schema) -> Region:  #type: ignore
+  ops = []
+  for n, t in zip(schema.names, schema.types):
+    ops.append(id.SchemaElement.get(n, convert_datatype(t)))
+  return Region.from_operation_list(ops)
 
-  def visit_Schema(self, schema: ibis.expr.schema.Schema) -> Region:
-    ops = []
-    for n, t in zip(schema.names, schema.types):
-      ops.append(id.SchemaElement.get(n, self.convert_datatype(t)))
-    return Region.from_operation_list(ops)
 
-  def visit_TableExpr(self, table: ibis.expr.types.TableExpr) -> Operation:
-    op = table.op()
-    if isinstance(op, PandasBackend.PandasTable):
-      schema = self.visit_Schema(op.schema)
-      new_op = id.PandasTable.get(op.name, schema)
-      return new_op
-    if isinstance(op, rels.Selection):
-      table = Region.from_operation_list([self.visit(op.table)])
-      # TODO: handle mulitple predicates
-      predicates = Region.from_operation_list([self.visit(op.predicates[0])])
-      new_op = id.Selection.get(table, predicates)
-      return new_op
-    raise KeyError(f"Unknown tableExpr: {type(op)}")
+@dispatch(ibis.expr.types.TableExpr)
+def visit(  #type: ignore
+    table: ibis.expr.types.TableExpr) -> Operation:  #type: ignore
+  op = table.op()
+  if isinstance(op, PandasBackend.PandasTable):
+    schema = visit_schema(op.schema)
+    new_op = id.PandasTable.get(op.name, schema)
+    return new_op
+  if isinstance(op, rels.Selection):
+    table = Region.from_operation_list([visit(op.table)])
+    # TODO: handle multiple predicates
+    predicates = Region.from_operation_list([visit(op.predicates[0])])
+    new_op = id.Selection.get(table, predicates)
+    return new_op
+  raise KeyError(f"Unknown tableExpr: {type(op)}")
 
-  def visit_StringColumn(
-      self, stringColumn: ibis.expr.types.StringColumn) -> Operation:
-    op = stringColumn.op()
-    if isinstance(op, gen_types.TableColumn):
-      table = Region.from_operation_list([self.visit(op.table)])
-      new_op = id.TableColumn.get(table, op.name)
-      return new_op
-    raise Exception(f"Unknown stringcolumn: {type(op)}")
 
-  def visit_BooleanColumn(
-      self, boolColumn: ibis.expr.types.BooleanColumn) -> Operation:
-    op = boolColumn.op()
-    if isinstance(op, gen_types.TableColumn):
-      reg = Region.from_operation_list([self.visit(op.table)])
-      return id.TableColumn.get(reg, op.name)
-    if isinstance(op, EQ):
-      left_reg = Region.from_operation_list([self.visit(op.left)])
-      right_reg = Region.from_operation_list([self.visit(op.right)])
-      new_op = id.Equals.get(left_reg, right_reg)
-      return new_op
-    raise Exception(f"Unknown booleancolumn: {type(op)}")
+@dispatch(ibis.expr.types.StringColumn)
+def visit(  #type: ignore
+    stringColumn: ibis.expr.types.StringColumn) -> Operation:
+  op = stringColumn.op()
+  if isinstance(op, gen_types.TableColumn):
+    table = Region.from_operation_list([visit(op.table)])
+    new_op = id.TableColumn.get(table, op.name)
+    return new_op
+  raise Exception(f"Unknown stringcolumn: {type(op)}")
 
-  def visit_StringScalar(self,
-                         strScalar: ibis.expr.types.StringScalar) -> Operation:
-    op = strScalar.op()
-    if isinstance(op, gen_types.Literal):
-      new_op = id.Literal.get(StringAttr.from_str(op.value),
-                              self.convert_datatype(op.dtype))
-      return new_op
-    raise Exception(f"Unknown stringscalar: {type(op)}")
+
+@dispatch(ibis.expr.types.BooleanColumn)
+def visit(  #type: ignore
+    boolColumn: ibis.expr.types.BooleanColumn) -> Operation:
+  op = boolColumn.op()
+  if isinstance(op, gen_types.TableColumn):
+    reg = Region.from_operation_list([visit(op.table)])
+    return id.TableColumn.get(reg, op.name)
+  if isinstance(op, EQ):
+    left_reg = Region.from_operation_list([visit(op.left)])
+    right_reg = Region.from_operation_list([visit(op.right)])
+    new_op = id.Equals.get(left_reg, right_reg)
+    return new_op
+  raise Exception(f"Unknown booleancolumn: {type(op)}")
+
+
+@dispatch(ibis.expr.types.StringScalar)
+def visit(  #type: ignore
+    strScalar: ibis.expr.types.StringScalar) -> Operation:
+  op = strScalar.op()
+  if isinstance(op, gen_types.Literal):
+    new_op = id.Literal.get(StringAttr.from_str(op.value),
+                            convert_datatype(op.dtype))
+    return new_op
+  raise Exception(f"Unknown stringscalar: {type(op)}")
 
 
 def ibis_to_xdsl(ctx: MLContext, query: ibis.expr.types.Expr) -> ModuleOp:
-  return ModuleOp.build(
-      regions=[Region.from_operation_list([NodeVisitor(ctx).visit(query)])])
+  return ModuleOp.build(regions=[Region.from_operation_list([visit(query)])])

--- a/experimental/sql/test/frontend/selection.ibis
+++ b/experimental/sql/test/frontend/selection.ibis
@@ -1,0 +1,19 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table.filter(table['a'] == 'AS')
+
+CHECK: ibis.selection() {
+CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
+CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+CHECK-NEXT:    }
+CHECK-NEXT:  } {
+CHECK-NEXT:    ibis.equals() {
+CHECK-NEXT:      ibis.table_column() ["col_name" = "a"] {
+CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
+CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+CHECK-NEXT:        }
+CHECK-NEXT:      }
+CHECK-NEXT:    } {
+CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
+CHECK-NEXT:    }
+CHECK-NEXT:  }

--- a/experimental/sql/test/frontend/selection.ibis
+++ b/experimental/sql/test/frontend/selection.ibis
@@ -2,7 +2,7 @@
 
 table.filter(table['a'] == 'AS')
 
-# CHECK: ibis.selection() {
+#      CHECK: ibis.selection() {
 # CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
 # CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
 # CHECK-NEXT:    }

--- a/experimental/sql/test/frontend/selection.ibis
+++ b/experimental/sql/test/frontend/selection.ibis
@@ -2,18 +2,18 @@
 
 table.filter(table['a'] == 'AS')
 
-CHECK: ibis.selection() {
-CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
-CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-CHECK-NEXT:    }
-CHECK-NEXT:  } {
-CHECK-NEXT:    ibis.equals() {
-CHECK-NEXT:      ibis.table_column() ["col_name" = "a"] {
-CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
-CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-CHECK-NEXT:        }
-CHECK-NEXT:      }
-CHECK-NEXT:    } {
-CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
-CHECK-NEXT:    }
-CHECK-NEXT:  }
+# CHECK: ibis.selection() {
+# CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  } {
+# CHECK-NEXT:    ibis.equals() {
+# CHECK-NEXT:      ibis.table_column() ["col_name" = "a"] {
+# CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:        }
+# CHECK-NEXT:      }
+# CHECK-NEXT:    } {
+# CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -22,9 +22,7 @@ class RelOptMain(xDSLOptMain):
       connection = ibis.pandas.connect(
           {"t": pd.DataFrame({"a": ["AS", "EU", "NA"]})})
       table = connection.table('t')
-      f.readline()
-      f.readline()
-      query = f.readline()
+      query = f.read()
       res = eval(query)
 
       return ibis_to_xdsl(self.ctx, res)

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -4,11 +4,32 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from xdsl.xdsl_opt_main import xDSLOptMain
+from io import IOBase
 
+from src.ibis_frontend import ibis_to_xdsl
 from dialects.ibis_dialect import Ibis
 
 
 class RelOptMain(xDSLOptMain):
+
+  def register_all_frontends(self):
+    super().register_all_frontends()
+
+    def parse_ibis(f: IOBase):
+      import ibis
+      import pandas as pd
+
+      connection = ibis.pandas.connect(
+          {"t": pd.DataFrame({"a": ["AS", "EU", "NA"]})})
+      table = connection.table('t')
+      f.readline()
+      f.readline()
+      query = f.readline()
+      res = eval(query)
+
+      return ibis_to_xdsl(self.ctx, res)
+
+    self.available_frontends['ibis'] = parse_ibis
 
   def register_all_dialects(self):
     super().register_all_dialects()


### PR DESCRIPTION
This patch adds a first version of an ibis frontend. The frontend currently supports exactly the query `table.filter(table['a'] = 'AS').

The frontend consists of a basic visitorpattern with a `visit()`-function, that matches on the given node and dispatches to the proper function to build the operation for that node.