### PR TITLE
Update linalg bufferization attributes.

### DIFF
--- a/experimental/alp/python/alp/transition/blas/gemm.py
+++ b/experimental/alp/python/alp/transition/blas/gemm.py
@@ -43,8 +43,8 @@ def attach_inplaceable_attributes(func: func.FuncOp,
       continue
     attrs.append(
         DictAttr.get({
-            "linalg.inplaceable": BoolAttr.get(flag),
-            "linalg.buffer_layout": AffineMapAttr.get(map0),
+            "bufferization.writable": BoolAttr.get(flag),
+            "bufferization.buffer_layout": AffineMapAttr.get(map0),
         }))
   func.arg_attrs = attrs
 

--- a/python/examples/core/compilation.py
+++ b/python/examples/core/compilation.py
@@ -75,8 +75,8 @@ def attach_inplaceable_attributes(func: func.FuncOp,
         AffineMap.get_identity(RankedTensorType(t).rank))
     attrs.append(
         DictAttr.get({
-            "linalg.inplaceable": BoolAttr.get(flag),
-            "linalg.buffer_layout": identity_map
+            "bufferization.writable": BoolAttr.get(flag),
+            "bufferization.buffer_layout": identity_map
         }))
   func.arg_attrs = attrs
 

--- a/test/Dialect/linalg_transform/bufferize.mlir
+++ b/test/Dialect/linalg_transform/bufferize.mlir
@@ -6,7 +6,7 @@
 // CHECK-SAME:    %[[TC:[0-9a-z]+]]: memref<128x128xf32
 // CHECK-NOT:   -> tensor
 func @matmul_tensors(
-  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { bufferization.writable = true})
     -> tensor<128x128xf32> {
   // CHECK: linalg.matmul ins(%[[TA]], %[[TB]] : memref{{.*}}, memref{{.*}} outs(%[[TC]] : memref{{.*}})
   %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)

--- a/test/Dialect/linalg_transform/double-tiling.mlir
+++ b/test/Dialect/linalg_transform/double-tiling.mlir
@@ -4,7 +4,7 @@
 
 // CHECK-LABEL: func @matmul_tensors(
 func @matmul_tensors(
-  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { bufferization.writable = true})
     -> tensor<128x128xf32> {
   // Pack transposed padding of 1st operand.
   //      CHECK:    tensor.pad

--- a/test/Dialect/linalg_transform/drop-schedule.mlir
+++ b/test/Dialect/linalg_transform/drop-schedule.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-proto-opt -linalg-drop-schedule %s | FileCheck %s
 
 func @matmul_tensors(
-  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { bufferization.writable = true})
     -> tensor<128x128xf32> {
   %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
                      outs(%arg2: tensor<128x128xf32>)

--- a/test/Dialect/linalg_transform/expert.mlir
+++ b/test/Dialect/linalg_transform/expert.mlir
@@ -5,7 +5,7 @@
 // CHECK-NOT: linalg
 // CHECK: llvm
 func @matmul_tensors(
-  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { bufferization.writable = true})
     -> tensor<128x128xf32> {
   %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
                      outs(%arg2: tensor<128x128xf32>)
@@ -88,7 +88,7 @@ module @strategies {
 // CHECK-NOT: linalg
 // CHECK: llvm
 func @matmul_tensors2(
-  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { bufferization.writable = true})
     -> tensor<128x128xf32> {
   %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
                      outs(%arg2: tensor<128x128xf32>)

--- a/test/Dialect/linalg_transform/failure.mlir
+++ b/test/Dialect/linalg_transform/failure.mlir
@@ -104,7 +104,7 @@ iree_linalg_transform.sequence {
 
 func @no_replacement(
   %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>,
-  %arg2: tensor<128x128xf32> {linalg.inplaceable = true})
+  %arg2: tensor<128x128xf32> {bufferization.writable = true})
     -> tensor<128x128xf32> {
   // expected-error @below {{could not find replacement for tracked op}}
   %0 = linalg.matmul {test.attrA}
@@ -135,7 +135,7 @@ iree_linalg_transform.sequence {
 
 func @repeated_match(
   %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>,
-  %arg2: tensor<128x128xf32> {linalg.inplaceable = true})
+  %arg2: tensor<128x128xf32> {bufferization.writable = true})
     -> tensor<128x128xf32> {
   // expected-error @below {{operation tracked by two handles}}
   %0 = linalg.matmul {test.attrA}

--- a/test/Dialect/linalg_transform/selective-targeting.mlir
+++ b/test/Dialect/linalg_transform/selective-targeting.mlir
@@ -4,7 +4,7 @@
 func @matmul_tensors(
   %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>,
   %arg3: tensor<128x128xf32>, %arg4: tensor<128x128xf32>, %arg5: tensor<128x128xf32>,
-  %arg6: tensor<128x128xf32> {linalg.inplaceable = true})
+  %arg6: tensor<128x128xf32> {bufferization.writable = true})
     -> tensor<128x128xf32> {
   // This operation is marked for tiling only.
   // CHECK-COUNT-3: scf.for
@@ -82,7 +82,7 @@ iree_linalg_transform.sequence {
 // CHECK-LABEL: @vectorize_one
 func @vectorize_one(
   %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>,
-  %arg3: tensor<128x128xf32> {linalg.inplaceable = true})
+  %arg3: tensor<128x128xf32> {bufferization.writable = true})
     -> tensor<128x128xf32> {
   // CHECK: vector.contract
   %0 = linalg.matmul {test.attrA}
@@ -118,7 +118,7 @@ iree_linalg_transform.sequence {
 // CHECK-LABEL: @vectorize_all
 func @vectorize_all(
   %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>,
-  %arg3: tensor<128x128xf32> {linalg.inplaceable = true})
+  %arg3: tensor<128x128xf32> {bufferization.writable = true})
     -> tensor<128x128xf32> {
   // CHECK: vector.contract
   %0 = linalg.matmul {test.attrA}

--- a/test/Dialect/linalg_transform/single-tiling-full-script.mlir
+++ b/test/Dialect/linalg_transform/single-tiling-full-script.mlir
@@ -4,7 +4,7 @@
 // CHECK-NOT: linalg
 // CHECK: llvm
 func @matmul_tensors(
-  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { bufferization.writable = true})
     -> tensor<128x128xf32> {
   %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
                      outs(%arg2: tensor<128x128xf32>)

--- a/test/Dialect/linalg_transform/tile-and-peel.mlir
+++ b/test/Dialect/linalg_transform/tile-and-peel.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: func @matmul_tensors(
 func @matmul_tensors(
-  %arg0: tensor<126x127xf32>, %arg1: tensor<127x128xf32>, %arg2: tensor<126x128xf32> { linalg.inplaceable = true})
+  %arg0: tensor<126x127xf32>, %arg1: tensor<127x128xf32>, %arg2: tensor<126x128xf32> { bufferization.writable = true})
     -> tensor<126x128xf32> {
   // CHECK-DAG: %[[c124:.*]] = arith.constant 124 : index
   // CHECK-DAG: %[[c127:.*]] = arith.constant 127 : index

--- a/test/Dialect/linalg_transform/tile-interchange.mlir
+++ b/test/Dialect/linalg_transform/tile-interchange.mlir
@@ -9,7 +9,7 @@
 // CHECK-LABEL: @matmul_021
 // CHECK-NOT: linalg.generic
 // CHECK: vector.contract
-func public @matmul_021(%arg0: tensor<39x154xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = false}, %arg1: tensor<154x5xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = false}, %arg2: tensor<39x5xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = true}) -> tensor<39x5xf32> attributes {passthrough = ["noinline", ["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]} {
+func public @matmul_021(%arg0: tensor<39x154xf32> {bufferization.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, bufferization.writable = false}, %arg1: tensor<154x5xf32> {bufferization.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, bufferization.writable = false}, %arg2: tensor<39x5xf32> {bufferization.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, bufferization.writable = true}) -> tensor<39x5xf32> attributes {passthrough = ["noinline", ["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]} {
   %0 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<39x154xf32>, tensor<154x5xf32>) outs(%arg2 : tensor<39x5xf32>) {
   ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
     %1 = arith.mulf %arg3, %arg4 : f32
@@ -47,7 +47,7 @@ iree_linalg_transform.sequence {
 // CHECK-LABEL: @matmul_210
 // CHECK-NOT: linalg.generic
 // CHECK: vector.contract
-func public @matmul_210(%arg0: tensor<39x154xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = false}, %arg1: tensor<154x5xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = false}, %arg2: tensor<39x5xf32> {linalg.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, linalg.inplaceable = true}) -> tensor<39x5xf32> attributes {passthrough = ["noinline", ["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]} {
+func public @matmul_210(%arg0: tensor<39x154xf32> {bufferization.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, bufferization.writable = false}, %arg1: tensor<154x5xf32> {bufferization.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, bufferization.writable = false}, %arg2: tensor<39x5xf32> {bufferization.buffer_layout = affine_map<(d0, d1) -> (d0, d1)>, bufferization.writable = true}) -> tensor<39x5xf32> attributes {passthrough = ["noinline", ["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]} {
   %0 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<39x154xf32>, tensor<154x5xf32>) outs(%arg2 : tensor<39x5xf32>) {
   ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
     %1 = arith.mulf %arg3, %arg4 : f32

--- a/test/Dialect/linalg_transform/tile.mlir
+++ b/test/Dialect/linalg_transform/tile.mlir
@@ -6,7 +6,7 @@
 // CHECK-SAME:    %[[TC:[0-9a-z]+]]: tensor<128x128xf32>
 // CHECK-SAME:  -> tensor<128x128xf32> {
 func @matmul_tensors(
-  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { bufferization.writable = true})
     -> tensor<128x128xf32> {
 //      CHECK: %[[TD0:.*]] = scf.for {{.*}} to {{.*}} step {{.*}} iter_args(%[[TC0:.*]] = %[[TC]]) -> (tensor<128x128xf32>) {
 //      CHECK:   %[[TD1:.*]] = scf.for {{.*}} to {{.*}} step {{.*}} iter_args(%[[TC1:.*]] = %[[TC0]]) -> (tensor<128x128xf32>) {

--- a/test/Dialect/linalg_transform/vectorize.mlir
+++ b/test/Dialect/linalg_transform/vectorize.mlir
@@ -6,7 +6,7 @@
 // CHECK-SAME:    %[[TC:[0-9a-z]+]]: tensor<128x128xf32>
 // CHECK-SAME:  -> tensor<128x128xf32> {
 func @matmul_tensors(
-  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { linalg.inplaceable = true})
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32> { bufferization.writable = true})
     -> tensor<128x128xf32> {
   // CHECK: %[[VA:.*]] = vector.transfer_read %[[TA]]
   // CHECK: %[[VB:.*]] = vector.transfer_read %[[TB]]

--- a/test/matmul-f32-base.mlir
+++ b/test/matmul-f32-base.mlir
@@ -6,9 +6,9 @@
 !row_major_C = type tensor<${M}x${N}x!elem_type_c>
 
 func @init_and_matmul(
-  %a: !row_major_A {linalg.buffer_layout = affine_map<(i, j)[s0, s1] -> (i, j)>},
-  %b: !row_major_B {linalg.buffer_layout = affine_map<(i, j)[s0, s1] -> (i, j)>},
-  %c: !row_major_C {linalg.buffer_layout = affine_map<(i, j)[s0, s1] -> (i, j)>}) -> !row_major_C
+  %a: !row_major_A {bufferization.buffer_layout = affine_map<(i, j)[s0, s1] -> (i, j)>},
+  %b: !row_major_B {bufferization.buffer_layout = affine_map<(i, j)[s0, s1] -> (i, j)>},
+  %c: !row_major_C {bufferization.buffer_layout = affine_map<(i, j)[s0, s1] -> (i, j)>}) -> !row_major_C
 // TODO: activate manually for now.
 // attributes { passthrough = [["target-cpu", "skylake-avx512"], ["prefer-vector-width", "512"]]}
 {


### PR DESCRIPTION
In the new OneShotBufferization, the `linalg.buffer_layout` and `linalg.inplaceable` are replaced by `bufferization.buffer_layout` and `bufferization.writable`.

This fixes the bufferization after we bumped the LLVM in #459.