### PR TITLE
SQL: add support for naming to ibis dialect

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -124,15 +124,16 @@ class Selection(Operation):
   """
   Models an SQL `Select` statement and related concepts. If there are predicates
   to filter with, they are part of `predicates`. If there is a projection, the
-  wanted columns are part of `projections`. If `projections` is empty, all of
-  the columns are part of the result.
+  wanted columns are part of `projections`. The ith projected column will have
+  the ith name of `names`. If `projections` is empty, all of the columns are
+  part of the result.
 
   https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/relations.py#L375
 
   Example:
 
   ```
-  ibis.selection() {
+  ibis.selection() ["names" = []] {
     // table
     ibis.table() ...
   } {
@@ -142,7 +143,7 @@ class Selection(Operation):
     // projections
   }
 
-  ibis.selection() {
+  ibis.selection() ["names" = ["c"]] {
     // table
     ibis.table() ...
   } {
@@ -158,12 +159,18 @@ class Selection(Operation):
   table = SingleBlockRegionDef()
   predicates = SingleBlockRegionDef()
   projections = SingleBlockRegionDef()
+  names = AttributeDef(ArrayOfConstraint(StringAttr))
 
   @staticmethod
   @builder
-  def get(table: Region, predicates: Region,
-          projections: Region) -> 'Selection':
-    return Selection.build(regions=[table, predicates, projections])
+  def get(table: Region, predicates: Region, projections: Region,
+          names: list[str]) -> 'Selection':
+    return Selection.build(regions=[table, predicates, projections],
+                           attributes={
+                               "names":
+                                   ArrayAttr.from_list(
+                                       [StringAttr.from_str(n) for n in names])
+                           })
 
 
 @irdl_op_definition

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -62,10 +62,14 @@ def visit(  #type: ignore
 @dispatch(ibis.expr.operations.relations.Selection)
 def visit(  #type: ignore
     op: ibis.expr.operations.relations.Selection) -> Operation:
+  assert (op.inputs[0] is op.table)
+  names = []
+  if len(op.inputs) > 0:
+    names = [n.get_name() for n in op.inputs[1]]
   table = Region.from_operation_list([visit(op.table)])
   predicates = visit_ibis_expr_list(op.predicates)
   projections = visit_ibis_expr_list(op.selections)
-  return id.Selection.get(table, predicates, projections)
+  return id.Selection.get(table, predicates, projections, names)
 
 
 @dispatch(ibis.expr.operations.relations.Aggregation)

--- a/experimental/sql/test/frontend/naming.ibis
+++ b/experimental/sql/test/frontend/naming.ibis
@@ -1,21 +1,14 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
-table['a', 'b']
+table[table['b'].name('d')]
 
-#      CHECK: ibis.selection() ["names" = ["a", "b"]] {
+#      CHECK: ibis.selection() ["names" = ["d"]] {
 # CHECK-NEXT:     ibis.pandas_table() ["table_name" = "t"] {
 # CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
 # CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
 # CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
 # CHECK-NEXT:     }
 # CHECK-NEXT:   } {} {
-# CHECK-NEXT:     ibis.table_column() ["col_name" = "a"] {
-# CHECK-NEXT:       ibis.pandas_table() ["table_name" = "t"] {
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
-# CHECK-NEXT:       }
-# CHECK-NEXT:     }
 # CHECK-NEXT:     ibis.table_column() ["col_name" = "b"] {
 # CHECK-NEXT:       ibis.pandas_table() ["table_name" = "t"] {
 # CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]

--- a/experimental/sql/test/frontend/selection.ibis
+++ b/experimental/sql/test/frontend/selection.ibis
@@ -2,7 +2,7 @@
 
 table.filter(table['a'] == 'AS')
 
-#      CHECK: ibis.selection() {
+#      CHECK: ibis.selection() ["names" = []] {
 # CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
 # CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
 # CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/projection.xdsl
@@ -2,7 +2,7 @@
 
 // Query: table['a', 'b']
 module() {
-  ibis.selection() {
+  ibis.selection() ["names" = ["a", "b"]] {
     // selection input
     ibis.pandas_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
@@ -28,7 +28,7 @@ module() {
   }
 }
 
-//      CHECK: ibis.selection() {
+//      CHECK: ibis.selection() ["names" = ["a", "b"]] {
 // CHECK-NEXT:     ibis.pandas_table() ["table_name" = "t"] {
 // CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
 // CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_dialect_tests/selection.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/selection.xdsl
@@ -2,7 +2,7 @@
 
 // Query: table.filter(table['a'] == 'AS')
 module() {
-  ibis.selection() {
+  ibis.selection() ["names" = []] {
     // selection input
     ibis.pandas_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
@@ -27,7 +27,7 @@ module() {
   } {}
 }
 
-//      CHECK: ibis.selection() {
+//      CHECK: ibis.selection() ["names" = []] {
 // CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
 // CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
 // CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_to_alg/selection_op.xdsl
+++ b/experimental/sql/test/ibis_to_alg/selection_op.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
 module() {
-  ibis.selection() {
+  ibis.selection() ["names" = []] {
     // selection input
     ibis.pandas_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int32]


### PR DESCRIPTION
When working on projections, I realized that I had not represented an obscure, but crucial component of the selection node. The selection node has a tuple field called `inputs`. In this field the name of a projected column can be found, which is crucial to get the schema for the result right.

This patch adds a list of names to the selection node in the ibis_dialect. I feel that `inputs` represents things that are already represented by other parts of the selection node (like the table), so I decided not to mirror the field itself for the moment. 