### PR TITLE
Iterators: Parametrize ReduceOp with reduce function.

### DIFF
--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/Iterators.h
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/Iterators.h
@@ -9,6 +9,7 @@
 #ifndef ITERATORS_DIALECT_ITERATORS_IR_ITERATORS_H
 #define ITERATORS_DIALECT_ITERATORS_IR_ITERATORS_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -96,12 +96,70 @@ def Iterators_ConstantStreamOp
   let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
 }
 
-// TODO(ingomueller): Support custom reduce function.
-// TODO(ingomueller): Extend to any type matching reduce function.
-def Iterators_ReduceOp : Iterators_Op<"reduce"> {
+/// Looks up the given symbol, which must refer to a FuncOp, in the scope of the
+/// given op and returns the function type of that symbol.
+class LookupFuncType<string opName, string symbolName>
+  : StrFunc<"::mlir::SymbolTable::lookupNearestSymbolFrom<func::FuncOp>("
+            "    &$" # opName # ","
+            "    " # symbolName # ".dyn_cast<FlatSymbolRefAttr>())"
+            "       .getFunctionType()">;
+
+/// A reduce function, that is a function with a signature of the form
+/// (T, T) -> T.
+class Iterators_ReduceFunc
+  : Type<And<[FunctionType.predicate,
+              CPred<"$_self.dyn_cast<FunctionType>().getInputs().size() == 2">,
+              CPred<"$_self.dyn_cast<FunctionType>().getResults().size() == 1">,
+              AllMatchPred<[
+                "$_self.dyn_cast<FunctionType>().getInput(0)",
+                "$_self.dyn_cast<FunctionType>().getInput(1)",
+                "$_self.dyn_cast<FunctionType>().getResult(0)",
+              ]>
+             ]>,
+         "function with signature (T, T) -> T",
+         "FunctionType">;
+
+/// A FlatSymbolRef referring to a reduce function.
+def Iterators_ReduceFuncRefAttr
+  : Confined<FlatSymbolRefAttr, [
+        ReferToOp<"func::FuncOp">,
+        AttrConstraint<
+          SubstLeaves<"$_self",
+                      LookupFuncType<"_op", "$_self.dyn_cast<FlatSymbolRefAttr>()">.result,
+                      Iterators_ReduceFunc<>.predicate>,
+          "referring to a " # Iterators_ReduceFunc<>.summary>
+      ]>;
+
+def Iterators_ReduceOp : Iterators_Op<"reduce",
+    [AllMatch<["getReduceFunc().getResultTypes().front()",
+               "$input.getType().dyn_cast<StreamType>().getElementType()"],
+              "the reduce function signature must match its element type">]> {
   let summary = "Reduce the input to a single tuple";
-  let arguments = (ins Iterators_StreamOfLLVMStructOfSingleI32:$input);
-  let results = (outs Iterators_StreamOfLLVMStructOfSingleI32:$result);
+  let description = [{
+    Reads the elements of its operand stream and reduces them to a single
+    element using the provided reduce function. The result stream is empty iff
+    the operand stream is empty. Otherwise, the elements are reduced pairwise in
+    an implementation-defined order until a single element is left, which
+    constitutes the result stream. This is only deterministic if the reduce
+    function is associative.
+
+    Example:
+    ```mlir
+    %reduced = "iterators.reduce"(%input) {reduceFuncRef = @sum} :
+                   (!iterators.stream<i32>) -> (!iterators.stream<i32>)
+    ```
+  }];
+  let arguments = (ins
+      Iterators_StreamOfLLVMStructOfNumerics:$input,
+      Iterators_ReduceFuncRefAttr:$reduceFuncRef
+    );
+  let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
+  let extraClassDeclaration = [{
+    func::FuncOp getReduceFunc() {
+      return SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+          *this, reduceFuncRefAttr());
+    }
+  }];
 }
 
 /// The sink op is a special op that only consumes a stream of values and 

--- a/experimental/iterators/lib/Dialects/Iterators/IR/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialects/Iterators/IR/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_library(MLIRIterators
   Iterators.cpp
 
   LINK_LIBS PUBLIC
+  MLIRFunc
   MLIRInferTypeOpInterface
   MLIRIR
   MLIRLLVMIR

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/reduce.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/reduce.mlir
@@ -5,15 +5,58 @@
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \
 // RUN: | FileCheck %s
 
-!element_type = type !llvm.struct<(i32)>
+!i32_struct = type !llvm.struct<(i32)>
 
-func @main() {
+func private @sum_struct(%lhs : !i32_struct, %rhs : !i32_struct) -> !i32_struct {
+  %lhsi = llvm.extractvalue %lhs[0 : index] : !i32_struct
+  %rhsi = llvm.extractvalue %rhs[0 : index] : !i32_struct
+  %i = arith.addi %lhsi, %rhsi : i32
+  %result = llvm.insertvalue %i, %lhs[0 : index] : !i32_struct
+  return %result : !i32_struct
+}
+
+func @query1() {
   %input = "iterators.constantstream"()
       { value = [[0 : i32], [1 : i32], [2 : i32], [3 : i32]] }
-      : () -> (!iterators.stream<!element_type>)
-  %reduce = "iterators.reduce"(%input)
-      : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
-  "iterators.sink"(%reduce) : (!iterators.stream<!element_type>) -> ()
+      : () -> (!iterators.stream<!i32_struct>)
+  %reduce = "iterators.reduce"(%input) {reduceFuncRef = @sum_struct}
+    : (!iterators.stream<!i32_struct>) -> (!iterators.stream<!i32_struct>)
+  "iterators.sink"(%reduce) : (!iterators.stream<!i32_struct>) -> ()
   // CHECK:      (6)
+  return
+}
+
+!i32f32_struct = type !llvm.struct<(i32, f32)>
+
+// Return input where second struct field is larger. Return lhs on equality or
+// unordered.
+func private @arg_max(%lhs : !i32f32_struct, %rhs : !i32f32_struct) -> !i32f32_struct {
+  %lhsf = llvm.extractvalue %lhs[1 : index] : !i32f32_struct
+  %rhsf = llvm.extractvalue %rhs[1 : index] : !i32f32_struct
+  %cmp = arith.cmpf "uge", %lhsf, %rhsf : f32
+  %result = scf.if %cmp -> !i32f32_struct {
+    scf.yield %lhs : !i32f32_struct
+  } else {
+    scf.yield %rhs : !i32f32_struct
+  }
+  return %result : !i32f32_struct
+}
+
+func @query2() {
+  %input = "iterators.constantstream"()
+      { value = [[0 : i32,  0.   : f32],
+                 [1 : i32, 13.37 : f32],  // <-- max value
+                 [2 : i32,  4.2  : f32]] }
+      : () -> (!iterators.stream<!i32f32_struct>)
+  %reduce = "iterators.reduce"(%input) {reduceFuncRef = @arg_max}
+    : (!iterators.stream<!i32f32_struct>) -> (!iterators.stream<!i32f32_struct>)
+  "iterators.sink"(%reduce) : (!iterators.stream<!i32f32_struct>) -> ()
+  // CHECK:      (1, 13.37)
+  return
+}
+
+func @main() {
+  call @query1() : () -> ()
+  call @query2() : () -> ()
   return
 }


### PR DESCRIPTION
This PR depends on and therefore includes #482, #500, and #501. It should be rebased once those PRs are landed.

This PR extends the `ReduceOp` with a parameter for the reduction logic, i.e., the logic that combines two elements iteratively. This also removes the restriction on element types: only `!llvm.struct<(i32)>` was supported, now all LLVM struct types supported by the other operators are supported as well.