### PR TITLE
SQL: change pandas_table to full_table_scan in the impl dialect

### DIFF
--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -295,25 +295,25 @@ class Operator(Operation):
 
 
 @irdl_op_definition
-class PandasTable(Operator):
+class FullTableScanOp(Operator):
   """
-  Defines a table with name `table_name` and the schema defined in the result_type.
+  Performs a full table scan of the table `table_name` and produces a bag with the given schema.
 
   Example:
 
   '''
-  %0 : rel_impl.bag<[!rel_impl.int32]> = rel_impl.pandas_table() ["table_name" = "t"]
+  %0 : rel_impl.bag<[!rel_impl.int32]> = rel_impl.full_table_scan() ["table_name" = "t"]
   '''
   """
-  name = "rel_impl.pandas_table"
+  name = "rel_impl.full_table_scan"
 
   table_name = AttributeDef(StringAttr)
   result = ResultDef(Bag)
 
   @staticmethod
   @builder
-  def get(name: str, result_type: Bag) -> 'PandasTable':
-    return PandasTable.build(
+  def get(name: str, result_type: Bag) -> 'FullTableScanOp':
+    return FullTableScanOp.build(
         attributes={"table_name": StringAttr.from_str(name)},
         result_types=[result_type])
 
@@ -408,7 +408,7 @@ class RelImpl:
 
     self.ctx.register_op(Select)
     self.ctx.register_op(Aggregate)
-    self.ctx.register_op(PandasTable)
+    self.ctx.register_op(FullTableScanOp)
     self.ctx.register_op(Literal)
     self.ctx.register_op(Compare)
     self.ctx.register_op(IndexByName)

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -45,10 +45,10 @@ class RelImplRewriter(RewritePattern):
 
 
 @dataclass
-class PandasTableRewriter(RelImplRewriter):
+class FullTableScanRewriter(RelImplRewriter):
 
   @op_type_rewrite_pattern
-  def match_and_rewrite(self, op: RelImpl.PandasTable,
+  def match_and_rewrite(self, op: RelImpl.FullTableScanOp,
                         rewriter: PatternRewriter):
     # TODO: Change this once not only SampleInputOp is supported
     rewriter.replace_matched_op(
@@ -71,7 +71,7 @@ class AggregateRewriter(RelImplRewriter):
 def impl_to_iterators(ctx: MLContext, query: ModuleOp):
 
   walker = PatternRewriteWalker(GreedyRewritePatternApplier(
-      [PandasTableRewriter(), AggregateRewriter()]),
+      [FullTableScanRewriter(), AggregateRewriter()]),
                                 walk_regions_first=False,
                                 apply_recursively=False,
                                 walk_reverse=False)

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -114,8 +114,8 @@ class PandasTableRewriter(RelSSARewriter):
   def match_and_rewrite(self, op: RelSSA.PandasTable,
                         rewriter: PatternRewriter):
     rewriter.replace_matched_op(
-        RelImpl.PandasTable.get(op.table_name.data,
-                                self.convert_bag(op.result.typ)))
+        RelImpl.FullTableScanOp.get(op.table_name.data,
+                                    self.convert_bag(op.result.typ)))
 
 
 @dataclass

--- a/experimental/sql/test/impl_to_iterators/sum.xdsl
+++ b/experimental/sql/test/impl_to_iterators/sum.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
 module() {
-    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
     %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
 }
 

--- a/experimental/sql/test/relational_implementation_dialect_tests/selection_op.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/selection_op.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
     %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) {
       ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>):
         %3 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : !i32]
@@ -11,7 +11,7 @@ module() {
     }
 }
 
-//      CHECK:    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+//      CHECK:    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
 // CHECK-NEXT:    %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) {
 // CHECK-NEXT:      ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>):
 // CHECK-NEXT:        %3 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : !i32]

--- a/experimental/sql/test/relational_implementation_dialect_tests/sum.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/sum.xdsl
@@ -1,9 +1,9 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
     %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
 }
 
-//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
 // CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]

--- a/experimental/sql/test/relational_implementation_dialect_tests/table_op.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/table_op.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
 }
 
-// CHECK: %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+// CHECK: %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]

--- a/experimental/sql/test/ssa_to_impl/selection_op.xdsl
+++ b/experimental/sql/test/ssa_to_impl/selection_op.xdsl
@@ -10,7 +10,7 @@ module() {
     }
 }
 
-//      CHECK:    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+//      CHECK:    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
 // CHECK-NEXT:    %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) {
 // CHECK-NEXT:      ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>):
 // CHECK-NEXT:        %3 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : !i32]

--- a/experimental/sql/test/ssa_to_impl/sum.xdsl
+++ b/experimental/sql/test/ssa_to_impl/sum.xdsl
@@ -5,5 +5,5 @@ module() {
     %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
 }
 
-//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
 // CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]

--- a/experimental/sql/test/ssa_to_impl/table_op.xdsl
+++ b/experimental/sql/test/ssa_to_impl/table_op.xdsl
@@ -4,4 +4,4 @@ module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.pandas_table() ["table_name" = "some_name"]
 }
 
-// CHECK: %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.pandas_table() ["table_name" = "some_name"]
+// CHECK: %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]


### PR DESCRIPTION
This PR adds representation of access methods by changing the `PandasTable` operation in rel_impl to a `FullTableScanOp`. This is not fundamentally different in terms of IR, but reflects the lower abstraction level this IR is supposed to represent.