### PR TITLE
Update Github action for ccache to avoid cache flushing.

### DIFF
--- a/.github/workflows/buildAndTestIreeDialects.yml
+++ b/.github/workflows/buildAndTestIreeDialects.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install Ninja
       uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
     - name: Ccache for C++ compilation
-      uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
+      uses: hendrikmuhs/ccache-action@ed038da2f2f09b0c8387c00e1498290a4808da2e # v1.2.2
       with:
         key: ${{ runner.os }}-buildtestasserts
         # LLVM needs serious cache size

--- a/.github/workflows/buildAndTestIterators.yml
+++ b/.github/workflows/buildAndTestIterators.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install Ninja
       uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
     - name: Ccache for C++ compilation
-      uses: hendrikmuhs/ccache-action@4687d037e4d7cf725512d9b819137a3af34d39b3
+      uses: hendrikmuhs/ccache-action@ed038da2f2f09b0c8387c00e1498290a4808da2e # v1.2.2
       with:
         key: ${{ runner.os }}-buildtestasserts
         # LLVM needs serious cache size


### PR DESCRIPTION
The version of the ccache Github action we are currently using uploads the ccache even if the cache is empty. This can happen if a CI job is cancelled at an unfortunate moment, such as this one: https://github.com/google/iree-llvm-sandbox/runs/6447917749 (see that the cache size is 0.0 kB and that it is uploaded with the key `ccache-Linux-buildtestasserts-2022-05-16T07:40:36.374Z`). This means that subsequent builds start with an empty cache (as happened here: https://github.com/google/iree-llvm-sandbox/runs/6447938528).

This issue in the Github action has been raised recently and fixed (see https://github.com/hendrikmuhs/ccache-action/issues/45), which the latest version includes.