### PR TITLE
SQL: Move schema from rel_opt into files

### DIFF
--- a/experimental/sql/test/frontend/LessEqual.ibis
+++ b/experimental/sql/test/frontend/LessEqual.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.filter(table['b'] <= np.int64(0))
 
 #      CHECK:    ibis.lessEqual() {

--- a/experimental/sql/test/frontend/LessThan.ibis
+++ b/experimental/sql/test/frontend/LessThan.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.filter(table['b'] < np.int64(0))
 
 #      CHECK:    ibis.lessThan() {

--- a/experimental/sql/test/frontend/greaterEqual.ibis
+++ b/experimental/sql/test/frontend/greaterEqual.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.filter(table['b'] >= np.int64(0))
 
 #      CHECK:    ibis.greaterEqual() {

--- a/experimental/sql/test/frontend/multiply.ibis
+++ b/experimental/sql/test/frontend/multiply.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table[(table['b'] * table['c']).name('d')]
 
 #      CHECK: ibis.selection() ["names" = ["d"]] {

--- a/experimental/sql/test/frontend/naming.ibis
+++ b/experimental/sql/test/frontend/naming.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table[table['b'].name('d')]
 
 #      CHECK: ibis.selection() ["names" = ["d"]] {

--- a/experimental/sql/test/frontend/projection.ibis
+++ b/experimental/sql/test/frontend/projection.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table['a', 'b']
 
 #      CHECK: ibis.selection() ["names" = ["a", "b"]] {

--- a/experimental/sql/test/frontend/selection.ibis
+++ b/experimental/sql/test/frontend/selection.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.filter(table['a'] == 'AS')
 
 #      CHECK: ibis.selection() ["names" = []] {

--- a/experimental/sql/test/frontend/sum.ibis
+++ b/experimental/sql/test/frontend/sum.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.aggregate(table.b.sum())
 
 #      CHECK: ibis.aggregation() {

--- a/experimental/sql/test/frontend/var_def.ibis
+++ b/experimental/sql/test/frontend/var_def.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 cond = (table['a'] == 'AS')
 table.filter(cond)
 

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -40,22 +40,19 @@ class RelOptMain(xDSLOptMain):
       import ibis
       import numpy as np
 
-      def exec_then_eval(query: str, tables: list[ibis.expr.types.Expr],
-                         names: list[str]):
+      def exec_then_eval(query: str):
         """
         Takes a (potentially multi-line) string that defines an ibis query with
         variables for subexpressions. The expression tree is built with the ith
         names of `names` corresponding to the ith table of `tables`. Finally,
         the result of the last line (modulo comments) is returned.
         """
-        assert len(tables) == len(names)
         import ast
 
         _globals, _locals = {}, {}
-        for t, n in zip(tables, names):
-          _locals[n] = t
 
         _locals["np"] = np
+        _locals["ibis"] = ibis
 
         ast_query = ast.parse(query)
         last = ast.Expression(ast_query.body.pop().value)
@@ -63,10 +60,7 @@ class RelOptMain(xDSLOptMain):
         return eval(compile(last, '<string>', mode='eval'), _globals, _locals)
 
       query = f.read()
-      res = exec_then_eval(query, [
-          ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't'),
-          ibis.table([("b", "int64")], 'u')
-      ], ["table", "sum_table"])
+      res = exec_then_eval(query)
       return ibis_to_xdsl(self.ctx, res)
 
     self.available_frontends['ibis'] = parse_ibis


### PR DESCRIPTION
This PR moves the schema definition from rel_opt into the individual files. In this way, the files get more self-contained.

The only contextual things that are still part of rel_opt and need to be mapped in to the local context of the interpretation environment that generates ibis expressions from the files, are the numpy and ibis imports. I think the only way to get around this would be to actually parse things instead of interpreting them, which would mean we could also just forget about using ibis all together IMO.