### PR TITLE
Iterators: Make SampleInputOp work on tuple<i32> instead of i32.

### DIFF
--- a/experimental/iterators/lib/Dialects/Iterators/IR/Iterators.cpp
+++ b/experimental/iterators/lib/Dialects/Iterators/IR/Iterators.cpp
@@ -51,9 +51,11 @@ LogicalResult CreateSampleInputStateOp::verify() {
       createdState().getType().dyn_cast<IteratorInterface>();
   assert(iteratorType);
 
-  if (iteratorType.getElementType() != IntegerType::get(getContext(), 32)) {
+  TupleType tupleType =
+      TupleType::get(getContext(), {IntegerType::get(getContext(), 32)});
+  if (iteratorType.getElementType() != tupleType) {
     return emitOpError() << "Type mismatch: Sample input iterator (currently) "
-                            "has to return elements of type 'i32'";
+                            "has to return elements of type 'tuple<i32>'";
   }
 
   return success();

--- a/experimental/iterators/test/Dialect/Iterators/iterator-states-invalid.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/iterator-states-invalid.mlir
@@ -1,21 +1,21 @@
 // Test that we can parse and verify iterator states without errors
 // RUN: mlir-proto-opt --verify-diagnostics --split-input-file %s
 
-!sampleInputState = type !iterators.sampleinputstate<i32>
+!sampleInputState = type !iterators.sampleinputstate<tuple<i32>>
 func @testCreateSampleInputTypeMismatch() {
-  // expected-error@+1 {{Sample input iterator (currently) has to return elements of type 'i32'}}
-  %initialState = "iterators.createSampleInputState"() : () -> !iterators.sampleinputstate<i64>
+  // expected-error@+1 {{Sample input iterator (currently) has to return elements of type 'tuple<i32>'}}
+  %initialState = "iterators.createSampleInputState"() : () -> !iterators.sampleinputstate<tuple<i64>>
   return
 }
 
 // -----
 
-!sampleInputState = type !iterators.sampleinputstate<i32>
-!wrongSampleInputState = type !iterators.sampleinputstate<i64>
+!sampleInputState = type !iterators.sampleinputstate<tuple<i32>>
+!wrongSampleInputState = type !iterators.sampleinputstate<tuple<i64>>
 !wrongReduceState = type !iterators.reducestate<!wrongSampleInputState>
 func @testCreateSampleInputTypeMismatch() {
   %initialUpstreamState = "iterators.createSampleInputState"() : () -> !sampleInputState
-  // expected-error@+1 {{Upstream iterator of reduce iterator must produce elements of type 'i64' but produces elements of type 'i32'}}
+  // expected-error@+1 {{Upstream iterator of reduce iterator must produce elements of type 'tuple<i64>' but produces elements of type 'tuple<i32>'}}
   %initialState = "iterators.createReduceState"(%initialUpstreamState) : (!sampleInputState) -> !wrongReduceState
   return
 }

--- a/experimental/iterators/test/Dialect/Iterators/iterator-states.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/iterator-states.mlir
@@ -1,13 +1,13 @@
 // Test that we can parse and verify iterator states without errors
 // RUN: mlir-proto-opt %s
 
-!sampleInputState = type !iterators.sampleinputstate<i32>
+!sampleInputState = type !iterators.sampleinputstate<tuple<i32>>
 !reduceState = type !iterators.reducestate<!sampleInputState>
 
 func @testSampleInput() {
   %initialState = "iterators.createSampleInputState"() : () -> !sampleInputState
   %openedState = "iterators.open"(%initialState) : (!sampleInputState) -> !sampleInputState
-  %consumedState, %hasNext, %nextElement = "iterators.next"(%openedState) : (!sampleInputState) -> (!sampleInputState, i1, i32)
+  %consumedState, %hasNext, %nextElement = "iterators.next"(%openedState) : (!sampleInputState) -> (!sampleInputState, i1, tuple<i32>)
   %closedState = "iterators.close"(%consumedState) : (!sampleInputState) -> !sampleInputState
   return
 }
@@ -16,7 +16,7 @@ func @testReduce() {
   %initialUpstreamState = "iterators.createSampleInputState"() : () -> !sampleInputState
   %initialState = "iterators.createReduceState"(%initialUpstreamState) : (!sampleInputState) -> !reduceState
   %openedState = "iterators.open"(%initialState) : (!reduceState) -> !reduceState
-  %consumedState, %hasNext, %nextElement = "iterators.next"(%openedState) : (!reduceState) -> (!reduceState, i1, i32)
+  %consumedState, %hasNext, %nextElement = "iterators.next"(%openedState) : (!reduceState) -> (!reduceState, i1, tuple<i32>)
   %closedState = "iterators.close"(%consumedState) : (!reduceState) -> !reduceState
   return
 }


### PR DESCRIPTION
Since we'll mostly work with iterators of tuples, it makes sense to have the sample input generate those as well.

As discussed [here](https://github.com/google/iree-llvm-sandbox/pull/446#discussion_r853090086).