### PR TITLE
Consume IREE as submodule by default.

### DIFF
--- a/.github/workflows/buildAndTestIreeDialects.yml
+++ b/.github/workflows/buildAndTestIreeDialects.yml
@@ -25,14 +25,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: sandbox
-    - name: Checkout IREE
-      uses: actions/checkout@v2
-      with:
-        path: iree
-        repository: nicolasvasilache/iree
-        # Always build with iree/iree-dialects on the nicolasvasilache/iree/ntv-sandbox branch.
-        ref: ntv-sandbox
-        # Use the LLVM version bundled with IREE and coming from iree-llvm-fork.
         submodules: recursive
 
     - name: Install Python depends
@@ -50,8 +42,7 @@ jobs:
     - name: Build
       run: |
         cd ${GITHUB_WORKSPACE}/sandbox
-        # Always build with iree/iree-dialects on the iree/ntv-sandbox branch.
-        python configure.py --iree-path=../iree
+        python configure.py
         ccache -s
         echo "IREE_LLVM_SANDBOX_BUILD_DIR=${GITHUB_WORKSPACE}/sandbox/build" >> $GITHUB_ENV
 

--- a/.github/workflows/buildAndTestIterators.yml
+++ b/.github/workflows/buildAndTestIterators.yml
@@ -25,14 +25,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: sandbox
-    - name: Checkout IREE
-      uses: actions/checkout@v2
-      with:
-        path: iree
-        repository: nicolasvasilache/iree
-        # Always build with iree/iree-dialects on the nicolasvasilache/iree/ntv-sandbox branch.
-        ref: ntv-sandbox
-        # Use the LLVM version bundled with IREE and coming from iree-llvm-fork.
         submodules: recursive
 
     - name: Install Python depends
@@ -50,8 +42,7 @@ jobs:
     - name: Build
       run: |
         cd ${GITHUB_WORKSPACE}/sandbox
-        # Always build with iree/iree-dialects on the iree/ntv-sandbox branch.
-        python configure.py --iree-path=../iree --iterators
+        python configure.py --iterators
         ccache -s
         echo "IREE_LLVM_SANDBOX_BUILD_DIR=${GITHUB_WORKSPACE}/sandbox/build" >> $GITHUB_ENV
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/iree"]
+	path = third_party/iree
+	url = https://github.com/google/iree.git

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In your `$HOME/src` directory, check out each project:
 
 Required:
 
-* `git clone https://github.com/google/iree-llvm-sandbox`
+* `git clone --recursive https://github.com/google/iree-llvm-sandbox`
 
 We use the following environment variables defaults in these instructions:
 
@@ -53,37 +53,51 @@ python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
 ```
 
-## Configure and build
-
-The sandbox must be built with IREE integration.
-
 Note that useful python environment `activate` scripts for `mlirdev` and
 `mlirdev-debug` are provided in the `scripts` directory.
 
-Checkout the [IREE](https://github.com/google/iree) GitHub repo next to this
-directory and initialize submodules:
+## Configure and build
 
-```
-(cd .. && git clone https://github.com/google/iree --recurse-submodules=third_party/llvm-project && \
- git checkout ntv-sandbox && \
- git submodule update --init --recursive)
-```
+### Default IREE and LLVM versions
 
-And configure/build the project:
+Make sure that the git submodules are clone and up to date:
 
-```
-python configure.py --iree-path=../iree
+```bash
+git submodule update --recursive --init
 ```
 
-Or if using `scripts/mlirdev/bin/activate`:
+Configure the project and run an initial build:
 
+```bash
+python configure.py
 ```
+
+Run subsequent builds with:
+
+```bash
+cd ${IREE_LLVM_SANDBOX_BUILD_DIR}
+ninja
+```
+
+If using using `scripts/mlirdev/bin/activate`, the above steps can be run as:
+
+```bash
+sandbox-update-dependencies
 sandbox-configure-and-build-iree
+sandbox-build
 ```
 
-Note that the `third_party/llvm-project` bundled with IREE is used.
-The `IREE` `ntv-sandbox` branch often runs ahead of the IREE integration and should
-generally be used.
+### Custom IREE and LLVM versions
+
+Instead of using the versions of IREE and (transitively) LLVM as described
+above, i.e., by using the git submodules referenced by this repository, you
+can provide paths for custom locations of these dependencies:
+
+```bash
+python configure --iree-path=../iree  # Custom IREE with IREE-provided LLVM
+python configure --llvm-path=../llvm  # Default IREE but custom LLVM
+python configure --llvm-path=../llvm --iree-path=../iree  # Both custom
+```
 
 ## Using the Python API
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We use the following environment variables defaults in these instructions:
 Follow the instructions for
 [MLIR Python Bindings](https://mlir.llvm.org/docs/Bindings/Python/):
 
-```
+```bash
 which python
 python -m venv ~/.venv/mlirdev
 source ~/.venv/mlirdev/bin/activate
@@ -101,7 +101,7 @@ python configure --llvm-path=../llvm --iree-path=../iree  # Both custom
 
 ## Using the Python API
 
-```
+```bash
 source .env && export PYTHONPATH
 
 # Sanity check (should not error).
@@ -116,7 +116,7 @@ python -m python.examples.matmul.test
 
 ## Using mlir-proto-opt
 
-```
+```bash
 "${IREE_LLVM_SANDBOX_BUILD_DIR}"/bin/mlir-proto-opt \
   test/Dialect/vector_ext/vector_masking.mlir \
   -test-vector-masking-utils=masking -split-input-file
@@ -126,7 +126,7 @@ python -m python.examples.matmul.test
 
 The following commands either run the lit tests only or all tests:
 
-```
+```bash
 # Run lit tests
 lit -v test
 # Run python and lit tests
@@ -142,7 +142,7 @@ to display as-you-type diagnostics, code navigation, and similar features. In
 order to extend this functionality to the dialects from this repository, use
 the following LSP server binary:
 
-```
+```bash
 /path/to/iree-llvm-sandbox/build/bin/mlir-proto-lsp-server
 ```
 
@@ -154,7 +154,7 @@ In VS Code, this is done via the `mlir.server_path` property in
 The following command runs a simple search of 1000 iterations distributed across
 all processors of the machine, for a matmul of fixed size `40x50x60`:
 
-```
+```bash
 iree-llvm-sandbox# python -m python.examples.tuning.test_nevergrad_small_matmul \
 --search-budget 1000 --n_iters 100 --num-parallel-tasks $(nproc --all) \
 --num-cpus-per-benchmark 1 --timeout-per-compilation 1 --timeout-per-benchmark 1 \
@@ -166,7 +166,7 @@ iree-llvm-sandbox# python -m python.examples.tuning.test_nevergrad_small_matmul 
 Adaptation of recommended benchmark instructions found [here](https://llvm.org/docs/Benchmarking.html).
 Run the following as root.
 
-```
+```bash
 # Basic info
 numactl --hardware
 
@@ -237,14 +237,14 @@ PYTHONPATH=${IREE_LLVM_SANDBOX_BUILD_DIR}/tools/sandbox/python_packages cset pro
 
 Repro for experimental results described in [arxiv paper](https://arxiv.org/abs/2202.03293):
 
-```
+```bash
 git checkout 680c8160edb7aa13b621b28c221288624ebc37e4
 echo Please update LLVM to $(cat pinned-llvm-version)
 ```
 
 Hash before transitioning to schedule dialect only:
 
-```
+```bash
 git checkout ea0e5ec37a4d73808e16926c0335cc21fde0286c
 echo Please update LLVM to $(cat pinned-llvm-version)
 ```

--- a/configure.py
+++ b/configure.py
@@ -109,12 +109,16 @@ def main(args):
   llvm_builtin_projects = ["mlir", "clang", "clang-tools-extra"]
 
   # Detect IREE (defaults LLVM path as well).
-  iree_path = args.iree_path
+  if args.iree_path:
+    iree_path = os.path.abspath(args.iree_path)
+    print(f"-- Using explicit IREE path: {iree_path}")
+  else:
+    iree_path = os.path.abspath(
+        os.path.join(args.repo_root, 'third_party', 'iree'))
+    print(f"-- Using default IREE path at {iree_path}")
   if not os.path.exists(iree_path):
     print(f"ERROR: Could not find IREE at {iree_path}")
     return 1
-  iree_path = os.path.abspath(iree_path)
-  print(f"-- Enabling IREE from {iree_path}")
   if not os.path.exists(os.path.join(iree_path, "CMakeLists.txt")):
     print(f"ERROR: Could not find iree at {iree_path}")
     return 1

--- a/scripts/mlirdev/bin/activate
+++ b/scripts/mlirdev/bin/activate
@@ -22,6 +22,11 @@ export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:${ROOT_DIR}/.venv/mlirdev/lib/pyth
 
 export PYTHONPATH=${PYTHONPATH}:${IREE_LLVM_SANDBOX_BUILD_DIR}/tools/sandbox/python_packages/
 
+sandbox-update-dependencies() {
+    cd ${IREE_LLVM_SANDBOX_SOURCE_DIR}
+    git submodule update --recursive --init
+}
+
 sandbox-build() {
     cd ${IREE_LLVM_SANDBOX_SOURCE_DIR}
     (cd ${IREE_LLVM_SANDBOX_BUILD_DIR} && ninja tools/sandbox/all)


### PR DESCRIPTION
This PR changes the default build process such that IREE (and thus LLVM) is consumed as a git submodule instead of using a specific branch. This freezes the version of these dependencies such that unrelated updates of that branch do not affect them.