### PR TITLE
SQL: add int64 everywhere

### DIFF
--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -38,6 +38,20 @@ class Int32(DataType):
 
 
 @irdl_attr_definition
+class Int64(DataType):
+  """
+  Models a int64 type in a relational query.
+
+  Example:
+
+  ```
+  !rel_alg.int64
+  ```
+  """
+  name = "rel_alg.int64"
+
+
+@irdl_attr_definition
 class String(DataType):
   """
   Models a string type in a relational query, that can be either nullable or
@@ -267,6 +281,7 @@ class RelationalAlg:
     self.ctx.register_attr(DataType)
     self.ctx.register_attr(String)
     self.ctx.register_attr(Int32)
+    self.ctx.register_attr(Int64)
 
     self.ctx.register_op(PandasTable)
     self.ctx.register_op(SchemaElement)

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -44,6 +44,20 @@ class Int32(DataType):
 
 
 @irdl_attr_definition
+class Int64(DataType):
+  """
+  Models a int64 type in a relational implementation query.
+
+  Example:
+
+  ```
+  !rel_impl.int64
+  ```
+  """
+  name = "rel_impl.int64"
+
+
+@irdl_attr_definition
 class String(DataType):
   """
   Models a string type in a relational implementation query, that can be either
@@ -386,6 +400,7 @@ class RelImpl:
     self.ctx.register_attr(Bag)
     self.ctx.register_attr(DataType)
     self.ctx.register_attr(Int32)
+    self.ctx.register_attr(Int64)
     self.ctx.register_attr(String)
     self.ctx.register_attr(Boolean)
     self.ctx.register_attr(SchemaElement)

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -42,6 +42,20 @@ class Int32(DataType):
 
 
 @irdl_attr_definition
+class Int64(DataType):
+  """
+  Models a int64 type in a relational SSA query.
+
+  Example:
+
+  ```
+  !rel_ssa.int64
+  ```
+  """
+  name = "rel_ssa.int64"
+
+
+@irdl_attr_definition
 class String(DataType):
   """
   Models a string type in a relational SSA query, that can be either nullable or
@@ -357,6 +371,7 @@ class RelSSA:
     self.ctx.register_attr(Bag)
     self.ctx.register_attr(DataType)
     self.ctx.register_attr(Int32)
+    self.ctx.register_attr(Int64)
     self.ctx.register_attr(String)
     self.ctx.register_attr(Boolean)
     self.ctx.register_attr(SchemaElement)

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -29,6 +29,8 @@ class RelAlgRewriter(RewritePattern):
       return RelSSA.String.get(type_.nullable)
     if isinstance(type_, RelAlg.Int32):
       return RelSSA.Int32()
+    if isinstance(type_, RelAlg.Int64):
+      return RelSSA.Int64()
     raise Exception(
         f"datatype conversion not yet implemented for {type(type_)}")
 

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -27,6 +27,8 @@ class IbisRewriter(RewritePattern):
       return RelAlg.String.get(type_.nullable)
     if isinstance(type_, ibis.Int32):
       return RelAlg.Int32()
+    if isinstance(type_, ibis.Int64):
+      return RelAlg.Int64()
     raise Exception(
         f"datatype conversion not yet implemented for {type(type_)}")
 

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -26,6 +26,8 @@ class RelSSARewriter(RewritePattern):
       return RelImpl.String.get(type_.nullable)
     if isinstance(type_, RelSSA.Int32):
       return RelImpl.Int32()
+    if isinstance(type_, RelSSA.Int64):
+      return RelImpl.Int64()
     raise Exception(
         f"datatype conversion not yet implemented for {type(type_)}")
 


### PR DESCRIPTION
This patch adds the int64 datatype everywhere. This is needed since ibis represents integers of pandas dataframes as int64, so we will need to lower this throughout the entire pipeline.