### PR TITLE
SQL: allow different names for aggregation results

### DIFF
--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -427,8 +427,8 @@ class Aggregate(Operator):
 
   @builder
   @staticmethod
-  def get(input: Operation, col_names: List[str],
-          functions: List[str]) -> 'Aggregate':
+  def get(input: Operation, col_names: List[str], functions: List[str],
+          res_names: List[str]) -> 'Aggregate':
     return Aggregate.build(
         operands=[input],
         attributes={
@@ -438,7 +438,11 @@ class Aggregate(Operator):
             "functions":
                 ArrayAttr.from_list([StringAttr.from_str(f) for f in functions])
         },
-        result_types=[Bag.get(col_names, [Int32()] * len(functions))])
+        result_types=[
+            Bag.get(
+                res_names,
+                [input.result.typ.lookup_type_in_schema(n) for n in col_names])
+        ])
 
 
 @dataclass

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -155,7 +155,8 @@ class AggregateRewriter(RelAlgRewriter):
     rewriter.insert_op_before_matched_op([
         RelSSA.Aggregate.get(rewriter.added_operations_before[0],
                              [c.data for c in op.col_names.data],
-                             [f.data for f in op.functions.data])
+                             [f.data for f in op.functions.data],
+                             [r.data for r in op.res_names.data])
     ])
     rewriter.erase_matched_op()
 

--- a/experimental/sql/test/alg_to_ssa/sum.xdsl
+++ b/experimental/sql/test/alg_to_ssa/sum.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
 module() {
-    rel_alg.aggregate() ["col_names" = ["id"], "functions" = ["sum"], "res_names" = ["id"]] {
+    rel_alg.aggregate() ["col_names" = ["id"], "functions" = ["sum"], "res_names" = ["idsum"]] {
         rel_alg.table() ["table_name" = "t"] {
             rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
         }
@@ -9,4 +9,4 @@ module() {
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]


### PR DESCRIPTION
This PR allows new names for results of aggregations. This is a continuation of #519.