### PR TITLE
Apply cleanups and refactorings for #482.

### DIFF
--- a/experimental/iterators/include/iterators/Conversion/Passes.td
+++ b/experimental/iterators/include/iterators/Conversion/Passes.td
@@ -20,7 +20,7 @@ def ConvertIteratorsToLLVM : Pass<"convert-iterators-to-llvm", "ModuleOp"> {
                 "LLVM dialect";
   let description = [{
     This lowering pass converts iterators, i.e., operation that have operands
-    and results of type `Stream`, to control flow that co-executes all iterators
+    and results of type `Stream`, to control-flow that co-executes all iterators
     connected via use-def chains of `Stream`s as well as the state that is
     required for each iterator to do so. This is achieved by having each
     iterator *consumes* the elements in its operand `Stream`s in order to
@@ -29,12 +29,12 @@ def ConvertIteratorsToLLVM : Pass<"convert-iterators-to-llvm", "ModuleOp"> {
     currently only works if the use-def chains of `Stream`s form a tree, i.e.,
     every `Stream` is used as an operand by exactly one subsequent iterator.
 
-    More precisely, for each iterator, the lowering produces a state in form
+    More precisely, for each iterator, the lowering produces a state in the form
     of an `!llvm.struct<...>`, including any local state that the iterator might
     require **plus the states of all iterators in the transitive use-def chain**
     of its operands. The computations are expressed as three functions, `Open`,
     `Next`, and `Close`, which operate on that state and which continuously pass
-    control flow between the logic of the different iterators:
+    control-flow between the logic of the different iterators:
 
     * `Open` initializes the computations, typically calling `Open` on the
       nested states of the current iterator;

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsDialect.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsDialect.td
@@ -47,7 +47,7 @@ def Iterators_Dialect : Dialect {
     stream in its entirety. However, the intention is to lower a program of
     iterator ops such that **all iterators** in a connected component of
     iterators **run at the same time**, continuously passing individual elements
-    of the streams (and potentially control flow) between them. In many cases,
+    of the streams (and potentially control-flow) between them. In many cases,
     this removes the need to write the potentially large result of one iterator
     (represented by a stream) to slow memory because each element in the stream
     is consumed by the subsequent (downstream) iterator immediately after it has

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsInterfaces.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsInterfaces.td
@@ -27,4 +27,8 @@ def Iterators_IteratorInterface : TypeInterface<"IteratorInterface"> {
   ];
 }
 
+def Iterators_IteratorOpInterface : OpInterface<"IteratorOpInterface"> {
+  let description = [{Iterators op interface.}];
+}
+
 #endif // ITERATORS_DIALECT_ITERATORS_IR_ITERATORSINTERFACES

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -14,8 +14,12 @@ include "iterators/Dialect/Iterators/IR/IteratorsTypes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/IR/OpBase.td"
 
-class Iterators_Op<string mnemonic, list<Trait> traits = []> :
+class Iterators_Base_Op<string mnemonic, list<Trait> traits = []> :
     Op<Iterators_Dialect, mnemonic, traits> {
+}
+
+class Iterators_Op<string mnemonic, list<Trait> traits = []> :
+    Iterators_Base_Op<mnemonic,  traits # [Iterators_IteratorOpInterface]> {
 }
 
 //===----------------------------------------------------------------------===//
@@ -30,14 +34,14 @@ def MatchingFieldCountsConstraint
                   MatchingFieldCountsPred>;
 
 def Iterators_ConstantTupleOp
-    : Iterators_Op<"constant", [MatchingFieldCountsConstraint]> {
+    : Iterators_Base_Op<"constant", [MatchingFieldCountsConstraint]> {
   let summary = "Creates a tuple from the given values";
   // TODO(ingomueller): extend to more field types
   let arguments = (ins I32ArrayAttr:$values);
   let results = (outs TupleOf<[I32]>:$tuple);
 }
 
-def Iterators_PrintTupleOp : Iterators_Op<"print"> {
+def Iterators_PrintTupleOp : Iterators_Base_Op<"print"> {
   let summary = "Print the elements of a tuple";
   // TODO(ingomueller): extend to all supported tuple types
   let arguments = (ins TupleOf<[I32]>);
@@ -63,8 +67,11 @@ def Iterators_ReduceOp : Iterators_Op<"reduce"> {
   let results = (outs Iterators_StreamOfLLVMStructOfSingleI32:$result);
 }
 
+/// The sink op is a special op that only consumes a stream of values and 
+/// produces nothing.
+/// It is not markes with Iterators_IteratorOpInterface.
 // TODO(ingomueller): Extend to more LLVM structs/builtin types
-def Iterators_SinkOp : Iterators_Op<"sink"> {
+def Iterators_SinkOp : Iterators_Base_Op<"sink"> {
   let summary = "Consume tuples from an iterator";
   let arguments = (ins Iterators_StreamOfLLVMStructOfSingleI32:$input);
 }

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
@@ -56,7 +56,7 @@ class Iterators_StreamOf<Type elementType>
 def Iterators_StreamOfLLVMStructOfSingleI32
   : Iterators_StreamOf<Iterators_LLVMStructOfSingleI32>;
 
-/// Prediate to verify that a named argument or result's stream type matches a
+/// Predicate to verify that a named argument or result's stream type matches a
 /// given type.
 class Iterators_IsStreamOfPred<string name, Type type>
   : SubstLeaves<"$_self", "$" # name # ".getType()",

--- a/experimental/iterators/include/iterators/Utils/MLIRSupport.h
+++ b/experimental/iterators/include/iterators/Utils/MLIRSupport.h
@@ -9,18 +9,8 @@
 #ifndef ITERATORS_UTILS_MLIR_SUPPORT_H
 #define ITERATORS_UTILS_MLIR_SUPPORT_H
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/IR/Block.h"
-#include "mlir/IR/Location.h"
 #include "mlir/IR/OperationSupport.h"
-#include "mlir/IR/TypeRange.h"
-#include "mlir/IR/Types.h"
-#include "mlir/IR/Value.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/STLFunctionalExtras.h"
-
-#include <stdint.h>
 
 namespace mlir {
 class NamedAttribute;
@@ -29,6 +19,7 @@ class OpBuilder;
 
 namespace mlir {
 namespace scf {
+class WhileOp;
 
 WhileOp createWhileOp(
     OpBuilder &builder, Location loc, TypeRange resultTypes,
@@ -42,6 +33,8 @@ WhileOp createWhileOp(
 } // namespace scf
 
 namespace LLVM {
+class InsertValueOp;
+class ExtractValueOp;
 
 InsertValueOp createInsertValueOp(OpBuilder &builder, Location loc,
                                   Value container, Value value,
@@ -52,7 +45,6 @@ ExtractValueOp createExtractValueOp(OpBuilder &builder, Location loc, Type res,
                                     ArrayRef<int64_t> position);
 
 } // namespace LLVM
-
 } // namespace mlir
 
 #endif // ITERATORS_UTILS_MLIR_SUPPORT_H

--- a/experimental/iterators/include/iterators/Utils/NameAssigner.h
+++ b/experimental/iterators/include/iterators/Utils/NameAssigner.h
@@ -1,4 +1,4 @@
-//===-- IteratorAnalysis.h - Lowering information of iterators --*- C++ -*-===//
+//===-- NameAssigner.h - Assigner of unique names --------------*- C++ -*-===//
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,14 +9,12 @@
 #ifndef ITERATORS_UTILS_NAMEASSIGNER_H
 #define ITERATORS_UTILS_NAMEASSIGNER_H
 
-#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/StringRef.h"
-
-#include <stdint.h>
+#include "mlir/Support/LLVM.h"
 
 namespace mlir {
+
+class ModuleOp;
 namespace iterators {
 
 /// Pre-assigns unique symbol names in the given module. Uniqueness is

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.cpp
@@ -4,51 +4,21 @@
 #include "iterators/Utils/NameAssigner.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/BuiltinAttributes.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/None.h"
-#include "llvm/ADT/Optional.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 
-namespace mlir {
-namespace iterators {
+using namespace mlir;
+using namespace mlir::iterators;
 
-IteratorAnalysis::IteratorAnalysis(Operation *parentOp, ModuleOp module)
-    : parentOp(parentOp), nameAssigner(module) {
-  parentOp->walk([&](Operation *op) {
-    llvm::TypeSwitch<Operation *, void>(op).Case<SampleInputOp, ReduceOp>(
-        [&](auto op) { buildIteratorInfo(op); });
-  });
-}
+using SymbolTriple = std::tuple<SymbolRefAttr, SymbolRefAttr, SymbolRefAttr>;
 
-llvm::Optional<IteratorAnalysis::IteratorInfo>
-IteratorAnalysis::getIteratorInfo(Operation *op) const {
-  auto it = opMap.find(op);
-  if (it == opMap.end())
-    return llvm::None;
-  return it->getSecond();
-}
-
-void IteratorAnalysis::buildIteratorInfo(Operation *op) {
-  llvm::SmallVector<SymbolRefAttr, 3> symbols = assignFunctionNames(op);
-  SymbolRefAttr openFuncSymbol = symbols[0];
-  SymbolRefAttr nextFuncSymbol = symbols[1];
-  SymbolRefAttr closeFuncSymbol = symbols[2];
-
-  auto stateType = llvm::TypeSwitch<Operation *, LLVM::LLVMStructType>(op)
-                       .Case<ReduceOp, SampleInputOp>(
-                           [&](auto op) { return computeStateType(op); })
-                       .Default(LLVM::LLVMStructType());
-
-  opMap.try_emplace(op, IteratorInfo{stateType, openFuncSymbol, nextFuncSymbol,
-                                     closeFuncSymbol});
-}
-
-llvm::SmallVector<SymbolRefAttr, 3>
-IteratorAnalysis::assignFunctionNames(Operation *op) {
-  llvm::SmallVector<SymbolRefAttr, 3> symbols;
-  for (auto const *suffix :
-       std::array<const char *, 3>{"open", "next", "close"}) {
+/// Pre-assigns names for the Open/Next/Close functions of the given iterator
+/// op. The conversion is expected to create these names in the lowering of
+/// the corresponding op and can look them up in the lowering of downstream
+/// iterators.
+static SymbolTriple assignFunctionNames(Operation *op,
+                                        NameAssigner &nameAssigner) {
+  SmallVector<SymbolRefAttr, 3> symbols;
+  for (auto suffix : {"open", "next", "close"}) {
     // Construct base name from op type and Open/Next/Close.
     auto baseName = StringAttr::get(
         op->getContext(),
@@ -60,13 +30,12 @@ IteratorAnalysis::assignFunctionNames(Operation *op) {
     auto symbol = SymbolRefAttr::get(op->getContext(), uniqueName);
     symbols.push_back(symbol);
   }
-
-  return symbols;
+  return std::make_tuple(symbols[0], symbols[1], symbols[2]);
 }
 
 /// The state of SampleInputOp consists of a single number that corresponds
 /// to the next number returned by the iterator.
-LLVM::LLVMStructType IteratorAnalysis::computeStateType(SampleInputOp op) {
+static LLVM::LLVMStructType computeStateType(SampleInputOp op) {
   auto resultType = op.result().getType().dyn_cast<StreamType>();
   assert(resultType);
   auto elementType =
@@ -79,13 +48,65 @@ LLVM::LLVMStructType IteratorAnalysis::computeStateType(SampleInputOp op) {
 
 /// The state of ReduceOp only consists of the state of its upstream iterator,
 /// i.e., the state of the iterator that produces its input stream.
-LLVM::LLVMStructType IteratorAnalysis::computeStateType(ReduceOp op) {
-  auto maybeUpstreamInfo = getIteratorInfo(op.input().getDefiningOp());
-  assert(maybeUpstreamInfo.hasValue());
-  auto upstreamInfo = maybeUpstreamInfo.getValue();
+static LLVM::LLVMStructType
+computeStateType(ReduceOp op, LLVM::LLVMStructType upstreamStateType) {
   return LLVM::LLVMStructType::getNewIdentified(
-      op->getContext(), "iterators.reduce_state", {upstreamInfo.stateType});
+      op->getContext(), "iterators.reduce_state", {upstreamStateType});
 }
 
-} // namespace iterators
-} // namespace mlir
+/// Build IteratorInfo, assigning new unique names as needed.
+/// Takes the `LLVM::LLVMStructType` as a parameter, to ensure proper build
+/// order (all uses are visited before any def).
+mlir::iterators::IteratorInfo::IteratorInfo(IteratorOpInterface op,
+                                            NameAssigner &nameAssigner,
+                                            LLVM::LLVMStructType t) {
+  std::tie(openFunc, nextFunc, closeFunc) =
+      assignFunctionNames(op, nameAssigner);
+  stateType = t;
+}
+
+IteratorInfo mlir::iterators::IteratorAnalysis::getExpectedIteratorInfo(
+    IteratorOpInterface op) const {
+  auto it = opMap.find(op);
+  assert(it != opMap.end() && "analysis does not contain this op");
+  return it->getSecond();
+}
+
+void mlir::iterators::IteratorAnalysis::setIteratorInfo(
+    IteratorOpInterface op, const IteratorInfo &info) {
+  assert(info.stateType && "state type must be computed");
+  auto inserted = opMap.insert({op, info});
+  assert(inserted.second && "IteratorInfo already present");
+}
+
+template <typename OpTy>
+static OpTy getSelfOrParentOfType(Operation *op) {
+  auto maybe = dyn_cast<OpTy>(op);
+  return maybe ? maybe : op->getParentOfType<OpTy>();
+}
+
+mlir::iterators::IteratorAnalysis::IteratorAnalysis(Operation *rootOp)
+    : rootOp(rootOp), nameAssigner(getSelfOrParentOfType<ModuleOp>(rootOp)) {
+  /// This needs to be built in use-def order so that all uses are visited
+  /// before any def.
+  rootOp->walk([&](IteratorOpInterface iteratorOp) {
+    llvm::TypeSwitch<Operation *, void>(iteratorOp)
+        /// The state of SampleInputOp consists of a single number that
+        /// corresponds to the next number returned by the iterator.
+        .Case<SampleInputOp>([&](auto op) {
+          auto stateType = computeStateType(op);
+          setIteratorInfo(op, IteratorInfo(op, nameAssigner, stateType));
+        })
+        /// The state of ReduceOp only consists of the state of its upstream
+        /// iterator, i.e., the state of the iterator that produces its input
+        /// stream.
+        // TODO: ReduceOp verifier that op.input does not come from a bbArg.
+        .Case<ReduceOp>([&](auto op) {
+          Operation *def = op.input().getDefiningOp();
+          auto stateType =
+              computeStateType(op, getExpectedIteratorInfo(def).stateType);
+          setIteratorInfo(op, IteratorInfo(op, nameAssigner, stateType));
+        })
+        .Default([&](auto op) { assert(false && "Unexpected op"); });
+  });
+}

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.h
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.h
@@ -9,68 +9,67 @@
 #ifndef EXPERIMENTAL_ITERATORS_LIB_CONVERSION_ITERATORSTOLLVM_ITERATORANALYSIS_H
 #define EXPERIMENTAL_ITERATORS_LIB_CONVERSION_ITERATORSTOLLVM_ITERATORANALYSIS_H
 
-#include "iterators/Dialect/Iterators/IR/Iterators.h"
 #include "iterators/Utils/NameAssigner.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/BuiltinAttributes.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/Optional.h"
-#include "llvm/ADT/SmallVector.h"
-
 namespace mlir {
 class ModuleOp;
 class Operation;
 
 namespace iterators {
 
-/// Constructs information about the state type and the Open/Next/Close
-/// functions of all iterator ops nested inside the given parent op. The state
-/// type of each iterator usually consists of a private part, which the iterator
-/// accesses in its Open/Next/Close logic, as well as the state of all of its
-/// transitive upstream iterators, i.e., the iterators that produce the operand
-/// streams.
-class IteratorAnalysis {
-public:
-  /// Information about each op constructed by this analysis.
-  struct IteratorInfo {
-    /// State of the iterator including the state of its potential upstreams.
-    LLVM::LLVMStructType stateType;
-    // Pre-assigned symbols that should be used for the Open/Next/Close
-    // functions of this iterator.
-    SymbolRefAttr openFunc;
-    SymbolRefAttr nextFunc;
-    SymbolRefAttr closeFunc;
-  };
+class IteratorOpInterface;
 
-private:
+/// Information about each op constructed by IteratorAnalysis.
+struct IteratorInfo {
+  /// Takes the `LLVM::LLVMStructType` as a parameter, to ensure proper build
+  /// order (all uses are visited before any def).
+  IteratorInfo(IteratorOpInterface op, NameAssigner &nameAssigner,
+               LLVM::LLVMStructType t);
+
+  // Pre-assigned symbols that should be used for the Open/Next/Close
+  // functions of this iterator.
+  SymbolRefAttr openFunc;
+  SymbolRefAttr nextFunc;
+  SymbolRefAttr closeFunc;
+
+  /// State of the iterator including the state of its potential upstreams.
+  LLVM::LLVMStructType stateType;
+};
+
+/// Constructs information about the state type and the Open/Next/Close
+/// functions of all iterator ops nested inside the given parent op.
+/// The state type of each iterator usually consists of a private part, which
+/// the iterator accesses in its Open/Next/Close logic, as well as the state of
+/// all of its transitive upstream iterators, i.e., the iterators that produce
+/// the operand streams.
+class IteratorAnalysis {
   using OperationMap = llvm::DenseMap<Operation *, IteratorInfo>;
 
 public:
-  explicit IteratorAnalysis(Operation *parentOp, ModuleOp module);
+  explicit IteratorAnalysis(Operation *rootOp);
 
   /// Returns the operation this analysis was constructed from.
-  Operation *getOperation() const { return parentOp; }
+  Operation *getRootOperation() const { return rootOp; }
 
-  /// Returns the information for the given op.
-  llvm::Optional<IteratorInfo> getIteratorInfo(Operation *op) const;
+  /// Return the result of the analysis on `op`.
+  /// Expects an entry for `op` to already exist.
+  IteratorInfo getExpectedIteratorInfo(IteratorOpInterface op) const;
+
+  /// Set the info for `op`.
+  /// Expects an entry for `op` to **not** already exist.
+  void setIteratorInfo(IteratorOpInterface op, const IteratorInfo &info);
 
 private:
-  /// Assembles all required information of a given iterator op.
-  void buildIteratorInfo(Operation *op);
+  /// Operation this analysis was constructed from.
+  Operation *rootOp;
 
-  /// Pre-assigns names for the Open/Next/Close functions of the given iterator
-  /// op. The conversion is expected to create these names in the lowering of
-  /// the corresponding op and can look them up in the lowering of downstream
-  /// iterators.
-  llvm::SmallVector<SymbolRefAttr, 3> assignFunctionNames(Operation *op);
-
-  // Compute the state type of an op of a given type.
-  LLVM::LLVMStructType computeStateType(SampleInputOp op);
-  LLVM::LLVMStructType computeStateType(ReduceOp op);
-
-  Operation *parentOp;
-  OperationMap opMap;
+  /// Helper class that pre-assigns unique symbols for Open/Next/Close.
+  /// The scope of unicity is the immediately enclosing ModuleOp.
   NameAssigner nameAssigner;
+
+  /// Results of the analysis.
+  OperationMap opMap;
 };
 
 } // namespace iterators

--- a/experimental/iterators/lib/Utils/MLIRSupport.cpp
+++ b/experimental/iterators/lib/Utils/MLIRSupport.cpp
@@ -8,32 +8,20 @@
 
 #include "iterators/Utils/MLIRSupport.h"
 
-#include "mlir/IR/Block.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/Location.h"
-#include "mlir/IR/OperationSupport.h"
-#include "mlir/IR/TypeRange.h"
-#include "mlir/IR/Types.h"
-#include "mlir/IR/Value.h"
-#include "mlir/Support/LLVM.h"
-#include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/SCF.h"
 
-namespace mlir {
-class NamedAttribute;
-} // namespace mlir
+using namespace mlir;
 
-namespace mlir {
-namespace scf {
-
-WhileOp
-createWhileOp(OpBuilder &builder, Location loc, TypeRange resultTypes,
-              ValueRange operands,
-              function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
-                  beforeBuilder,
-              function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
-                  afterBuilder,
-              ArrayRef<NamedAttribute> attributes) {
+// TODO: Move builder to core MLIR.
+scf::WhileOp mlir::scf::createWhileOp(
+    OpBuilder &builder, Location loc, TypeRange resultTypes,
+    ValueRange operands,
+    function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
+        beforeBuilder,
+    function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
+        afterBuilder,
+    ArrayRef<NamedAttribute> attributes) {
   auto op =
       builder.create<scf::WhileOp>(loc, resultTypes, operands, attributes);
   OpBuilder::InsertionGuard guard(builder);
@@ -53,30 +41,24 @@ createWhileOp(OpBuilder &builder, Location loc, TypeRange resultTypes,
   return op;
 }
 
-} // namespace scf
-
-namespace LLVM {
-
-InsertValueOp createInsertValueOp(OpBuilder &builder, Location loc,
-                                  Value container, Value value,
-                                  ArrayRef<int64_t> position) {
+LLVM::InsertValueOp
+mlir::LLVM::createInsertValueOp(OpBuilder &builder, Location loc,
+                                Value container, Value value,
+                                ArrayRef<int64_t> position) {
   // Create index attribute.
   ArrayAttr indicesAttr = builder.getIndexArrayAttr(position);
 
   // Insert into struct.
-  return builder.create<InsertValueOp>(loc, container, value, indicesAttr);
+  return builder.create<LLVM::InsertValueOp>(loc, container, value,
+                                             indicesAttr);
 }
 
-ExtractValueOp createExtractValueOp(OpBuilder &builder, Location loc, Type res,
-                                    Value container,
-                                    ArrayRef<int64_t> position) {
+LLVM::ExtractValueOp
+mlir::LLVM::createExtractValueOp(OpBuilder &builder, Location loc, Type res,
+                                 Value container, ArrayRef<int64_t> position) {
   // Create index attribute.
   ArrayAttr indicesAttr = builder.getIndexArrayAttr(position);
 
   // Extract from struct.
-  return builder.create<ExtractValueOp>(loc, res, container, indicesAttr);
+  return builder.create<LLVM::ExtractValueOp>(loc, res, container, indicesAttr);
 }
-
-} // namespace LLVM
-
-} // namespace mlir


### PR DESCRIPTION
This simplifies the overall implementation, reduces API footprints and better exposes dependences coming from def-use traversal requirements directly in the API.