### PR TITLE
Fix IREE test.

### DIFF
--- a/python/examples/dialects/linalg_transform_test.py
+++ b/python/examples/dialects/linalg_transform_test.py
@@ -27,6 +27,7 @@ def tile_once(module):
     with ir.InsertionPoint(foo_pattern.body):
       pdl_op = pdl.OperationOp()
       pdl.RewriteOp(pdl_op, "transform.dialect")
+
     sequence = transform.CanonicalizedSequenceOp(root.body.blocks[0].arguments[0])
     sequence_block = sequence.body.blocks[0]
     with ir.InsertionPoint(sequence_block):

--- a/python/examples/iree/simple_matmul.py
+++ b/python/examples/iree/simple_matmul.py
@@ -3,6 +3,7 @@ import numpy as np
 import logging
 from iree import runtime as ireert
 from iree.compiler import compile_str
+from iree.compiler.transforms import ireec
 
 import iree.compiler.tools
 import iree.compiler.dialects.transform as transform
@@ -14,49 +15,51 @@ import iree.compiler.ir as ir
 
 module_str = None
 with ir.Context() as ctx, ir.Location.unknown(ctx):
-  transform.register_dialect(ctx)
+  ireec.register_all_dialects(ctx)
+
   module = ir.Module.create()
   with ir.InsertionPoint(module.body):
-    isa_matmul = pdl.PatternOp(benefit = 1, name = "isa_matmul")
-    with ir.InsertionPoint(isa_matmul.body):
-      args = pdl.OperandsOp()
-      types = pdl.TypesOp()
-      pdl_op = pdl.OperationOp(args=[args], types=[types])
-      op_name = pdl.AttributeOp(value=ir.StringAttr.get("linalg.matmul"))
-      pdl.ApplyNativeConstraintOp("isEquivalentToOp", args=[pdl_op, op_name])
-      pdl.RewriteOp(pdl_op, "transform.apply")
+    root = transform.WithPDLPatternsOp(root=None)
+    with ir.InsertionPoint(root.body.blocks[0]):
+      isa_matmul = pdl.PatternOp(benefit = 1, name = "isa_matmul")
+      with ir.InsertionPoint(isa_matmul.body):
+        args = pdl.OperandsOp()
+        types = pdl.TypesOp()
+        pdl_op = pdl.OperationOp(args=[args], types=[types])
+        op_name = pdl.AttributeOp(value=ir.StringAttr.get("linalg.matmul"))
+        pdl.ApplyNativeConstraintOp("isEquivalentToOp", args=[pdl_op, op_name])
+        pdl.RewriteOp(pdl_op, "transform.dialect")
 
-    transform_sequence = transform.SequenceOp()
-    with ir.InsertionPoint(transform_sequence.body.blocks[0]):
-      ir.Operation.create(name="transform.iree.set_num_workgroups_to_one")
-      target_match = transform.MatchOp(ir.FlatSymbolRefAttr.get('isa_matmul'))
-      # TODO: fuse...
-      tiled = transform.TileOp(target=target_match,
-                               sizes=[8, 32, 8],
-                               interchange=[0, 1, 2])
-      transform.PeelLoopOp(tiled.results[1])
-      transform.PeelLoopOp(tiled.results[2])
-      # TODO: Match dynamic matmul and scalarize.
-      transform.VectorizeOp(vectorize_padding=False)
-      ir.Operation.create(name="transform.iree.bufferize")
+      sequence = transform.CanonicalizedSequenceOp(root.body.blocks[0].arguments[0])
+      sequence_block = sequence.body.blocks[0]
+      with ir.InsertionPoint(sequence_block):
+        ir.Operation.create(name="transform.iree.set_num_workgroups_to_one")
+        target_match = transform.PDLMatchOp(sequence_block.arguments[0], "isa_matmul")
+        # TODO: fuse...
+        tiled = transform.TileOp(target=target_match, sizes=[8, 32, 8])
+        transform.PeelLoopOp(tiled.results[1])
+        transform.PeelLoopOp(tiled.results[2])
+        # TODO: Match dynamic matmul and scalarize.
+        transform.VectorizeOp(vectorize_padding=False)
+        ir.Operation.create(name="transform.iree.bufferize")
 
-      stages = []
-      for i in range(1, 8):
-        stages.append(i)
-        transform.LowerVectorsOp(contraction_lowering="outerproduct",
-                                 multireduction_lowering="innerparallel",
-                                 split_transfers="linalg-copy",
-                                 stages=stages,
-                                 transpose_avx2_lowering=False,
-                                 transpose_lowering="eltwise",
-                                 unroll_vector_transfers=True)
+        stages = []
+        for i in range(1, 8):
+          stages.append(i)
+          transform.LowerVectorsOp(contraction_lowering="outerproduct",
+                                  multireduction_lowering="innerparallel",
+                                  split_transfers="linalg-copy",
+                                  stages=stages,
+                                  transpose_avx2_lowering=False,
+                                  transpose_lowering="eltwise",
+                                  unroll_vector_transfers=True)
 
-      transform.YieldOp([])
+        transform.YieldOp([])
   module_str = str(module)
 
-################################################################################
-# Hardcoded strategy with the schedule dialect to drive IREE through a file.
-################################################################################
+# ################################################################################
+# # Hardcoded strategy with the schedule dialect to drive IREE through a file.
+# ################################################################################
 
 TRANSFORM_SPEC_FILE_NAME = "/tmp/linalg_transform_spec.mlir"
 with open(TRANSFORM_SPEC_FILE_NAME, "w") as f:
@@ -69,7 +72,7 @@ with open(TRANSFORM_SPEC_FILE_NAME, "w") as f:
 # Compile a module.
 
 DOT_ASM = """
-func @dot(%lhs: tensor<127x128xf32>, %rhs: tensor<128x129xf32>) -> tensor<127x129xf32> {
+func.func @dot(%lhs: tensor<127x128xf32>, %rhs: tensor<128x129xf32>) -> tensor<127x129xf32> {
      %0 = "mhlo.dot"(%lhs, %rhs) : (tensor<127x128xf32>, tensor<128x129xf32>) -> tensor<127x129xf32>
     return %0 : tensor<127x129xf32>
 }
@@ -101,7 +104,7 @@ ctx.add_vm_module(vm_module)
 lhs = np.full((127, 128), 1, dtype=np.float32)
 rhs = np.full((128, 129), 2, dtype=np.float32)
 dot = ctx.modules.module.dot
-res = dot()
+res = dot(lhs, rhs)
 
 np.testing.assert_allclose(res, np.dot(lhs, rhs))
 print('SUCCESS')


### PR DESCRIPTION
This requires IREE using an LLVM version that does not crash when registering ops multiple times in the transform dialect (incoming).
Additionally, the roundtripping through a file is currently broken in core and requires manual intervention (i.e. manually prefixing transform op names with `transform.`).
    
Once both are fixed, the test passes.