### PR TITLE
SQL: lower comparators to rel_alg

### DIFF
--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -79,6 +79,39 @@ class EqualsRewriter(IbisRewriter):
 
 
 @dataclass
+class GreaterEqualRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: ibis.GreaterEqual, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(
+        RelAlg.Compare.get(
+            ">=", rewriter.move_region_contents_to_new_regions(op.left),
+            rewriter.move_region_contents_to_new_regions(op.right)))
+
+
+@dataclass
+class LessThanRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: ibis.LessThan, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(
+        RelAlg.Compare.get(
+            "<", rewriter.move_region_contents_to_new_regions(op.left),
+            rewriter.move_region_contents_to_new_regions(op.right)))
+
+
+@dataclass
+class LessEqualRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: ibis.LessEqual, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(
+        RelAlg.Compare.get(
+            "<=", rewriter.move_region_contents_to_new_regions(op.left),
+            rewriter.move_region_contents_to_new_regions(op.right)))
+
+
+@dataclass
 class TableColumnRewriter(IbisRewriter):
 
   @op_type_rewrite_pattern
@@ -124,6 +157,9 @@ def ibis_to_alg(ctx: MLContext, query: ModuleOp):
       SchemaElementRewriter(),
       SelectionRewriter(),
       EqualsRewriter(),
+      GreaterEqualRewriter(),
+      LessEqualRewriter(),
+      LessThanRewriter(),
       TableColumnRewriter(),
       AggregationRewriter(),
       LiteralRewriter()

--- a/experimental/sql/test/ibis_to_alg/LessEqual.xdsl
+++ b/experimental/sql/test/ibis_to_alg/LessEqual.xdsl
@@ -1,0 +1,22 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+  ibis.selection() ["names" = []] {
+     ibis.unbound_table() ["table_name" = "t"] {
+       ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+     }
+   } {
+     ibis.lessEqual() {
+       ibis.table_column() ["col_name" = "id"] {
+         ibis.unbound_table() ["table_name" = "t"] {
+           ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+         }
+       }
+     } {
+       ibis.literal() ["val" = 5, "type" = !ibis.int64]
+     }
+   } {}
+ }
+
+//      CHECK:         rel_alg.compare() ["comparator" = "<="] {
+// CHECK-NEXT:             rel_alg.column() ["col_name" = "id"]

--- a/experimental/sql/test/ibis_to_alg/equals.xdsl
+++ b/experimental/sql/test/ibis_to_alg/equals.xdsl
@@ -1,0 +1,22 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+  ibis.selection() ["names" = []] {
+     ibis.unbound_table() ["table_name" = "t"] {
+       ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+     }
+   } {
+     ibis.equals() {
+       ibis.table_column() ["col_name" = "id"] {
+         ibis.unbound_table() ["table_name" = "t"] {
+           ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+         }
+       }
+     } {
+       ibis.literal() ["val" = 5 : !i64, "type" = !ibis.int64]
+     }
+   } {}
+}
+
+//      CHECK:         rel_alg.compare() ["comparator" = "="] {
+// CHECK-NEXT:             rel_alg.column() ["col_name" = "id"]

--- a/experimental/sql/test/ibis_to_alg/greaterEqual.xdsl
+++ b/experimental/sql/test/ibis_to_alg/greaterEqual.xdsl
@@ -1,0 +1,22 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+  ibis.selection() ["names" = []] {
+     ibis.unbound_table() ["table_name" = "t"] {
+       ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+     }
+   } {
+     ibis.greaterEqual() {
+       ibis.table_column() ["col_name" = "id"] {
+         ibis.unbound_table() ["table_name" = "t"] {
+           ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+         }
+       }
+     } {
+       ibis.literal() ["val" = 5, "type" = !ibis.int64]
+     }
+   } {}
+}
+
+//      CHECK:         rel_alg.compare() ["comparator" = ">="] {
+// CHECK-NEXT:             rel_alg.column() ["col_name" = "id"]

--- a/experimental/sql/test/ibis_to_alg/lessThan.xdsl
+++ b/experimental/sql/test/ibis_to_alg/lessThan.xdsl
@@ -1,0 +1,22 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+  ibis.selection() ["names" = []] {
+     ibis.unbound_table() ["table_name" = "t"] {
+       ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+     }
+   } {
+     ibis.lessThan() {
+       ibis.table_column() ["col_name" = "id"] {
+         ibis.unbound_table() ["table_name" = "t"] {
+           ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+         }
+       }
+     } {
+       ibis.literal() ["val" = 5, "type" = !ibis.int64]
+     }
+   } {}
+ }
+
+//      CHECK:         rel_alg.compare() ["comparator" = "<"] {
+// CHECK-NEXT:             rel_alg.column() ["col_name" = "id"]


### PR DESCRIPTION
This patch adds lowering for the comparators from the ibis_dialect to rel_alg. They all lower to `rel_alg.compare`, but with a different attribute.