### PR TITLE
SQL: add more comparators to ibis_dialect

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -262,6 +262,36 @@ class Equals(Operation):
 
 
 @irdl_op_definition
+class GreaterEqual(Operation):
+  """
+  Checks whether each entry of `left` is greater or equal to `right`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/logical.py#L89
+
+  Example:
+
+  ```
+  ibis.greaterEqual() {
+    // left
+    ibis.table_column() ...
+  } {
+    // right
+    ibis.literal() ...
+  }
+  ```
+  """
+  name = "ibis.greaterEqual"
+
+  left = SingleBlockRegionDef()
+  right = SingleBlockRegionDef()
+
+  @builder
+  @staticmethod
+  def get(left: Region, right: Region) -> 'GreaterEqual':
+    return GreaterEqual.build(regions=[left, right])
+
+
+@irdl_op_definition
 class PandasTable(Operation):
   """
   Defines a table with name `table_name` and schema `schema`. The table is
@@ -354,6 +384,7 @@ class Ibis:
     self.ctx.register_op(SchemaElement)
     self.ctx.register_op(Selection)
     self.ctx.register_op(Equals)
+    self.ctx.register_op(GreaterEqual)
     self.ctx.register_op(TableColumn)
     self.ctx.register_op(Literal)
     self.ctx.register_op(Sum)

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -292,6 +292,66 @@ class GreaterEqual(Operation):
 
 
 @irdl_op_definition
+class LessThan(Operation):
+  """
+  Checks whether each entry of `left` is less than `right`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/logical.py#L104
+
+  Example:
+
+  ```
+  ibis.lessThan() {
+    // left
+    ibis.table_column() ...
+  } {
+    // right
+    ibis.literal() ...
+  }
+  ```
+  """
+  name = "ibis.lessThan"
+
+  left = SingleBlockRegionDef()
+  right = SingleBlockRegionDef()
+
+  @builder
+  @staticmethod
+  def get(left: Region, right: Region) -> 'LessThan':
+    return LessThan.build(regions=[left, right])
+
+
+@irdl_op_definition
+class LessEqual(Operation):
+  """
+  Checks whether each entry of `left` is less or equal to `right`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/logical.py#L99
+
+  Example:
+
+  ```
+  ibis.lessEqual() {
+    // left
+    ibis.table_column() ...
+  } {
+    // right
+    ibis.literal() ...
+  }
+  ```
+  """
+  name = "ibis.lessEqual"
+
+  left = SingleBlockRegionDef()
+  right = SingleBlockRegionDef()
+
+  @builder
+  @staticmethod
+  def get(left: Region, right: Region) -> 'LessEqual':
+    return LessEqual.build(regions=[left, right])
+
+
+@irdl_op_definition
 class PandasTable(Operation):
   """
   Defines a table with name `table_name` and schema `schema`. The table is
@@ -385,6 +445,8 @@ class Ibis:
     self.ctx.register_op(Selection)
     self.ctx.register_op(Equals)
     self.ctx.register_op(GreaterEqual)
+    self.ctx.register_op(LessEqual)
+    self.ctx.register_op(LessThan)
     self.ctx.register_op(TableColumn)
     self.ctx.register_op(Literal)
     self.ctx.register_op(Sum)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -92,36 +92,35 @@ def visit(  #type: ignore
   return id.TableColumn.get(table, op.name)
 
 
+def create_logical_op(op: ibis.expr.operations.Comparison,
+                      _class: Operation) -> Operation:
+  left_reg = Region.from_operation_list([visit(op.left)])
+  right_reg = Region.from_operation_list([visit(op.right)])
+  return _class.get(left_reg, right_reg)
+
+
 @dispatch(ibis.expr.operations.logical.Equals)
 def visit(  #type: ignore
     op: ibis.expr.operations.logical.Equals) -> Operation:
-  left_reg = Region.from_operation_list([visit(op.left)])
-  right_reg = Region.from_operation_list([visit(op.right)])
-  return id.Equals.get(left_reg, right_reg)
+  return create_logical_op(op, id.Equals)
 
 
 @dispatch(ibis.expr.operations.logical.GreaterEqual)
 def visit(  #type: ignore
     op: ibis.expr.operations.logical.GreaterEqual) -> Operation:
-  left_reg = Region.from_operation_list([visit(op.left)])
-  right_reg = Region.from_operation_list([visit(op.right)])
-  return id.GreaterEqual.get(left_reg, right_reg)
+  return create_logical_op(op, id.GreaterEqual)
 
 
 @dispatch(ibis.expr.operations.logical.LessEqual)
 def visit(  #type: ignore
     op: ibis.expr.operations.logical.LessEqual) -> Operation:
-  left_reg = Region.from_operation_list([visit(op.left)])
-  right_reg = Region.from_operation_list([visit(op.right)])
-  return id.LessEqual.get(left_reg, right_reg)
+  return create_logical_op(op, id.LessEqual)
 
 
 @dispatch(ibis.expr.operations.logical.Less)
 def visit(  #type: ignore
     op: ibis.expr.operations.logical.Less) -> Operation:
-  left_reg = Region.from_operation_list([visit(op.left)])
-  right_reg = Region.from_operation_list([visit(op.right)])
-  return id.LessThan.get(left_reg, right_reg)
+  return create_logical_op(op, id.LessThan)
 
 
 @dispatch(ibis.expr.operations.generic.Literal)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -108,6 +108,22 @@ def visit(  #type: ignore
   return id.GreaterEqual.get(left_reg, right_reg)
 
 
+@dispatch(ibis.expr.operations.logical.LessEqual)
+def visit(  #type: ignore
+    op: ibis.expr.operations.logical.LessEqual) -> Operation:
+  left_reg = Region.from_operation_list([visit(op.left)])
+  right_reg = Region.from_operation_list([visit(op.right)])
+  return id.LessEqual.get(left_reg, right_reg)
+
+
+@dispatch(ibis.expr.operations.logical.Less)
+def visit(  #type: ignore
+    op: ibis.expr.operations.logical.Less) -> Operation:
+  left_reg = Region.from_operation_list([visit(op.left)])
+  right_reg = Region.from_operation_list([visit(op.right)])
+  return id.LessThan.get(left_reg, right_reg)
+
+
 @dispatch(ibis.expr.operations.generic.Literal)
 def visit(  #type: ignore
     op: ibis.expr.operations.generic.Literal) -> Operation:

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -4,11 +4,12 @@
 
 from dataclasses import dataclass
 from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr
-from xdsl.ir import Operation, MLContext, Region, Block
+from xdsl.ir import Operation, MLContext, Region, Block, Attribute
 from typing import List, Type, Optional
 from multipledispatch import dispatch
 
 import ibis
+import numpy as np
 
 import dialects.ibis_dialect as id
 
@@ -28,6 +29,14 @@ def convert_datatype(type_: ibis.expr.datatypes) -> id.DataType:
   if isinstance(type_, ibis.expr.datatypes.Int64):
     return id.Int64()
   raise KeyError(f"Unknown datatype: {type(type_)}")
+
+
+def convert_literal(literal) -> Attribute:
+  if isinstance(literal, str):
+    return StringAttr.from_str(literal)
+  if isinstance(literal, np.int64):
+    return IntegerAttr.from_int_and_width(literal, 64)
+  raise Exception(f"literal conversion not yet implemented for {type(literal)}")
 
 
 # The first two functions work on multiple parts of the ibis tree, so they
@@ -91,11 +100,18 @@ def visit(  #type: ignore
   return id.Equals.get(left_reg, right_reg)
 
 
+@dispatch(ibis.expr.operations.logical.GreaterEqual)
+def visit(  #type: ignore
+    op: ibis.expr.operations.logical.GreaterEqual) -> Operation:
+  left_reg = Region.from_operation_list([visit(op.left)])
+  right_reg = Region.from_operation_list([visit(op.right)])
+  return id.GreaterEqual.get(left_reg, right_reg)
+
+
 @dispatch(ibis.expr.operations.generic.Literal)
 def visit(  #type: ignore
     op: ibis.expr.operations.generic.Literal) -> Operation:
-  return id.Literal.get(StringAttr.from_str(op.value),
-                        convert_datatype(op.dtype))
+  return id.Literal.get(convert_literal(op.value), convert_datatype(op.dtype))
 
 
 @dispatch(ibis.expr.operations.reductions.Sum)

--- a/experimental/sql/test/frontend/LessEqual.ibis
+++ b/experimental/sql/test/frontend/LessEqual.ibis
@@ -1,0 +1,23 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table.filter(table['b'] <= np.int64(0))
+
+#      CHECK: ibis.selection() {
+# CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  } {
+# CHECK-NEXT:    ibis.lessEqual() {
+# CHECK-NEXT:      ibis.table_column() ["col_name" = "b"] {
+# CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:        }
+# CHECK-NEXT:      }
+# CHECK-NEXT:    } {
+# CHECK-NEXT:      ibis.literal() ["val" = 0 : !i64, "type" = !ibis.int64]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  } {}

--- a/experimental/sql/test/frontend/LessEqual.ibis
+++ b/experimental/sql/test/frontend/LessEqual.ibis
@@ -2,22 +2,6 @@
 
 table.filter(table['b'] <= np.int64(0))
 
-#      CHECK: ibis.selection() {
-# CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
-# CHECK-NEXT:    }
-# CHECK-NEXT:  } {
-# CHECK-NEXT:    ibis.lessEqual() {
+#      CHECK:    ibis.lessEqual() {
 # CHECK-NEXT:      ibis.table_column() ["col_name" = "b"] {
 # CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
-# CHECK-NEXT:        }
-# CHECK-NEXT:      }
-# CHECK-NEXT:    } {
-# CHECK-NEXT:      ibis.literal() ["val" = 0 : !i64, "type" = !ibis.int64]
-# CHECK-NEXT:    }
-# CHECK-NEXT:  } {}

--- a/experimental/sql/test/frontend/LessThan.ibis
+++ b/experimental/sql/test/frontend/LessThan.ibis
@@ -1,0 +1,23 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table.filter(table['b'] < np.int64(0))
+
+#      CHECK: ibis.selection() {
+# CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  } {
+# CHECK-NEXT:    ibis.lessThan() {
+# CHECK-NEXT:      ibis.table_column() ["col_name" = "b"] {
+# CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:        }
+# CHECK-NEXT:      }
+# CHECK-NEXT:    } {
+# CHECK-NEXT:      ibis.literal() ["val" = 0 : !i64, "type" = !ibis.int64]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  } {}

--- a/experimental/sql/test/frontend/LessThan.ibis
+++ b/experimental/sql/test/frontend/LessThan.ibis
@@ -2,22 +2,6 @@
 
 table.filter(table['b'] < np.int64(0))
 
-#      CHECK: ibis.selection() {
-# CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
-# CHECK-NEXT:    }
-# CHECK-NEXT:  } {
-# CHECK-NEXT:    ibis.lessThan() {
+#      CHECK:    ibis.lessThan() {
 # CHECK-NEXT:      ibis.table_column() ["col_name" = "b"] {
 # CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
-# CHECK-NEXT:        }
-# CHECK-NEXT:      }
-# CHECK-NEXT:    } {
-# CHECK-NEXT:      ibis.literal() ["val" = 0 : !i64, "type" = !ibis.int64]
-# CHECK-NEXT:    }
-# CHECK-NEXT:  } {}

--- a/experimental/sql/test/frontend/greaterEqual.ibis
+++ b/experimental/sql/test/frontend/greaterEqual.ibis
@@ -2,22 +2,6 @@
 
 table.filter(table['b'] >= np.int64(0))
 
-#      CHECK: ibis.selection() {
-# CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
-# CHECK-NEXT:    }
-# CHECK-NEXT:  } {
-# CHECK-NEXT:    ibis.greaterEqual() {
+#      CHECK:    ibis.greaterEqual() {
 # CHECK-NEXT:      ibis.table_column() ["col_name" = "b"] {
 # CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
-# CHECK-NEXT:        }
-# CHECK-NEXT:      }
-# CHECK-NEXT:    } {
-# CHECK-NEXT:      ibis.literal() ["val" = 0 : !i64, "type" = !ibis.int64]
-# CHECK-NEXT:    }
-# CHECK-NEXT:  } {}

--- a/experimental/sql/test/frontend/greaterEqual.ibis
+++ b/experimental/sql/test/frontend/greaterEqual.ibis
@@ -1,0 +1,23 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table.filter(table['b'] >= np.int64(0))
+
+#      CHECK: ibis.selection() {
+# CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  } {
+# CHECK-NEXT:    ibis.greaterEqual() {
+# CHECK-NEXT:      ibis.table_column() ["col_name" = "b"] {
+# CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:        }
+# CHECK-NEXT:      }
+# CHECK-NEXT:    } {
+# CHECK-NEXT:      ibis.literal() ["val" = 0 : !i64, "type" = !ibis.int64]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  } {}

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -39,6 +39,7 @@ class RelOptMain(xDSLOptMain):
     def parse_ibis(f: IOBase):
       import ibis
       import pandas as pd
+      import numpy as np
 
       connection = ibis.pandas.connect({
           "t":


### PR DESCRIPTION
This patch adds the greaterEqual comparator to the ibis dialect. The functionality is basically 1-1 with the equals comparator. I am unsure whether functionality could be reused by adding a `Logical` operation and making these operations children of it. I currently only see the two regions definitions that could be moved to a parent class, but I would be happy about suggestions.