### PR TITLE
SQL: Ibis dialect and frontend refactoring

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -38,7 +38,7 @@ class DataType(ParametrizedAttribute):
 
 
 @irdl_attr_definition
-class int32(DataType):
+class Int32(DataType):
   """
   Models the ibis int32 type.
 
@@ -249,7 +249,7 @@ class Ibis:
   def __post_init__(self: 'Ibis'):
     self.ctx.register_attr(DataType)
     self.ctx.register_attr(String)
-    self.ctx.register_attr(int32)
+    self.ctx.register_attr(Int32)
 
     self.ctx.register_op(PandasTable)
     self.ctx.register_op(SchemaElement)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from dataclasses import dataclass
-from modulefinder import Module
-from unittest import result
 from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr
 from xdsl.ir import Operation, MLContext, Region, Block
 from typing import List, Type, Optional


### PR DESCRIPTION
This patch fixes two small issues, i.e., there was a  lower case class names in the ibis dialect and my editor decided to auto import unnecessary things, which I did not realise earlier. I disable auto imports, so this should not happen anymore :)