### PR TITLE
SQL: rel_impl first prototype

### DIFF
--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -12,8 +12,8 @@ from xdsl.irdl import AttributeDef, OperandDef, ResultDef, RegionDef, SingleBloc
 # expresses relational queries using low-level concepts like tuples as block
 # arguments and specific join implementations. The dialect consists of two types
 # of operations: Expressions and Operators. Operators work on Bags whereas
-# expressions work on single values and are used to specify the exact behavior
-# of operators. The IndexByName and Yield Expressions bridge the gap to convert
+# expressions work on scalars and are used to specify the exact behavior of
+# operators. The IndexByName and Yield Expressions bridge the gap to convert
 # from one to the other.
 
 #===------------------------------------------------------------------------===#
@@ -171,7 +171,7 @@ class Expression(Operation):
 @irdl_op_definition
 class IndexByName(Expression):
   """
-  Indexes into `tuple` at the position of the filed `col_name` and returns its
+  Indexes into `tuple` at the position of the field `col_name` and returns its
   content.
 
   Example:

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -1,0 +1,354 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from typing import Any, Union, List
+from xdsl.ir import Block, Region, Operation, SSAValue, ParametrizedAttribute, Data, MLContext, Attribute
+from xdsl.dialects.builtin import StringAttr, ArrayAttr, ArrayOfConstraint, IntegerAttr
+from xdsl.irdl import AttributeDef, OperandDef, ResultDef, RegionDef, SingleBlockRegionDef, irdl_attr_definition, irdl_op_definition, ParameterDef, AnyAttr, VarOperandDef, builder
+
+# This file contains the relational implementation dialect, a dialect that
+# expresses relational queries using low-level concepts like tuples as block
+# arguments and specific join implementations. The dialect consists of two types
+# of operations: Expressions and Operators. Operators work on Bags whereas
+# expressions work on single values and are used to specify the exact behavior
+# of operators. The IndexByName and Yield Expressions bridge the gap to convert
+# from one to the other.
+
+#===------------------------------------------------------------------------===#
+# Data types
+#===------------------------------------------------------------------------===#
+
+
+@irdl_attr_definition
+class DataType(ParametrizedAttribute):
+  """
+  Models a datatype in a relational implementation query.
+  """
+  name = "rel_impl.datatype"
+
+
+@irdl_attr_definition
+class Int32(DataType):
+  """
+  Models a int32 type in a relational implementation query.
+
+  Example:
+
+  ```
+  !rel_impl.int32
+  ```
+  """
+  name = "rel_impl.int32"
+
+
+@irdl_attr_definition
+class String(DataType):
+  """
+  Models a string type in a relational implementation query, that can be either
+  nullable or not.
+
+  Example:
+
+  ```
+  !rel_impl.string<0: !i1>
+  ```
+  """
+  name = "rel_impl.string"
+
+  # TODO: redefine nullable as a property of all fields
+  nullable = ParameterDef(IntegerAttr)
+
+  @staticmethod
+  @builder
+  def get(val: Union[int, IntegerAttr]) -> 'String':
+    if isinstance(val, IntegerAttr):
+      return String([val])
+    return String([IntegerAttr.from_int_and_width(val, 1)])
+
+
+#===------------------------------------------------------------------------===#
+# Query types
+#===------------------------------------------------------------------------===#
+
+
+@irdl_attr_definition
+class Boolean(ParametrizedAttribute):
+  """
+  Models a type that can either be true or false to, e.g., show whether a tuple
+  is part of the result or not.
+
+  Example:
+
+  '''
+  !rel_impl.bool
+  '''
+  """
+  name = "rel_impl.bool"
+
+
+@irdl_attr_definition
+class SchemaElement(ParametrizedAttribute):
+  """
+  Models an element of a schema with name `elt_name` and type `elt_type`.
+
+  Example:
+  '''
+  !rel_impl.schema_element<"id", !rel_impl.int32>
+  '''
+  """
+  name = "rel_impl.schema_element"
+
+  elt_name = ParameterDef(StringAttr)
+  elt_type = ParameterDef(DataType)
+
+  @staticmethod
+  @builder
+  def get(name: str, type_: DataType) -> 'SchemaElement':
+    return SchemaElement([StringAttr.from_str(name), type_])
+
+
+@irdl_attr_definition
+class Bag(ParametrizedAttribute):
+  """
+  Models a bag in a relational implementation query. The exact schema of the bag
+  is part of the type itself.
+
+  Example:
+
+  '''
+  !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>
+  '''
+  """
+  name = "rel_impl.bag"
+
+  schema = ParameterDef(ArrayOfConstraint(SchemaElement))
+
+  @staticmethod
+  @builder
+  def get(types: list[DataType], names: list[str]) -> 'Bag':
+    schema_elts = [SchemaElement.get(n, t) for n, t in zip(names, types)]
+    return Bag([ArrayAttr.from_list(schema_elts)])
+
+
+@irdl_attr_definition
+class Tuple(ParametrizedAttribute):
+  """
+  Models a tuple in a relational implementation query. The schema is part of the
+  type of the tuple.
+
+  Example:
+
+  '''
+  !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>
+  '''
+  """
+  name = "rel_impl.tuple"
+
+  schema = ParameterDef(ArrayOfConstraint(SchemaElement))
+
+  @staticmethod
+  @builder
+  def get(types: list[DataType], names: list[str]) -> 'Tuple':
+    schema_elts = [SchemaElement.get(n, t) for n, t in zip(names, types)]
+    return Tuple([ArrayAttr.from_list(schema_elts)])
+
+
+#===------------------------------------------------------------------------===#
+# Expressions
+#===------------------------------------------------------------------------===#
+
+
+class Expression(Operation):
+  """
+  Interface class for all Expressions, i.e., operations that work on single
+  values.
+  """
+  ...
+
+
+@irdl_op_definition
+class IndexByName(Expression):
+  """
+  Indexes into `tuple` at the position of the filed `col_name` and returns its
+  content.
+
+  Example:
+
+  '''
+   %0 : rel_impl.int32 = rel_impl.index_by_name(%t : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_name" = "id"]
+    '''
+  """
+  name = "rel_impl.index_by_name"
+
+  col_name = AttributeDef(StringAttr)
+  tuple = OperandDef(Tuple)
+  result = ResultDef(DataType)
+
+  @builder
+  @staticmethod
+  def get(name: str, tuple: Tuple, res_type: DataType) -> 'IndexByName':
+    return IndexByName.build(operands=[tuple],
+                             result_types=[res_type],
+                             attributes={"col_name": StringAttr.from_str(name)})
+
+
+@irdl_op_definition
+class Compare(Expression):
+  """
+  Returns `left` 'comparator' `right`.
+
+  Example:
+
+  '''
+  ...
+  %0 : !rel_impl.bool = rel_impl.compare(%a : !rel_impl.int32, %b : !rel_impl.int32) ["comparator" = "="]
+  '''
+  """
+  name = "rel_impl.compare"
+
+  left = OperandDef(DataType)
+  right = OperandDef(DataType)
+  comparator = AttributeDef(StringAttr)
+
+  result = ResultDef(Boolean)
+
+  @staticmethod
+  @builder
+  def get(left: Operation, right: Operation,
+          comparator: StringAttr) -> 'Compare':
+    return Compare.build(operands=[left, right],
+                         attributes={"comparator": comparator},
+                         result_types=[Boolean()])
+
+
+@irdl_op_definition
+class Yield(Expression):
+  """
+  Bridges the gap from expressions back to operators by yielding the result of
+  an expression to the encompassing operator.
+
+  Example:
+
+  '''
+  rel_impl.yield(%0 : !rel_impl.bool)
+  '''
+  """
+  name = "rel_impl.yield"
+
+  ops = VarOperandDef(AnyAttr())
+
+  @staticmethod
+  @builder
+  def get(ops: list[Operation]) -> 'Yield':
+    return Yield.build(operands=[ops])
+
+
+@irdl_op_definition
+class Literal(Expression):
+  """
+  Creates a literal with value `value`.
+
+  Example:
+
+  '''
+  %0 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : i32]
+  '''
+  """
+  name = "rel_impl.literal"
+
+  # TODO: change IntegerAttr s.t. it can have type !rel.int32
+  value = AttributeDef(AnyAttr())
+  result = ResultDef(DataType)
+
+  @staticmethod
+  @builder
+  def get(val: Attribute, res: DataType) -> 'Literal':
+    return Literal.build(attributes={"value": val}, result_types=[res])
+
+
+#===------------------------------------------------------------------------===#
+# Operators
+#===------------------------------------------------------------------------===#
+
+
+class Operator(Operation):
+  """
+  Interface class for all Operators, i.e., operations that work on bags.
+  """
+  ...
+
+
+@irdl_op_definition
+class PandasTable(Operator):
+  """
+  Defines a table with name `table_name` and the schema defined in the result_type.
+
+  Example:
+
+  '''
+  %0 : rel_impl.bag<[!rel_impl.int32]> = rel_impl.pandas_table() ["table_name" = "t"]
+  '''
+  """
+  name = "rel_impl.pandas_table"
+
+  table_name = AttributeDef(StringAttr)
+  result = ResultDef(Bag)
+
+  @staticmethod
+  @builder
+  def get(name: str, result_type: Bag) -> 'PandasTable':
+    return PandasTable.build(
+        attributes={"table_name": StringAttr.from_str(name)},
+        result_types=[result_type])
+
+
+@irdl_op_definition
+class Select(Operator):
+  """
+  Selects all tuples of `input` according to the yielded expression in `predicates`.
+
+  Example:
+
+  '''
+  rel_impl.select(%0: rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) {
+    ...
+    rel_impl.yield(%3 : rel_impl.bool)
+  }
+  '''
+  """
+  name = "rel_impl.select"
+
+  input = OperandDef(Bag)
+  predicates = SingleBlockRegionDef()
+
+  result = ResultDef(Bag)
+
+  @builder
+  @staticmethod
+  def get(input: Operation, predicates: Region) -> 'Select':
+    return Select.build(operands=[input],
+                        regions=[predicates],
+                        result_types=[input.results[0].typ])
+
+
+@dataclass
+class RelImpl:
+  ctx: MLContext
+
+  def __post_init__(self: 'RelImpl'):
+    self.ctx.register_attr(Bag)
+    self.ctx.register_attr(DataType)
+    self.ctx.register_attr(Int32)
+    self.ctx.register_attr(String)
+    self.ctx.register_attr(Boolean)
+    self.ctx.register_attr(SchemaElement)
+    self.ctx.register_attr(Tuple)
+
+    self.ctx.register_op(Select)
+    self.ctx.register_op(PandasTable)
+    self.ctx.register_op(Literal)
+    self.ctx.register_op(Compare)
+    self.ctx.register_op(IndexByName)
+    self.ctx.register_op(Yield)

--- a/experimental/sql/test/relational_implementation_dialect_tests/selection_op.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/selection_op.xdsl
@@ -1,0 +1,21 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+    %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) {
+      ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>):
+        %3 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : !i32]
+        %4 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_name" = "id"]
+        %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.int32, %4 : !rel_impl.int32) ["comparator" = "="]
+        rel_impl.yield(%5 : !rel_impl.bool)
+    }
+}
+
+//      CHECK:    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+// CHECK-NEXT:    %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) {
+// CHECK-NEXT:      ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>):
+// CHECK-NEXT:        %3 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : !i32]
+// CHECK-NEXT:        %4 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_name" = "id"]
+// CHECK-NEXT:        %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.int32, %4 : !rel_impl.int32) ["comparator" = "="]
+// CHECK-NEXT:        rel_impl.yield(%5 : !rel_impl.bool)
+// CHECK-NEXT:    }

--- a/experimental/sql/test/relational_implementation_dialect_tests/table_op.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/table_op.xdsl
@@ -1,0 +1,7 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+}
+
+// CHECK: %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -12,6 +12,7 @@ from src.alg_to_ssa import alg_to_ssa
 from dialects.ibis_dialect import Ibis
 from dialects.rel_alg import RelationalAlg
 from dialects.rel_ssa import RelSSA
+from dialects.rel_impl import RelImpl
 
 
 class RelOptMain(xDSLOptMain):
@@ -50,6 +51,7 @@ class RelOptMain(xDSLOptMain):
     ibis = Ibis(self.ctx)
     rel_Alg = RelationalAlg(self.ctx)
     rel_ssa = RelSSA(self.ctx)
+    rel_impl = RelImpl(self.ctx)
 
 
 def __main__():


### PR DESCRIPTION
This patch adds a first prototype of the rel_impl dialect, a dialect that should be closer to the implementation than the rel_ssa dialect. In particular, there are block arguments introduced for selections and there should only be operations for join implementations in the future.