### PR TITLE
SQL: allow variable definitions in ibis filecheck files

### DIFF
--- a/experimental/sql/test/frontend/var_def.ibis
+++ b/experimental/sql/test/frontend/var_def.ibis
@@ -1,0 +1,24 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+cond = (table['a'] == 'AS')
+table.filter(cond)
+
+#      CHECK: ibis.selection() {
+# CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  } {
+# CHECK-NEXT:    ibis.equals() {
+# CHECK-NEXT:      ibis.table_column() ["col_name" = "a"] {
+# CHECK-NEXT:        ibis.pandas_table() ["table_name" = "t"] {
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:        }
+# CHECK-NEXT:      }
+# CHECK-NEXT:    } {
+# CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:    }
+# CHECK-NEXT:  } {}

--- a/experimental/sql/test/frontend/var_def.ibis
+++ b/experimental/sql/test/frontend/var_def.ibis
@@ -3,7 +3,7 @@
 cond = (table['a'] == 'AS')
 table.filter(cond)
 
-#      CHECK: ibis.selection() {
+#      CHECK: ibis.selection() ["names" = []] {
 # CHECK-NEXT:    ibis.pandas_table() ["table_name" = "t"] {
 # CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
 # CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -56,6 +56,8 @@ class RelOptMain(xDSLOptMain):
         for t, n in zip(tables, names):
           _locals[n] = t
 
+        _locals["np"] = np
+
         ast_query = ast.parse(query)
         last = ast.Expression(ast_query.body.pop().value)
         exec(compile(ast_query, '<string>', mode='exec'), _globals, _locals)


### PR DESCRIPTION
This patch uses the ast module to allow defining variables in the filecheck tests. While our current queries are reasonably small and, hence, easy to write in a single expression, later queries can become far more complicated.