### PR TITLE
SQL: add datatypes to rel alg

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -39,11 +39,21 @@ class DataType(ParametrizedAttribute):
 
 @irdl_attr_definition
 class Decimal(DataType):
+  """
+  Models the ibis decimal type.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/datatypes.py#L344
+  """
   name = "ibis.decimal"
 
 
 @irdl_attr_definition
 class Timestamp(DataType):
+  """
+  Models the ibis timestamp type.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/datatypes.py#L222
+  """
   name = "ibis.timestamp"
 
 

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -38,6 +38,16 @@ class DataType(ParametrizedAttribute):
 
 
 @irdl_attr_definition
+class Decimal(DataType):
+  name = "ibis.decimal"
+
+
+@irdl_attr_definition
+class Timestamp(DataType):
+  name = "ibis.timestamp"
+
+
+@irdl_attr_definition
 class Int32(DataType):
   """
   Models the ibis int32 type.
@@ -481,6 +491,8 @@ class Ibis:
     self.ctx.register_attr(String)
     self.ctx.register_attr(Int32)
     self.ctx.register_attr(Int64)
+    self.ctx.register_attr(Decimal)
+    self.ctx.register_attr(Timestamp)
 
     self.ctx.register_op(UnboundTable)
     self.ctx.register_op(SchemaElement)

--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -38,6 +38,34 @@ class Int32(DataType):
 
 
 @irdl_attr_definition
+class Decimal(DataType):
+  """
+  Models a decimal type in a relational query.
+
+  Example:
+
+  ```
+  !rel_alg.decimal
+  ```
+  """
+  name = "rel_alg.decimal"
+
+
+@irdl_attr_definition
+class Timestamp(DataType):
+  """
+  Models a timestamp type in a relational query.
+
+  Example:
+
+  ```
+  !rel_alg.timestamp
+  ```
+  """
+  name = "rel_alg.timestamp"
+
+
+@irdl_attr_definition
 class Int64(DataType):
   """
   Models a int64 type in a relational query.
@@ -281,6 +309,8 @@ class RelationalAlg:
     self.ctx.register_attr(DataType)
     self.ctx.register_attr(String)
     self.ctx.register_attr(Int32)
+    self.ctx.register_attr(Timestamp)
+    self.ctx.register_attr(Decimal)
     self.ctx.register_attr(Int64)
 
     self.ctx.register_op(Table)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -28,6 +28,10 @@ def convert_datatype(type_: ibis.expr.datatypes) -> id.DataType:
     return id.Int32()
   if isinstance(type_, ibis.expr.datatypes.Int64):
     return id.Int64()
+  if isinstance(type_, ibis.expr.datatypes.Decimal):
+    return id.Decimal()
+  if isinstance(type_, ibis.expr.datatypes.Timestamp):
+    return id.Timestamp()
   raise KeyError(f"Unknown datatype: {type(type_)}")
 
 

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -29,6 +29,10 @@ class IbisRewriter(RewritePattern):
       return RelAlg.Int32()
     if isinstance(type_, ibis.Int64):
       return RelAlg.Int64()
+    if isinstance(type_, ibis.Timestamp):
+      return RelAlg.Timestamp()
+    if isinstance(type_, ibis.Decimal):
+      return RelAlg.Decimal()
     raise Exception(
         f"datatype conversion not yet implemented for {type(type_)}")
 

--- a/experimental/sql/test/frontend/LessEqual.ibis
+++ b/experimental/sql/test/frontend/LessEqual.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.filter(table['b'] <= np.int64(0))
 
 #      CHECK:    ibis.lessEqual() {

--- a/experimental/sql/test/frontend/LessThan.ibis
+++ b/experimental/sql/test/frontend/LessThan.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.filter(table['b'] < np.int64(0))
 
 #      CHECK:    ibis.lessThan() {

--- a/experimental/sql/test/frontend/dataTypes.ibis
+++ b/experimental/sql/test/frontend/dataTypes.ibis
@@ -1,0 +1,5 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+ibis.table([("ORDERKEY", "int64"), ("EXTENDEDPRICE", "decimal"),
+                ("RETURNFLAG", "string"), ("SHIPDATE", "timestamp")],
+                'lineitem')

--- a/experimental/sql/test/frontend/dataTypes.ibis
+++ b/experimental/sql/test/frontend/dataTypes.ibis
@@ -3,3 +3,10 @@
 ibis.table([("ORDERKEY", "int64"), ("EXTENDEDPRICE", "decimal"),
                 ("RETURNFLAG", "string"), ("SHIPDATE", "timestamp")],
                 'lineitem')
+
+#      CHECK:  ibis.unbound_table() ["table_name" = "lineitem"] {
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "ORDERKEY", "elt_type" = !ibis.int64]
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "EXTENDEDPRICE", "elt_type" = !ibis.decimal]
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "RETURNFLAG", "elt_type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "SHIPDATE", "elt_type" = !ibis.timestamp]
+# CHECK-NEXT:  }

--- a/experimental/sql/test/frontend/greaterEqual.ibis
+++ b/experimental/sql/test/frontend/greaterEqual.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.filter(table['b'] >= np.int64(0))
 
 #      CHECK:    ibis.greaterEqual() {

--- a/experimental/sql/test/frontend/multiply.ibis
+++ b/experimental/sql/test/frontend/multiply.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table[(table['b'] * table['c']).name('d')]
 
 #      CHECK: ibis.selection() ["names" = ["d"]] {

--- a/experimental/sql/test/frontend/naming.ibis
+++ b/experimental/sql/test/frontend/naming.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table[table['b'].name('d')]
 
 #      CHECK: ibis.selection() ["names" = ["d"]] {

--- a/experimental/sql/test/frontend/projection.ibis
+++ b/experimental/sql/test/frontend/projection.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table['a', 'b']
 
 #      CHECK: ibis.selection() ["names" = ["a", "b"]] {

--- a/experimental/sql/test/frontend/selection.ibis
+++ b/experimental/sql/test/frontend/selection.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.filter(table['a'] == 'AS')
 
 #      CHECK: ibis.selection() ["names" = []] {

--- a/experimental/sql/test/frontend/sum.ibis
+++ b/experimental/sql/test/frontend/sum.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 table.aggregate(table.b.sum())
 
 #      CHECK: ibis.aggregation() {

--- a/experimental/sql/test/frontend/var_def.ibis
+++ b/experimental/sql/test/frontend/var_def.ibis
@@ -1,5 +1,6 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
 cond = (table['a'] == 'AS')
 table.filter(cond)
 

--- a/experimental/sql/test/ibis_to_alg/datatypes.xdsl
+++ b/experimental/sql/test/ibis_to_alg/datatypes.xdsl
@@ -1,0 +1,17 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+    ibis.unbound_table() ["table_name" = "some_name"] {
+        ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int32]
+        ibis.schema_element() ["elt_name" = "price", "elt_type" = !ibis.decimal]
+        ibis.schema_element() ["elt_name" = "time", "elt_type" = !ibis.timestamp]
+        ibis.schema_element() ["elt_name" = "name", "elt_type" = !ibis.string<1 : !i1>]
+    }
+}
+
+//      CHECK: rel_alg.table() ["table_name" = "some_name"] {
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-Next: }

--- a/experimental/sql/test/relational_algebra_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/datatypes.xdsl
@@ -1,0 +1,17 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+    rel_alg.table() ["table_name" = "some_name"] {
+        rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
+        rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal]
+        rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
+        rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
+    }
+}
+
+//      CHECK: rel_alg.table() ["table_name" = "some_name"] {
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-Next: }

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -40,22 +40,19 @@ class RelOptMain(xDSLOptMain):
       import ibis
       import numpy as np
 
-      def exec_then_eval(query: str, tables: list[ibis.expr.types.Expr],
-                         names: list[str]):
+      def exec_then_eval(query: str):
         """
         Takes a (potentially multi-line) string that defines an ibis query with
         variables for subexpressions. The expression tree is built with the ith
         names of `names` corresponding to the ith table of `tables`. Finally,
         the result of the last line (modulo comments) is returned.
         """
-        assert len(tables) == len(names)
         import ast
 
         _globals, _locals = {}, {}
-        for t, n in zip(tables, names):
-          _locals[n] = t
 
         _locals["np"] = np
+        _locals["ibis"] = ibis
 
         ast_query = ast.parse(query)
         last = ast.Expression(ast_query.body.pop().value)
@@ -63,10 +60,7 @@ class RelOptMain(xDSLOptMain):
         return eval(compile(last, '<string>', mode='eval'), _globals, _locals)
 
       query = f.read()
-      res = exec_then_eval(query, [
-          ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't'),
-          ibis.table([("b", "int64")], 'u')
-      ], ["table", "sum_table"])
+      res = exec_then_eval(query)
       return ibis_to_xdsl(self.ctx, res)
 
     self.available_frontends['ibis'] = parse_ibis


### PR DESCRIPTION
This patch adds datatypes and lowerings to rel_alg. This patch requires and therefore includes #514. With this patch, the lowering of Q6 to rel_alg should work.