### PR TITLE
SQL: fix naming aggregation

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -252,6 +252,7 @@ class Aggregation(Operation):
 
   table = SingleBlockRegionDef()
   metrics = SingleBlockRegionDef()
+  names = AttributeDef(ArrayOfConstraint(StringAttr))
   # TODO: figure out what the rest of these two and model them
   # by = SingleBlockRegionDef()
   # having = SingleBlockRegionDef()
@@ -260,8 +261,13 @@ class Aggregation(Operation):
 
   @staticmethod
   @builder
-  def get(table: Region, metrics: Region) -> 'Aggregation':
-    return Aggregation.build(regions=[table, metrics])
+  def get(table: Region, metrics: Region, names: list[str]) -> 'Aggregation':
+    return Aggregation.build(
+        regions=[table, metrics],
+        attributes={
+            "names":
+                ArrayAttr.from_list([StringAttr.from_str(n) for n in names])
+        })
 
 
 @irdl_op_definition

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -102,6 +102,7 @@ def visit(  #type: ignore
     op: ibis.expr.operations.relations.Aggregation) -> Operation:
   table = Region.from_operation_list([visit(op.table)])
   metrics = visit_ibis_expr_list(op.metrics)
+  names = []
   if len(op.inputs) > 0:
     names = [n.get_name() for n in op.inputs[1]]
   return id.Aggregation.get(table, metrics, names)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -102,7 +102,9 @@ def visit(  #type: ignore
     op: ibis.expr.operations.relations.Aggregation) -> Operation:
   table = Region.from_operation_list([visit(op.table)])
   metrics = visit_ibis_expr_list(op.metrics)
-  return id.Aggregation.get(table, metrics)
+  if len(op.inputs) > 0:
+    names = [n.get_name() for n in op.inputs[1]]
+  return id.Aggregation.get(table, metrics, names)
 
 
 @dispatch(ibis.expr.operations.generic.TableColumn)

--- a/experimental/sql/test/frontend/sum.ibis
+++ b/experimental/sql/test/frontend/sum.ibis
@@ -1,9 +1,9 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
 table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
-table.aggregate(table.b.sum())
+table.aggregate(table.b.sum().name('b'))
 
-#      CHECK: ibis.aggregation() {
+#      CHECK: ibis.aggregation() ["names" = ["b"]] {
 # CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
 # CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
 # CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_dialect_tests/sum.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/sum.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-ibis.aggregation() {
+ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
@@ -20,7 +20,7 @@ ibis.aggregation() {
   }
 }
 
-//      CHECK: ibis.aggregation() {
+//      CHECK: ibis.aggregation() ["names" = ["b"]] {
 // CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
 // CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
 // CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_to_alg/sum.xdsl
+++ b/experimental/sql/test/ibis_to_alg/sum.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
 module() {
-ibis.aggregation() {
+ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]


### PR DESCRIPTION
It seems that an ibis aggregation actually needs a name supplied for the new column to make it data with a schema. This patch extracts this information from the ibis data structure and represents it in the ibis_dialect.