### PR TITLE
Iterators: Improve and extend print ops to any tuple of numerics

### DIFF
--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -36,15 +36,18 @@ def MatchingFieldCountsConstraint
 def Iterators_ConstantTupleOp
     : Iterators_Base_Op<"constant", [MatchingFieldCountsConstraint]> {
   let summary = "Creates a tuple from the given values";
-  // TODO(ingomueller): extend to more field types
-  let arguments = (ins I32ArrayAttr:$values);
-  let results = (outs TupleOf<[I32]>:$tuple);
+  let arguments = (ins Iterators_NumericArrayAttr:$values);
+  let results = (outs Iterators_TupleOfNumerics:$tuple);
 }
 
-def Iterators_PrintTupleOp : Iterators_Base_Op<"print"> {
-  let summary = "Print the elements of a tuple";
-  // TODO(ingomueller): extend to all supported tuple types
-  let arguments = (ins TupleOf<[I32]>);
+def Iterators_PrintTupleOp : Iterators_Base_Op<"printtuple"> {
+  let summary = "Prints the elements of a tuple";
+  let arguments = (ins Iterators_TupleOfNumerics:$tuple);
+}
+
+def Iterators_PrintOp : Iterators_Base_Op<"print"> {
+  let summary = "Prints the given element";
+  let arguments = (ins Iterators_LLVMStructOfNumerics:$element);
 }
 
 //===----------------------------------------------------------------------===//

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
@@ -31,11 +31,38 @@ def Iterators_Stream : Iterators_Type<"Stream", "stream"> {
   let assemblyFormat = "`<` qualified($elementType) `>`";
 }
 
+/// List of LLVM-compatible numeric types.
+def Iterators_NumericTypes {
+  list<Type> types = [I1, I8, I16, I32, I64,
+                      F16, F32, F64];
+}
+
+/// Any LLVM-compatible numeric types..
+def Iterators_AnyNumeric
+  : AnyTypeOf<Iterators_NumericTypes.types>;
+
+/// A tuple consisting only of numeric types.
+def Iterators_TupleOfNumerics : TupleOf<Iterators_NumericTypes.types>;
+
+/// Attribute of numeric type.
+def Iterators_NumericAttr
+  : Attr<SubstLeaves<"$_self", "$_self.getType()",
+                     Iterators_AnyNumeric.predicate>,
+        "any numeric type">;
+
+/// Array of numeric attributes.
+def Iterators_NumericArrayAttr
+  : TypedArrayAttrBase<Iterators_NumericAttr, "array of numeric types">;
+
 /// An LLVMStructType where the body only uses the provided types.
 class Iterators_LLVMStructOf<list<Type> allowedTypes>
   : MixedContainerType<AnyTypeOf<allowedTypes>, LLVM_AnyStruct.predicate,
                        "$_self.cast<::mlir::LLVM::LLVMStructType>().getBody()",
                        "LLVM struct">;
+
+/// An LLVMStructType where the body only uses numeric types.
+def Iterators_LLVMStructOfNumerics
+  : Iterators_LLVMStructOf<Iterators_NumericTypes.types>;
 
 /// An LLVMStructType where the body consists of a single I32
 def Iterators_LLVMStructOfSingleI32

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/printconstant.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/printconstant.mlir
@@ -3,25 +3,26 @@
 
 // CHECK:      module {
 // CHECK-NEXT:   llvm.func @printf(!llvm.ptr<i8>, ...) -> i32
-// CHECK-NEXT:   llvm.mlir.global internal constant @frmt_spec.tuple[[S0:.*]]("(%i)\0A\00")
+// CHECK-NEXT:   llvm.mlir.global internal constant @frmt_spec.tuple[[S0:.*]]("(%lli)\0A\00")
 // CHECK-NEXT:   func @main() {
 func @main() {
-  %emptyTuple = "iterators.constant"() { values = [] } : () -> tuple<>
+  %empty_tuple = "iterators.constant"() { values = [] } : () -> tuple<>
   // CHECK-NEXT:     %[[V0:.*]] = llvm.mlir.undef : !llvm.struct<"tuple[[S0:.*]]", ()>
 
-  %oneFieldTuple = "iterators.constant"() { values = [1 : i32] } : () -> tuple<i32>
+  %one_field_tuple = "iterators.constant"() { values = [1 : i32] } : () -> tuple<i32>
   // CHECK-NEXT:     %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"tuple[[S1:.*]]", (i32)>
   // CHECK-NEXT:     %[[V2:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT:     %[[V3:.*]] = llvm.insertvalue %[[V2]], %[[V1]][0 : index] : !llvm.struct<"tuple[[S1]]", (i32)>
 
-  "iterators.print"(%oneFieldTuple) : (tuple<i32>) -> ()
-  // CHECK:          %[[V4:.*]] = llvm.mlir.addressof @frmt_spec.tuple[[S1]] : !llvm.ptr<array<6 x i8>>
+  "iterators.printtuple"(%one_field_tuple) : (tuple<i32>) -> ()
+  // CHECK:          %[[V4:.*]] = llvm.mlir.addressof @frmt_spec.tuple[[S1]] : !llvm.ptr<array<8 x i8>>
   // CHECK-NEXT:     %[[V5:.*]] = llvm.mlir.constant(0 : i64) : i64
-  // CHECK-NEXT:     %[[V6:.*]] = llvm.getelementptr %[[V4]][%[[V5]], %[[V5]]] : (!llvm.ptr<array<6 x i8>>, i64, i64) -> !llvm.ptr<i8>
+  // CHECK-NEXT:     %[[V6:.*]] = llvm.getelementptr %[[V4]][%[[V5]], %[[V5]]] : (!llvm.ptr<array<8 x i8>>, i64, i64) -> !llvm.ptr<i8>
   // CHECK-NEXT:     %[[V7:.*]] = llvm.extractvalue %[[V3]][0 : index] : !llvm.struct<"tuple[[S1]]", (i32)>
-  // CHECK-NEXT:     %[[V8:.*]] = llvm.call @printf(%[[V6]], %[[V7]]) : (!llvm.ptr<i8>, i32) -> i32
+  // CHECK-NEXT:     %[[Vb:.*]] = llvm.zext %[[V7]] : i32 to i64
+  // CHECK-NEXT:     %[[V8:.*]] = llvm.call @printf(%[[V6]], %[[Vb]]) : (!llvm.ptr<i8>, i64) -> i32
 
-  %threeFieldTuple = "iterators.constant"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
+  %three_field_tuple = "iterators.constant"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
   // CHECK-NEXT:     %[[V4:.*]] = llvm.mlir.undef : !llvm.struct<"tuple[[S2:.*]]", (i32, i32, i32)>
   // CHECK-NEXT:     %[[V5:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT:     %[[V6:.*]] = llvm.insertvalue %[[V5]], %[[V4]][0 : index] : !llvm.struct<"tuple[[S2]]", (i32, i32, i32)>

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/sink.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/sink.mlir
@@ -14,11 +14,12 @@ func @main() {
   // CHECK-NEXT:      scf.condition(%[[V4]]#1) %[[V4]]#0, %[[V4]]#2 : [[rootStateType]], !llvm.struct<(i32)>
   // CHECK-NEXT:    } do {
   // CHECK-NEXT:    ^[[bb0:.*]](%[[arg1:.*]]: [[rootStateType]], %[[arg2:.*]]: !llvm.struct<(i32)>):
-  // CHECK-NEXT:      %[[V4]] = llvm.mlir.addressof @frmt_spec.anonymous_tuple : !llvm.ptr<array<6 x i8>>
+  // CHECK-NEXT:      %[[V4]] = llvm.mlir.addressof @frmt_spec.anonymous_tuple : !llvm.ptr<array<8 x i8>>
   // CHECK-NEXT:      %[[V5:.*]] = llvm.mlir.constant(0 : i64) : i64
-  // CHECK-NEXT:      %[[V6:.*]] = llvm.getelementptr %[[V4]][%[[V5]], %[[V5]]] : (!llvm.ptr<array<6 x i8>>, i64, i64) -> !llvm.ptr<i8>
+  // CHECK-NEXT:      %[[V6:.*]] = llvm.getelementptr %[[V4]][%[[V5]], %[[V5]]] : (!llvm.ptr<array<8 x i8>>, i64, i64) -> !llvm.ptr<i8>
   // CHECK-NEXT:      %[[V7:.*]] = llvm.extractvalue %[[arg2:.*]][0 : index] : !llvm.struct<(i32)>
-  // CHECK-NEXT:      %[[V8:.*]] = llvm.call @printf(%[[V6]], %[[V7]]) : (!llvm.ptr<i8>, i32) -> i32
+  // CHECK-NEXT:      %[[V9:.*]] = llvm.zext %[[V7]] : i32 to i64
+  // CHECK-NEXT:      %[[V8:.*]] = llvm.call @printf(%[[V6]], %[[V9]]) : (!llvm.ptr<i8>, i64) -> i32
   // CHECK-NEXT:      scf.yield %[[arg1]] : [[rootStateType]]
   // CHECK-NEXT:    }
   // CHECK-NEXT:    %[[V3:.*]] = call @[[rootIteratorName]].close.{{[0-9]+}}(%[[V2]]#0) : ([[rootStateType]]) -> [[rootStateType]]

--- a/experimental/iterators/test/Dialect/Iterators/constant.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/constant.mlir
@@ -2,8 +2,8 @@
 // RUN: mlir-proto-opt %s
 
 func @main() {
-  %emptyTuple = "iterators.constant"() { values = [] } : () -> tuple<>
-  %oneFieldTuple = "iterators.constant"() { values = [1 : i32] } : () -> tuple<i32>
-  %threeFieldTuple = "iterators.constant"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
+  %empty_tuple = "iterators.constant"() { values = [] } : () -> tuple<>
+  %one_field_tuple = "iterators.constant"() { values = [1 : i32] } : () -> tuple<i32>
+  %three_field_tuple = "iterators.constant"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
   return
 }

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/print.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/print.mlir
@@ -3,17 +3,31 @@
 // RUN: | FileCheck %s
 
 func @main() {
-  %emptyTuple = "iterators.constant"() { values = [] } : () -> tuple<>
-  "iterators.print"(%emptyTuple) : (tuple<>) -> ()
+  %empty_tuple = "iterators.constant"() { values = [] } : () -> tuple<>
+  "iterators.printtuple"(%empty_tuple) : (tuple<>) -> ()
   // CHECK:      ()
 
-  %oneFieldTuple = "iterators.constant"() { values = [1 : i32] } : () -> tuple<i32>
-  "iterators.print"(%oneFieldTuple) : (tuple<i32>) -> ()
+  %one_field_tuple = "iterators.constant"() { values = [1 : i32] } : () -> tuple<i32>
+  "iterators.printtuple"(%one_field_tuple) : (tuple<i32>) -> ()
   // CHECK-NEXT: (1)
 
-  %threeFieldTuple = "iterators.constant"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
-  "iterators.print"(%threeFieldTuple) : (tuple<i32, i32, i32>) -> ()
+  %three_field_tuple = "iterators.constant"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
+  "iterators.printtuple"(%three_field_tuple) : (tuple<i32, i32, i32>) -> ()
   // CHECK-NEXT: (1, 2, 3)
+
+  %mixed_field_tuple = "iterators.constant"()
+      { values = [1 : i1, 2 : i8, 3 : i16, 4 : i32, 5 : i64, 8.5 : f16, 8.25 : f32, 8.125 : f64] }
+      : () -> tuple<i1, i8, i16, i32, i64, f16, f32, f64>
+  "iterators.printtuple"(%mixed_field_tuple) : (tuple<i1, i8, i16, i32, i64, f16, f32, f64>) -> ()
+  // CHECK-NEXT: (1, 2, 3, 4, 5, 8.5, 8.25, 8.125)
+
+  %empty_struct = llvm.mlir.undef : !llvm.struct<()>
+  "iterators.print"(%empty_struct) : (!llvm.struct<()>) -> ()
+  // CHECK-NEXT: ()
+
+  %two_field_struct = llvm.mlir.constant([1, 2]) : !llvm.struct<(i32, i32)>
+  "iterators.print"(%two_field_struct) : (!llvm.struct<(i32, i32)>) -> ()
+  // CHECK-NEXT: (1, 2)
 
   return
 }


### PR DESCRIPTION
This PR depends on and therefore includes #482. It should be rebased once that PR is landed.

This PR adds support for printing of tuples and LLVM structs that contain numeric types. Printing is required for testing the support of other types in any interesting iterator op, so it makes sense to do this first.